### PR TITLE
Add configurable payload limits and validation to WebSocket broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ Follow these steps to bring the entire stack up locally on one machine:
      ```
    - The CLI flag takes precedence over the environment variable. Requests from origins not in the allow list (and not local) are rejected during the WebSocket upgrade.
 
-3. **Run the Python simulation client** (publishes telemetry messages):
+3. **Adjust the inbound payload limit (optional):**
+   - The broker rejects individual WebSocket messages larger than **1 MiB** by default to prevent runaway publishers from exhausting memory.
+   - Override the limit with the CLI flag or the `BROKER_MAX_PAYLOAD_BYTES` environment variable when your protocol needs larger payloads:
+     ```bash
+     go run main.go -max-payload-bytes=2097152
+     # or
+     export BROKER_MAX_PAYLOAD_BYTES=2097152
+     go run main.go
+     ```
+   - As with other settings, the CLI flag takes precedence when both are supplied.
+
+4. **Run the Python simulation client** (publishes telemetry messages):
    ```bash
    cd python-sim
    python -m venv .venv
@@ -54,7 +65,7 @@ Follow these steps to bring the entire stack up locally on one machine:
    python client.py
    ```
 
-4. **Open the viewer** to visualize entities streaming from the simulation:
+5. **Open the viewer** to visualize entities streaming from the simulation:
    - Navigate to `http://localhost:8080/viewer/index.html` in your browser.
    - You should see the 3D scene update in real time as telemetry arrives.
 

--- a/go-broker/main_test.go
+++ b/go-broker/main_test.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 type fakeBroker struct {
@@ -102,5 +107,148 @@ func TestStatsHandlerHonorsLocking(t *testing.T) {
 	blocker.mu.Unlock()
 	if calls != 1 {
 		t.Fatalf("expected Stats to be called once, got %d", calls)
+	}
+}
+
+func dialTestWebSocket(t *testing.T, serverURL string) *websocket.Conn {
+	t.Helper()
+	u := "ws" + strings.TrimPrefix(serverURL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	return conn
+}
+
+type wsReadResult struct {
+	msg []byte
+	err error
+}
+
+func listenOnce(conn *websocket.Conn) <-chan wsReadResult {
+	ch := make(chan wsReadResult, 1)
+	go func() {
+		_, msg, err := conn.ReadMessage()
+		ch <- wsReadResult{msg: msg, err: err}
+	}()
+	return ch
+}
+
+func TestServeWSDropsInvalidMessages(t *testing.T) {
+	upgrader.CheckOrigin = func(*http.Request) bool { return true }
+	broker := NewBroker(defaultMaxPayloadBytes)
+
+	server := httptest.NewServer(http.HandlerFunc(broker.serveWS))
+	defer server.Close()
+
+	receiver := dialTestWebSocket(t, server.URL)
+	defer receiver.Close()
+
+	sender := dialTestWebSocket(t, server.URL)
+	defer sender.Close()
+
+	pending := listenOnce(receiver)
+
+	if err := sender.WriteMessage(websocket.TextMessage, []byte("not json")); err != nil {
+		t.Fatalf("write invalid message: %v", err)
+	}
+	select {
+	case res := <-pending:
+		if res.err != nil {
+			t.Fatalf("receiver connection error after invalid message: %v", res.err)
+		}
+		t.Fatalf("unexpected broadcast after invalid message: %s", string(res.msg))
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	valid := []byte(`{"type":"update","id":"123"}`)
+	if err := sender.WriteMessage(websocket.TextMessage, valid); err != nil {
+		t.Fatalf("write valid message: %v", err)
+	}
+
+	select {
+	case res := <-pending:
+		if res.err != nil {
+			t.Fatalf("receiver connection error waiting for valid broadcast: %v", res.err)
+		}
+		var envelope inboundEnvelope
+		if err := json.Unmarshal(res.msg, &envelope); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if envelope.Type != "update" || envelope.ID != "123" {
+			t.Fatalf("unexpected broadcast payload: %+v", envelope)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for normalized broadcast")
+	}
+}
+
+func TestServeWSRejectsOversizedMessages(t *testing.T) {
+	upgrader.CheckOrigin = func(*http.Request) bool { return true }
+	broker := NewBroker(64)
+
+	server := httptest.NewServer(http.HandlerFunc(broker.serveWS))
+	defer server.Close()
+
+	receiver := dialTestWebSocket(t, server.URL)
+	defer receiver.Close()
+
+	sender := dialTestWebSocket(t, server.URL)
+	defer sender.Close()
+
+	pending := listenOnce(receiver)
+
+	oversized := []byte(fmt.Sprintf(`{"type":"big","id":"%s"}`, strings.Repeat("x", 80)))
+	if int64(len(oversized)) <= broker.maxPayloadBytes {
+		t.Fatalf("constructed message length %d does not exceed broker limit %d", len(oversized), broker.maxPayloadBytes)
+	}
+
+	if err := sender.WriteMessage(websocket.TextMessage, oversized); err != nil {
+		t.Fatalf("write oversized message: %v", err)
+	}
+
+	if err := sender.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	if _, _, err := sender.ReadMessage(); err == nil {
+		t.Fatal("expected connection to close after oversized message")
+	} else if !websocket.IsCloseError(err, websocket.CloseMessageTooBig) {
+		t.Fatalf("expected CloseMessageTooBig error, got %v", err)
+	}
+	if err := sender.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("reset read deadline: %v", err)
+	}
+
+	select {
+	case res := <-pending:
+		if res.err != nil {
+			t.Fatalf("receiver connection error after oversized message: %v", res.err)
+		}
+		t.Fatalf("unexpected broadcast after oversized message: %s", string(res.msg))
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	replacement := dialTestWebSocket(t, server.URL)
+	defer replacement.Close()
+
+	valid := []byte(`{"type":"ok","id":"42"}`)
+	if err := replacement.WriteMessage(websocket.TextMessage, valid); err != nil {
+		t.Fatalf("write valid message from replacement client: %v", err)
+	}
+
+	select {
+	case res := <-pending:
+		if res.err != nil {
+			t.Fatalf("receiver connection error waiting for broadcast: %v", res.err)
+		}
+		var envelope inboundEnvelope
+		if err := json.Unmarshal(res.msg, &envelope); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if envelope.Type != "ok" || envelope.ID != "42" {
+			t.Fatalf("unexpected broadcast payload: %+v", envelope)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for broadcast after oversized message")
 	}
 }


### PR DESCRIPTION
## Summary
- enforce a configurable inbound WebSocket payload limit and normalize validated messages before broadcasting
- drop oversized or malformed frames while logging context
- document the default limit and how to override it via flag or environment variable, and cover invalid/oversized cases with tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d98467ed68832983ab877476c8197c