### PR TITLE
Replace GLB model with inline glTF asset

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -5,11 +5,30 @@ const WS_URL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.
 const PLANE_STALE_TIMEOUT_MS = 5000;
 
 let scene, camera, renderer;
-const planeMeshes = new Map();   // id -> THREE.Mesh
+const planeMeshes = new Map();   // id -> THREE.Object3D
 const planeLastSeen = new Map(); // id -> timestamp
 let currentFollowId = null;
 let cakes = {};
+const MODEL_PATH = 'assets/models/high_fidelity_aircraft.gltf';
+let gltfLoader = null;
+let aircraftLoadError = false;
+try {
+  if (typeof THREE !== 'undefined' && typeof THREE.GLTFLoader === 'function'){
+    gltfLoader = new THREE.GLTFLoader();
+  } else {
+    console.warn('GLTFLoader helper unavailable; falling back to primitive aircraft mesh.');
+    aircraftLoadError = true;
+  }
+} catch (err){
+  console.warn('Failed to initialize GLTFLoader; using fallback mesh.', err);
+  aircraftLoadError = true;
+}
+let aircraftTemplate = null;
+let aircraftLoadPromise = null;
+const pendingTelemetry = [];
+const planeResources = new Map();
 initThree();
+if (gltfLoader) beginAircraftLoad();
 
 let socket = new WebSocket(WS_URL);
 socket.addEventListener('open', ()=>{ if (HUD) HUD.innerText = 'Connected to broker'; });
