### PR TITLE
Add configurable WebSocket origin allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Quickstart (all on one machine)
    - go run main.go
    Broker listens on http://localhost:8080
 
+Configuring allowed WebSocket origins
+-------------------------------------
+The broker enforces an allowlist for incoming WebSocket connections. By default, only local development origins (`http://localhost`, `http://127.0.0.1`, etc.) are accepted so you can run everything on one machine without extra configuration.
+
+- **Development:** No changes required when testing locally. Optional: `go run main.go -allowed-origins="http://localhost:5173"` to explicitly list your dev server.
+- **Staging/Production:** Provide a comma-separated list of allowed origins through either the `-allowed-origins` flag or the `BROKER_ALLOWED_ORIGINS` environment variable. Example: `BROKER_ALLOWED_ORIGINS="https://viewer.example.com,https://tools.example.com" go run main.go`.
+- The CLI flag takes precedence over the environment variable. Requests from origins not in the allowlist (and not local) will be rejected during the WebSocket upgrade.
+
 2. Start the Python sim client (telemetry producer):
    - Create a virtualenv, install requirements: pip install -r requirements.txt
    - cd python-sim

--- a/go-broker/go.sum
+++ b/go-broker/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/go-broker/main.go
+++ b/go-broker/main.go
@@ -1,107 +1,178 @@
 package main
 
 import (
-    "fmt"
-    "log"
-    "net/http"
-    "sync"
-    "time"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
 
-    "github.com/gorilla/websocket"
+	"github.com/gorilla/websocket"
 )
 
-var upgrader = websocket.Upgrader{
-    CheckOrigin: func(r *http.Request) bool { return true },
+var upgrader = websocket.Upgrader{}
+
+var localHosts = map[string]struct{}{
+	"127.0.0.1": {},
+	"localhost": {},
+	"::1":       {},
 }
 
 type Client struct {
-    conn *websocket.Conn
-    send chan []byte
-    id   string
+	conn *websocket.Conn
+	send chan []byte
+	id   string
 }
 
 type Broker struct {
-    clients map[*Client]bool
-    lock    sync.Mutex
+	clients map[*Client]bool
+	lock    sync.Mutex
 }
 
 func NewBroker() *Broker {
-    return &Broker{clients: make(map[*Client]bool)}
+	return &Broker{clients: make(map[*Client]bool)}
+}
+
+func parseAllowedOrigins(raw string) []string {
+	parts := strings.Split(raw, ",")
+	origins := make([]string, 0, len(parts))
+	for _, part := range parts {
+		origin := strings.TrimSpace(part)
+		if origin == "" {
+			continue
+		}
+		origins = append(origins, origin)
+	}
+	return origins
+}
+
+func buildOriginChecker(allowlist []string) func(*http.Request) bool {
+	allowed := make(map[string]struct{}, len(allowlist))
+	for _, origin := range allowlist {
+		u, err := url.Parse(origin)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			log.Printf("ignoring invalid allowed origin %q: %v", origin, err)
+			continue
+		}
+		key := strings.ToLower(u.Scheme + "://" + u.Host)
+		allowed[key] = struct{}{}
+	}
+
+	return func(r *http.Request) bool {
+		originHeader := r.Header.Get("Origin")
+		if originHeader == "" {
+			return false
+		}
+
+		originURL, err := url.Parse(originHeader)
+		if err != nil || originURL.Host == "" {
+			log.Printf("rejecting request with invalid origin %q: %v", originHeader, err)
+			return false
+		}
+
+		if _, ok := localHosts[originURL.Hostname()]; ok {
+			return true
+		}
+
+		key := strings.ToLower(originURL.Scheme + "://" + originURL.Host)
+		if _, ok := allowed[key]; ok {
+			return true
+		}
+
+		log.Printf("rejecting request from disallowed origin %q", originHeader)
+		return false
+	}
 }
 
 func (b *Broker) broadcast(msg []byte) {
-    b.lock.Lock()
-    defer b.lock.Unlock()
-    for c := range b.clients {
-        select {
-        case c.send <- msg:
-        default:
-            close(c.send)
-            delete(b.clients, c)
-        }
-    }
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	for c := range b.clients {
+		select {
+		case c.send <- msg:
+		default:
+			close(c.send)
+			delete(b.clients, c)
+		}
+	}
 }
 
 func (b *Broker) serveWS(w http.ResponseWriter, r *http.Request) {
-    conn, err := upgrader.Upgrade(w, r, nil)
-    if err != nil {
-        log.Println("upgrade:", err)
-        return
-    }
-    client := &Client{conn: conn, send: make(chan []byte, 256), id: r.RemoteAddr}
-    b.lock.Lock()
-    b.clients[client] = true
-    b.lock.Unlock()
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("upgrade:", err)
+		return
+	}
+	client := &Client{conn: conn, send: make(chan []byte, 256), id: r.RemoteAddr}
+	b.lock.Lock()
+	b.clients[client] = true
+	b.lock.Unlock()
 
