### PR TITLE
Add stats tracking and API for Go broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Follow these steps to bring the entire stack up locally on one machine:
    go run main.go
    ```
    The broker will start on port `8080` and serve both HTTP and WebSocket traffic.
+   A JSON summary of the broker status is exposed at `http://localhost:8080/api/stats`.
 
 2. **Configure allowed WebSocket origins (optional but recommended when deploying):**
    - By default the broker accepts local origins such as `http://localhost` and `http://127.0.0.1` so development "just works".
@@ -66,6 +67,7 @@ Once everything is running locally, you can visit these URLs:
 | Broker health/root | `http://localhost:8080/` |
 | Viewer web app | `http://localhost:8080/viewer/index.html` |
 | WebSocket endpoint | `ws://localhost:8080/ws` |
+| Broker statistics API | `http://localhost:8080/api/stats` |
 | Protocol documentation | `docs/protocol.md` (local file) |
 
 ## Next Steps

--- a/go-broker/main_test.go
+++ b/go-broker/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+type fakeBroker struct {
+	stats BrokerStats
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *fakeBroker) Stats() BrokerStats {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.stats
+}
+
+func TestStatsHandlerReturnsJSON(t *testing.T) {
+	fake := &fakeBroker{stats: BrokerStats{Broadcasts: 5, Clients: 2}}
+	req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	rr := httptest.NewRecorder()
+
+	statsHandler(fake).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: got %d", rr.Code)
+	}
+
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("unexpected content type: got %q", ct)
+	}
+
+	var resp BrokerStats
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp != fake.stats {
+		t.Fatalf("unexpected stats: got %+v want %+v", resp, fake.stats)
+	}
+
+	if fake.calls != 1 {
+		t.Fatalf("expected Stats to be called once, got %d", fake.calls)
+	}
+}
+
+type blockingBroker struct {
+	stats   BrokerStats
+	wait    chan struct{}
+	started chan struct{}
+	calls   int
+	mu      sync.Mutex
+}
+
+func (b *blockingBroker) Stats() BrokerStats {
+	b.mu.Lock()
+	b.calls++
+	if b.started != nil {
+		close(b.started)
+		b.started = nil
+	}
+	b.mu.Unlock()
+	<-b.wait
+	return b.stats
+}
+
+func TestStatsHandlerHonorsLocking(t *testing.T) {
+	blocker := &blockingBroker{
+		stats:   BrokerStats{Broadcasts: 1, Clients: 1},
+		wait:    make(chan struct{}),
+		started: make(chan struct{}),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		statsHandler(blocker).ServeHTTP(rr, req)
+		close(done)
+	}()
+
+	<-blocker.started
+
+	select {
+	case <-done:
+		t.Fatal("handler returned before broker released lock")
+	default:
+	}
+
+	close(blocker.wait)
+
+	<-done
+
+	blocker.mu.Lock()
+	calls := blocker.calls
+	blocker.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("expected Stats to be called once, got %d", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- track broadcast and client counters inside the broker and expose a Stats accessor
- add an /api/stats HTTP handler to serve the counters as JSON and update README documentation
- cover the handler with unit tests that verify JSON output and locking behavior

## Testing
- go test ./... (from go-broker)


------
https://chatgpt.com/codex/tasks/task_e_68d982a041d08329b245afbe4520841c