### PR TITLE
Add procedural stylized model set and selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This starter project wires together three pieces so you can focus on gameplay an
 - `go-broker/`: Simple Go WebSocket broker that relays messages and serves the static viewer.
 - `python-sim/`: Python simulation client that publishes telemetry and cake drops.
 - `viewer/`: A minimal three.js web client that subscribes to the broker feed.
+  - Pass `?modelSet=stylized_lowpoly` in the viewer URL to try the built-in procedural low-poly kit without needing a GLTF file.
 
 ## Prerequisites
 

--- a/viewer/assets/models/README.txt
+++ b/viewer/assets/models/README.txt
@@ -1,3 +1,7 @@
 The viewer ships with a lightweight stylized aircraft at `high_fidelity_aircraft.gltf`.
-Replace it with your own glTF or GLB asset (and update `MODEL_PATH` in `viewer/app.js` if you rename it)
-to customize the display. The viewer will fall back to a simple box if no model can be loaded.
+Replace it with your own glTF or GLB asset (and update the `MODEL_SETS` entry in `viewer/app.js` if you
+rename it) to customize the display. The viewer will fall back to a simple box if no model can be loaded.
+
+You can also try the built-in procedural "stylized_lowpoly" model set by appending `?modelSet=stylized_lowpoly`
+to the viewer URL. That model is assembled in code (no glTF needed) and is a good starting point for quick
+experiments without needing to create a full asset pipeline.


### PR DESCRIPTION
## Summary
- add a model-set registry to the viewer with URL query selection support
- implement a stylized low-poly procedural aircraft as an additional model set
- document how to switch model sets in the root and assets readme files

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8b8f1249883298e8472f08feb33ef