-    // reader
-    go func() {
-        defer func() {
-            b.lock.Lock()
-            delete(b.clients, client)
-            b.lock.Unlock()
-            client.conn.Close()
-        }()
-        for {
-            _, msg, err := client.conn.ReadMessage()
-            if err != nil {
-                log.Println("read error:", err)
-                break
-            }
-            // relay to all clients
-            b.broadcast(msg)
-        }
-    }()
+	// reader
+	go func() {
+		defer func() {
+			b.lock.Lock()
+			delete(b.clients, client)
+			b.lock.Unlock()
+			client.conn.Close()
+		}()
+		for {
+			_, msg, err := client.conn.ReadMessage()
+			if err != nil {
+				log.Println("read error:", err)
+				break
+			}
+			// relay to all clients
+			b.broadcast(msg)
+		}
+	}()
 
-    // writer
-    go func() {
-        ticker := time.NewTicker(time.Second * 30)
-        defer func() {
-            ticker.Stop()
-            client.conn.Close()
-        }()
-        for {
-            select {
-            case msg, ok := <-client.send:
-                if !ok {
-                    _ = client.conn.WriteMessage(websocket.CloseMessage, []byte{})
-                    return
-                }
-                _ = client.conn.WriteMessage(websocket.TextMessage, msg)
-            case <-ticker.C:
-                _ = client.conn.WriteMessage(websocket.PingMessage, []byte{})
-            }
-        }
-    }()
+	// writer
+	go func() {
+		ticker := time.NewTicker(time.Second * 30)
+		defer func() {
+			ticker.Stop()
+			client.conn.Close()
+		}()
+		for {
+			select {
+			case msg, ok := <-client.send:
+				if !ok {
+					_ = client.conn.WriteMessage(websocket.CloseMessage, []byte{})
+					return
+				}
+				_ = client.conn.WriteMessage(websocket.TextMessage, msg)
+			case <-ticker.C:
+				_ = client.conn.WriteMessage(websocket.PingMessage, []byte{})
+			}
+		}
+	}()
 }
 
 func main() {
-    b := NewBroker()
-    http.HandleFunc("/ws", b.serveWS)
-    // serve viewer static files
-    fs := http.FileServer(http.Dir("./viewer"))
-    http.Handle("/viewer/", http.StripPrefix("/viewer/", fs))
+	allowedOriginsDefault := os.Getenv("BROKER_ALLOWED_ORIGINS")
+	allowedOriginsFlag := flag.String("allowed-origins", allowedOriginsDefault, "Comma-separated list of allowed origins for WebSocket connections")
+	addr := flag.String("addr", ":8080", "address to listen on")
+	flag.Parse()
 
-    addr := ":8080"
-    fmt.Println("Broker listening on", addr)
-    log.Fatal(http.ListenAndServe(addr, nil))
+	allowlist := parseAllowedOrigins(*allowedOriginsFlag)
+	upgrader.CheckOrigin = buildOriginChecker(allowlist)
+	if len(allowlist) > 0 {
+		log.Printf("allowing WebSocket origins: %s", strings.Join(allowlist, ", "))
+	} else {
+		log.Println("no allowed origins configured; permitting only local development origins")
+	}
+
+	b := NewBroker()
+	http.HandleFunc("/ws", b.serveWS)
+	// serve viewer static files
+	fs := http.FileServer(http.Dir("./viewer"))
+	http.Handle("/viewer/", http.StripPrefix("/viewer/", fs))
+
+	fmt.Println("Broker listening on", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
## Summary
- enforce a configurable WebSocket origin allowlist with automatic localhost access for development
- allow configuration via CLI flag or BROKER_ALLOWED_ORIGINS environment variable and log the active rules
- document how to configure origins for development, staging, and production environments

## Testing
- GOSUMDB=off go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8887c3dd883299efa9659c95b106e