### PR TITLE
Add reconnect logic to python sim client

### DIFF
--- a/python-sim/client.py
+++ b/python-sim/client.py
@@ -30,43 +30,73 @@ def mk_telemetry(plane, t):
     })
 
 def run():
-    print("Connecting to", WS_URL)
-    try:
-        ws = create_connection(WS_URL)
-    except Exception as e:
-        print("Failed to connect:", e)
-        return
     p = Plane("plane-1", x=0, y=0, z=1200, speed=140.0)
     p.tags.append("pastel:turquoise")
     t0 = time.time()
     last_cake = -10.0
-    try:
-        while True:
-            t = time.time() - t0
-            p.step(TICK)
-            try:
-                ws.send(mk_telemetry(p, t))
-            except WebSocketConnectionClosedException:
-                print("Connection closed"); break
-            # simple cake drop every ~8-12s randomly
-            if (t - last_cake) > 8.0 and random.random() < 0.02:
-                last_cake = t
-                cake_msg = json.dumps({
-                    "type":"cake_drop",
-                    "id": f"cake-{int(t)}",
-                    "from": p.id,
-                    "pos": [float(p.pos[0]), float(p.pos[1]), float(p.pos[2])],
-                    "landing_pos": [float(p.pos[0]+50), float(p.pos[1]-20), 0.0],
-                    "status":"in_flight"
-                })
+    backoff = 1.0
+    max_backoff = 10.0
+    should_stop = False
+
+    while not should_stop:
+        ws = None
+        try:
+            print("Connecting to", WS_URL)
+            ws = create_connection(WS_URL)
+            print("Connected to", WS_URL)
+            backoff = 1.0
+
+            while True:
+                t = time.time() - t0
+                p.step(TICK)
                 try:
-                    ws.send(cake_msg)
-                    print("Sent cake_drop", cake_msg)
-                except Exception as e:
-                    print("send cake err", e)
-            time.sleep(TICK)
-    finally:
-        ws.close()
+                    ws.send(mk_telemetry(p, t))
+                except WebSocketConnectionClosedException:
+                    print("Connection closed while sending telemetry")
+                    raise
+
+                # simple cake drop every ~8-12s randomly
+                if (t - last_cake) > 8.0 and random.random() < 0.02:
+                    last_cake = t
+                    cake_msg = json.dumps({
+                        "type":"cake_drop",
+                        "id": f"cake-{int(t)}",
+                        "from": p.id,
+                        "pos": [float(p.pos[0]), float(p.pos[1]), float(p.pos[2])],
+                        "landing_pos": [float(p.pos[0]+50), float(p.pos[1]-20), 0.0],
+                        "status":"in_flight"
+                    })
+                    try:
+                        ws.send(cake_msg)
+                        print("Sent cake_drop", cake_msg)
+                    except WebSocketConnectionClosedException:
+                        print("Connection closed while sending cake_drop")
+                        raise
+                    except Exception as e:
+                        print("send cake err", e)
+
+                time.sleep(TICK)
+
+        except KeyboardInterrupt:
+            print("Stopping client")
+            should_stop = True
+        except WebSocketConnectionClosedException:
+            print("Lost connection to server")
+        except Exception as e:
+            print("Connection error:", e)
+        finally:
+            if ws is not None:
+                try:
+                    ws.close()
+                except Exception:
+                    pass
+
+        if should_stop:
+            break
+
+        print(f"Reconnecting in {backoff:.1f}s...")
+        time.sleep(backoff)
+        backoff = min(backoff * 2, max_backoff)
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
## Summary
- add reconnection loop with exponential backoff to the python simulation client
- resume telemetry and cake-drop publishing after a lost websocket connection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8887e856c8329b48282e76d49bdcf