### PR TITLE
Fix viewer asset path resolution in broker

### DIFF
--- a/go-broker/go.sum
+++ b/go-broker/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/go-broker/main.go
+++ b/go-broker/main.go
@@ -1,107 +1,130 @@
 package main
 
 import (
-    "fmt"
-    "log"
-    "net/http"
-    "sync"
-    "time"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
 
-    "github.com/gorilla/websocket"
+	"github.com/gorilla/websocket"
 )
 
 var upgrader = websocket.Upgrader{
-    CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
 type Client struct {
-    conn *websocket.Conn
-    send chan []byte
-    id   string
+	conn *websocket.Conn
+	send chan []byte
+	id   string
 }
 
 type Broker struct {
-    clients map[*Client]bool
-    lock    sync.Mutex
+	clients map[*Client]bool
+	lock    sync.Mutex
 }
 
 func NewBroker() *Broker {
-    return &Broker{clients: make(map[*Client]bool)}
+	return &Broker{clients: make(map[*Client]bool)}
 }
 
 func (b *Broker) broadcast(msg []byte) {
-    b.lock.Lock()
-    defer b.lock.Unlock()
-    for c := range b.clients {
-        select {
-        case c.send <- msg:
-        default:
-            close(c.send)
-            delete(b.clients, c)
-        }
-    }
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	for c := range b.clients {
+		select {
+		case c.send <- msg:
+		default:
+			close(c.send)
+			delete(b.clients, c)
+		}
+	}
 }
 
 func (b *Broker) serveWS(w http.ResponseWriter, r *http.Request) {
-    conn, err := upgrader.Upgrade(w, r, nil)
-    if err != nil {
-        log.Println("upgrade:", err)
-        return
-    }
-    client := &Client{conn: conn, send: make(chan []byte, 256), id: r.RemoteAddr}
-    b.lock.Lock()
-    b.clients[client] = true
-    b.lock.Unlock()
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("upgrade:", err)
+		return
+	}
+	client := &Client{conn: conn, send: make(chan []byte, 256), id: r.RemoteAddr}
+	b.lock.Lock()
+	b.clients[client] = true
+	b.lock.Unlock()
 
-    // reader
-    go func() {
-        defer func() {
-            b.lock.Lock()
-            delete(b.clients, client)
-            b.lock.Unlock()
-            client.conn.Close()
-        }()
-        for {
-            _, msg, err := client.conn.ReadMessage()
-            if err != nil {
-                log.Println("read error:", err)
-                break
-            }
-            // relay to all clients
-            b.broadcast(msg)
-        }
-    }()
+	// reader
+	go func() {
+		defer func() {
+			b.lock.Lock()
+			delete(b.clients, client)
+			b.lock.Unlock()
+			client.conn.Close()
+		}()
+		for {
+			_, msg, err := client.conn.ReadMessage()
+			if err != nil {
+				log.Println("read error:", err)
+				break
+			}
+			// relay to all clients
+			b.broadcast(msg)
+		}
+	}()
 
-    // writer
-    go func() {
-        ticker := time.NewTicker(time.Second * 30)
-        defer func() {
-            ticker.Stop()
-            client.conn.Close()
-        }()
-        for {
-            select {
-            case msg, ok := <-client.send:
-                if !ok {
-                    _ = client.conn.WriteMessage(websocket.CloseMessage, []byte{})
-                    return
-                }
-                _ = client.conn.WriteMessage(websocket.TextMessage, msg)
-            case <-ticker.C:
-                _ = client.conn.WriteMessage(websocket.PingMessage, []byte{})
-            }
-        }
-    }()
+	// writer
+	go func() {
+		ticker := time.NewTicker(time.Second * 30)
+		defer func() {
+			ticker.Stop()
+			client.conn.Close()
+		}()
+		for {
+			select {
+			case msg, ok := <-client.send:
+				if !ok {
+					_ = client.conn.WriteMessage(websocket.CloseMessage, []byte{})
+					return
+				}
+				_ = client.conn.WriteMessage(websocket.TextMessage, msg)
+			case <-ticker.C:
+				_ = client.conn.WriteMessage(websocket.PingMessage, []byte{})
+			}
+		}
+	}()
 }
 
 func main() {
-    b := NewBroker()
-    http.HandleFunc("/ws", b.serveWS)
-    // serve viewer static files
-    fs := http.FileServer(http.Dir("./viewer"))
-    http.Handle("/viewer/", http.StripPrefix("/viewer/", fs))
+	b := NewBroker()
+	http.HandleFunc("/ws", b.serveWS)
+	// serve viewer static files
+	viewerDir, err := resolveViewerDir()
+	if err != nil {
+		log.Fatalf("resolve viewer directory: %v", err)
+	}
+	fs := http.FileServer(http.Dir(viewerDir))
+	http.Handle("/viewer/", http.StripPrefix("/viewer/", fs))
 
-    addr := ":8080"
-    fmt.Println("Broker listening on", addr)
-    log.Fatal(http.ListenAndServe(addr, nil))
+	addr := ":8080"
+	fmt.Println("Broker listening on", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func resolveViewerDir() (string, error) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to determine current file path")
+	}
+	viewerDir := filepath.Join(filepath.Dir(currentFile), "..", "viewer")
+	viewerDir, err := filepath.Abs(viewerDir)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(viewerDir); err != nil {
+		return "", err
+	}
+	return viewerDir, nil
 }


### PR DESCRIPTION
## Summary
- resolve the viewer directory relative to the broker source so static assets serve regardless of working directory
- ensure the module checksum file is present for gorilla/websocket

## Testing
- go run .
- curl -I http://localhost:8080/viewer/


------
https://chatgpt.com/codex/tasks/task_e_68d8887a9d8c832980dfb0383c87b18f