### PR TITLE
Allow python sim to override broker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Quickstart (all on one machine)
    - Create a virtualenv, install requirements: pip install -r requirements.txt
    - cd python-sim
    - python client.py
-   This connects to ws://localhost:8080/ws and sends telemetry & occasional cake_drop messages.
+   This connects to ws://localhost:8080/ws by default and sends telemetry & occasional cake_drop messages.
+   - To target a different broker, run `python client.py --broker-url ws://example.com:8080/ws` or set the
+     `SIM_BROKER_URL` environment variable before running the client.
 
 3. Open the viewer in your browser:
    - Browse to http://localhost:8080/viewer/index.html


### PR DESCRIPTION
## Summary
- add CLI argument and environment variable support for configuring the Python simulator's broker URL
- document how to override the broker URL when running the simulator

## Testing
- python -m compileall python-sim/client.py

------
https://chatgpt.com/codex/tasks/task_e_68d8887f267c8329a26cc4da9e237b63