### PR TITLE
Add configurable WebSocket client limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Follow these steps to bring the entire stack up locally on one machine:
      ```
    - The CLI flag takes precedence over the environment variable. Requests from origins not in the allow list (and not local) are rejected during the WebSocket upgrade.
 
+### Broker options
+
+- **Maximum clients:** Limit concurrent WebSocket sessions with `--max-clients` (or `BROKER_MAX_CLIENTS`). The default is `256`; set it to `0` to allow unlimited clients. When the broker is at capacity, new connection attempts receive an HTTP 503 response and a log entry is emitted so operators can adjust the limit if needed.
+
 3. **Run the Python simulation client** (publishes telemetry messages):
    ```bash
    cd python-sim


### PR DESCRIPTION
## Summary
- add a configurable maximum WebSocket client limit sourced from flags or environment variables
- refuse excess connections with logging and update tests to cover the capacity guard
- document the new broker option in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d98469d0648329ad794f2d5cda62ec