### PR TITLE
Handle writer websocket errors

### DIFF
--- a/go-broker/main.go
+++ b/go-broker/main.go
@@ -29,6 +29,15 @@ func NewBroker() *Broker {
     return &Broker{clients: make(map[*Client]bool)}
 }
 
+func (b *Broker) deregisterClient(client *Client) {
+    b.lock.Lock()
+    if _, exists := b.clients[client]; exists {
+        delete(b.clients, client)
+        close(client.send)
+    }
+    b.lock.Unlock()
+}
+
 func (b *Broker) broadcast(msg []byte) {
     b.lock.Lock()
     defer b.lock.Unlock()
@@ -86,9 +95,17 @@ func (b *Broker) serveWS(w http.ResponseWriter, r *http.Request) {
                     _ = client.conn.WriteMessage(websocket.CloseMessage, []byte{})
                     return
                 }
-                _ = client.conn.WriteMessage(websocket.TextMessage, msg)
+                if err := client.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+                    log.Println("write error:", err)
+                    b.deregisterClient(client)
+                    return
+                }
             case <-ticker.C:
-                _ = client.conn.WriteMessage(websocket.PingMessage, []byte{})
+                if err := client.conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
+                    log.Println("ping error:", err)
+                    b.deregisterClient(client)
+                    return
+                }
             }
         }
     }()


### PR DESCRIPTION
## Summary
- add a helper to deregister websocket clients and close their send channels
- handle write errors for text and ping frames to avoid leaking goroutines

## Testing
- go test ./... *(fails: missing go.sum entry for github.com/gorilla/websocket)*

------
https://chatgpt.com/codex/tasks/task_e_68d8887b6aac83299838beda626c2250