@@ -24,12 +43,19 @@ function handleMsg(msg){
   if (msg.type === 'telemetry'){
     const id = msg.id;
     const p = msg.pos || [0,0,0];
+
+    if (!aircraftTemplate && !aircraftLoadError){
+      pendingTelemetry.push(msg);
+      beginAircraftLoad();
+      return;
+    }
+
     let mesh = planeMeshes.get(id);
     if (!mesh){
-      const geom = new THREE.BoxGeometry(12,4,4);
-      const mat = new THREE.MeshStandardMaterial({color:0x3366ff});
-      mesh = new THREE.Mesh(geom, mat);
+      const { object, geometries, materials, textures } = createAircraftInstance();
+      mesh = object;
       planeMeshes.set(id, mesh);
+      planeResources.set(id, { geometries, materials, textures });
       scene.add(mesh);
       if (!currentFollowId) currentFollowId = id; // follow first seen plane by default
     }
@@ -62,6 +88,164 @@ function handleMsg(msg){
     cakes[id] = s;
     setTimeout(()=>{ scene.remove(s); delete cakes[id]; }, 8000);
   }
+}
+
+function beginAircraftLoad(){
+  if (!gltfLoader){
+    aircraftLoadError = true;
+    if (pendingTelemetry.length){
+      const queued = pendingTelemetry.splice(0, pendingTelemetry.length);
+      queued.forEach((queuedMsg) => handleMsg(queuedMsg));
+    }
+    return null;
+  }
+
+  if (aircraftTemplate || aircraftLoadPromise || aircraftLoadError) return aircraftLoadPromise;
+
+  aircraftLoadPromise = new Promise((resolve, reject) => {
+    gltfLoader.load(MODEL_PATH, (gltf) => {
+      aircraftTemplate = gltf.scene;
+      aircraftTemplate.traverse((node) => {
+        if (node.isMesh){
+          node.castShadow = true;
+          node.receiveShadow = true;
+        }
+      });
+      resolve(aircraftTemplate);
+    }, undefined, (err) => {
+      reject(err);
+    });
+  });
+
+  aircraftLoadPromise.then(() => {
+    if (pendingTelemetry.length){
+      const queued = pendingTelemetry.splice(0, pendingTelemetry.length);
+      queued.forEach((queuedMsg) => handleMsg(queuedMsg));
+    }
+  }).catch((err) => {
+    aircraftLoadError = true;
+    console.error('Failed to load aircraft model', err);
+    if (pendingTelemetry.length){
+      const queued = pendingTelemetry.splice(0, pendingTelemetry.length);
+      queued.forEach((queuedMsg) => handleMsg(queuedMsg));
+    }
+  });
+
+  return aircraftLoadPromise;
+}
+
+function createAircraftInstance(){
+  if (!aircraftTemplate){
+    return createFallbackInstance();
+  }
+
+  const clone = aircraftTemplate.clone(true);
+  const geometries = [];
+  const materials = [];
+  const textures = [];
+
+  clone.traverse((node) => {
+    if (node.isMesh){
+      if (node.geometry){
+        const clonedGeometry = node.geometry.clone();
+        node.geometry = clonedGeometry;
+        geometries.push(clonedGeometry);
+      }
+      if (node.material){
+        if (Array.isArray(node.material)){
+          node.material = node.material.map((mat) => {
+            const clonedMaterial = mat.clone();
+            clonedMaterial.metalness = mat.metalness ?? 0.2;
+            clonedMaterial.roughness = mat.roughness ?? 0.55;
+            materials.push(clonedMaterial);
+            captureMaterialTextures(clonedMaterial, textures);
+            return clonedMaterial;
+          });
+        } else {
+          const baseMaterial = node.material;
+          const clonedMaterial = baseMaterial.clone();
+          clonedMaterial.metalness = baseMaterial.metalness ?? 0.2;
+          clonedMaterial.roughness = baseMaterial.roughness ?? 0.55;
+          node.material = clonedMaterial;
+          materials.push(clonedMaterial);
+          captureMaterialTextures(clonedMaterial, textures);
+        }
+      } else {
+        const fallbackMaterial = new THREE.MeshStandardMaterial({color:0x355ad6, metalness:0.25, roughness:0.6});
+        node.material = fallbackMaterial;
+        materials.push(fallbackMaterial);
+      }
+      node.castShadow = true;
+      node.receiveShadow = true;
+    }
+  });
+
+  clone.scale.set(0.25, 0.25, 0.25);
+  clone.name = 'AircraftInstance';
+
+  return { object: clone, geometries, materials, textures };
+}
+
+function createFallbackInstance(){
+  const geom = new THREE.BoxGeometry(12,4,4);
+  const mat = new THREE.MeshStandardMaterial({color:0x3366ff});
+  const mesh = new THREE.Mesh(geom, mat);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  mesh.scale.set(0.25, 0.25, 0.25);
+  mesh.name = 'FallbackAircraft';
+  return { object: mesh, geometries: [geom], materials: [mat], textures: [] };
+}
+
+function disposePlaneResources(id){
+  const resources = planeResources.get(id);
+  if (resources){
+    if (Array.isArray(resources.geometries)){
+      resources.geometries.forEach((geom) => {
+        if (geom && geom.dispose){ geom.dispose(); }
+      });
+    }
+    if (Array.isArray(resources.materials)){
+      resources.materials.forEach((mat) => {
+        if (!mat) return;
+        if (Array.isArray(mat)){
+          mat.forEach((inner) => inner && inner.dispose && inner.dispose());
+        } else if (mat.dispose){
+          mat.dispose();
+        }
+      });
+    }
+    if (Array.isArray(resources.textures)){
+      resources.textures.forEach((tex) => {
+        if (tex && typeof tex.dispose === 'function'){
+          tex.dispose();
+        }
+      });
+    }
+  }
+  planeResources.delete(id);
+}
+
+function captureMaterialTextures(material, textures){
+  if (!material) return;
+  const textureKeys = [
+    'map',
+    'normalMap',
+    'metalnessMap',
+    'roughnessMap',
+    'aoMap',
+    'emissiveMap',
+    'alphaMap',
+    'envMap'
+  ];
+  textureKeys.forEach((key) => {
+    const tex = material[key];
+    if (tex){
+      const clonedTexture = (typeof tex.clone === 'function') ? tex.clone() : tex;
+      material[key] = clonedTexture;
+      textures.push(clonedTexture);
+    }
+  });
 }
 
 function initThree(){
@@ -109,15 +293,8 @@ function removeStalePlanes(){
       const mesh = planeMeshes.get(id);
       if (mesh){
         scene.remove(mesh);
-        if (mesh.geometry){ mesh.geometry.dispose(); }
-        if (mesh.material){
-          if (Array.isArray(mesh.material)){
-            mesh.material.forEach(m => m.dispose && m.dispose());
-          } else if (mesh.material.dispose){
-            mesh.material.dispose();
-          }
-        }
       }
+      disposePlaneResources(id);
       planeMeshes.delete(id);
       planeLastSeen.delete(id);
       if (currentFollowId === id){

--- a/viewer/assets/models/README.txt
+++ b/viewer/assets/models/README.txt
@@ -1,1 +1,3 @@
-Place a glTF plane model here as plane.gltf (optional). The viewer uses a box if no model is present.
+The viewer ships with a lightweight stylized aircraft at `high_fidelity_aircraft.gltf`.
+Replace it with your own glTF or GLB asset (and update `MODEL_PATH` in `viewer/app.js` if you rename it)
+to customize the display. The viewer will fall back to a simple box if no model can be loaded.

--- a/viewer/assets/models/high_fidelity_aircraft.gltf
+++ b/viewer/assets/models/high_fidelity_aircraft.gltf
@@ -1,0 +1,95 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Handcrafted"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "StylizedAircraft",
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "name": "StylizedAircraftMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "mode": 4,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "materials": [
+    {
+      "name": "AircraftMaterial",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.2,
+          0.32,
+          0.78,
+          1.0
+        ],
+        "metallicFactor": 0.1,
+        "roughnessFactor": 0.45
+      },
+      "doubleSided": false
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAAAAAEAAAAAAAAAAAAAAAMAAAAAAAABAwAAAAAAAAAC/AAAAAAAAAEAAAAAAAABAQAAAAAAAAAC/AAAAAAAAAMAAAAAAAAAAAAAAAEAAAAAAAABAwAAAAAAAAAC/AABAQAAAAAAAAAC/AAAAAAAAAMAAAAAAAABAQAAAAAAAAAC/AABAwAAAAAAAAAC/AAAAAAAAAMAAAAAAAAAAAAAAAMAAAIA/AABAwAAAAAAAAAC/AAAAAAAAAMAAAAAAAABAQAAAAAAAAAC/AAAAAAAAAMAAAIA/NVgoPgAAAABQhHy/NVgoPgAAAABQhHy/NVgoPgAAAABQhHy/NVgovgAAAIBQhHy/NVgovgAAAIBQhHy/NVgovgAAAIBQhHy/AAAAAEJbeL5CW3g/AAAAAEJbeL5CW3g/AAAAAEJbeL5CW3g/AAAAAEJbeD5CW3g/AAAAAEJbeD5CW3g/AAAAAEJbeD5CW3g/1QAOv0ABVb8AAAAA1QAOv0ABVb8AAAAA1QAOv0ABVb8AAAAA1QAOP0ABVb8AAAAA1QAOP0ABVb8AAAAA1QAOP0ABVb8AAAAA",
+      "byteLength": 432
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 216,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 216,
+      "byteLength": 216,
+      "target": 34962
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 18,
+      "type": "VEC3",
+      "min": [
+        -3,
+        -2,
+        -0.5
+      ],
+      "max": [
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 18,
+      "type": "VEC3"
+    }
+  ]
+}

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -8,6 +8,7 @@
 <body>
 <div id="hud">DriftPursuit Viewer - connecting...</div>
 <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/GLTFLoader.js"></script>
 <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the binary GLB aircraft asset with a text-based glTF model that complies with repository policies
- update the viewer to load the new template, clone its materials/textures per plane, and dispose cloned resources when planes are removed
- refresh the model README with guidance for swapping in alternate assets

## Testing
- manual viewer smoke-check via local http server

------
https://chatgpt.com/codex/tasks/task_e_68d8a2ca43e0832989581e88c7cc8d86