### PR TITLE
Add deterministic telemetry noise options to Python simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Follow these steps to bring the entire stack up locally on one machine:
    python client.py
    ```
 
+   To experiment with telemetry noise, supply the optional CLI flags. Noise
+   defaults to zero so runs are deterministic unless you opt in:
+
+   ```bash
+   python client.py --pos-noise 5.0 --vel-noise 1.5 --random-seed 12345
+   ```
+
+   - `--pos-noise` adds up to the specified number of meters of positional
+     jitter to each telemetry sample.
+   - `--vel-noise` adds up to the specified meters/second of velocity
+     variation.
+   - `--random-seed` makes the injected noise deterministic so you can
+     reproduce the same run later.
+
 5. **Open the viewer** to visualize entities streaming from the simulation:
    - Navigate to `http://localhost:8080/viewer/index.html` in your browser.
    - You should see the 3D scene update in real time as telemetry arrives.

--- a/python-sim/client.py
+++ b/python-sim/client.py
@@ -3,7 +3,7 @@
 
 import argparse
 import os
-from typing import Optional
+from typing import Optional, Tuple
 import json
 import random
 import threading
@@ -44,6 +44,30 @@ def mk_telemetry(plane, t):
         "ori": plane.ori,
         "tags": plane.tags,
     })
+
+
+def apply_noise(plane, rng: np.random.Generator, pos_noise: float, vel_noise: float) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    """Apply bounded uniform noise to the plane's position and velocity.
+
+    Returns the generated deltas so callers can restore the original state
+    after emitting telemetry.
+    """
+
+    if (pos_noise <= 0 and vel_noise <= 0) or rng is None:
+        return None, None
+
+    pos_delta: Optional[np.ndarray] = None
+    vel_delta: Optional[np.ndarray] = None
+
+    if pos_noise > 0:
+        pos_delta = rng.uniform(-pos_noise, pos_noise, size=plane.pos.shape)
+        plane.pos += pos_delta
+
+    if vel_noise > 0:
+        vel_delta = rng.uniform(-vel_noise, vel_noise, size=plane.vel.shape)
+        plane.vel += vel_delta
+
+    return pos_delta, vel_delta
 
 
 def mk_cake_drop(plane, landing_pos=None, status="in_flight"):
@@ -114,7 +138,13 @@ def handle_command(command, plane, ws):
         print(f"No handler for command '{cmd_name}', ignoring")
 
 
-def run(ws_url: str, origin: Optional[str] = None):
+def run(
+    ws_url: str,
+    origin: Optional[str] = None,
+    pos_noise: float = 0.0,
+    vel_noise: float = 0.0,
+    random_seed: Optional[int] = None,
+):
     print("Connecting to", ws_url)
     p = Plane("plane-1", x=0, y=0, z=1200, speed=140.0)
     p.tags.append("pastel:turquoise")
@@ -124,6 +154,8 @@ def run(ws_url: str, origin: Optional[str] = None):
     # aircraft continuously showcases the parallax of the buildings and trees.
     planner = FlightPathPlanner(build_default_waypoints(), loop=True, arrival_tolerance=80.0)
     cruise = CruiseController(acceleration=18.0, max_speed=250.0)
+
+    rng = np.random.default_rng(random_seed)
 
     t0 = time.time()
     last_cake = -10.0
@@ -164,12 +196,18 @@ def run(ws_url: str, origin: Optional[str] = None):
                 # Handle incoming commands from broker
                 process_pending_commands(p, ws, command_queue)
 
-                # Send telemetry
+                # Send telemetry (with optional positional/velocity noise)
+                pos_delta, vel_delta = apply_noise(p, rng, pos_noise, vel_noise)
                 try:
                     ws.send(mk_telemetry(p, t))
                 except WebSocketConnectionClosedException:
                     print("Connection closed while sending telemetry")
                     raise
+                finally:
+                    if pos_delta is not None:
+                        p.pos -= pos_delta
+                    if vel_delta is not None:
+                        p.vel -= vel_delta
 
                 # Occasional cake drop
                 if (t - last_cake) > 8.0 and random.random() < 0.02:
@@ -212,6 +250,18 @@ def run(ws_url: str, origin: Optional[str] = None):
         backoff = min(backoff * 2, max_backoff)
 
 
+def non_negative_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid number") from exc
+
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("Noise values must be non-negative")
+
+    return parsed
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
@@ -232,6 +282,35 @@ def parse_args():
         help=(
             "HTTP(S) origin to send during the WebSocket handshake. Overrides "
             "the SIM_ORIGIN environment variable."
+        ),
+    )
+    parser.add_argument(
+        "--pos-noise",
+        type=non_negative_float,
+        default=0.0,
+        metavar="METERS",
+        help=(
+            "Maximum absolute positional noise (in meters) added to telemetry. "
+            "Defaults to 0.0 (no noise)."
+        ),
+    )
+    parser.add_argument(
+        "--vel-noise",
+        type=non_negative_float,
+        default=0.0,
+        metavar="MPS",
+        help=(
+            "Maximum absolute velocity noise (in meters/second) added to telemetry. "
+            "Defaults to 0.0 (no noise)."
+        ),
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=None,
+        help=(
+            "Seed for the telemetry noise RNG so runs can be reproduced. "
+            "If omitted, a random seed is used."
         ),
     )
     return parser.parse_args()
@@ -276,4 +355,10 @@ if __name__ == '__main__':
     args = parse_args()
     ws_url = get_ws_url(args.broker_url)
     origin = get_origin(args.origin, ws_url)
-    run(ws_url, origin)
+    run(
+        ws_url,
+        origin,
+        pos_noise=args.pos_noise,
+        vel_noise=args.vel_noise,
+        random_seed=args.random_seed,
+    )

--- a/python-sim/tests/test_noise.py
+++ b/python-sim/tests/test_noise.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import numpy as np
+
+# Ensure the simulator package is importable when running pytest from the repo root.
+THIS_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(THIS_DIR, ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from client import Plane, apply_noise  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_noise_stays_within_bounds():
+    plane = Plane("test-plane", x=10.0, y=-5.0, z=500.0, speed=45.0)
+    rng = np.random.default_rng(1234)
+
+    pos_noise = 3.5
+    vel_noise = 1.25
+
+    pos_before = plane.pos.copy()
+    vel_before = plane.vel.copy()
+
+    pos_delta, vel_delta = apply_noise(plane, rng, pos_noise, vel_noise)
+
+    assert pos_delta is not None
+    assert vel_delta is not None
+
+    assert np.all(np.abs(pos_delta) <= pos_noise)
+    assert np.all(np.abs(vel_delta) <= vel_noise)
+
+    assert np.allclose(plane.pos, pos_before + pos_delta)
+    assert np.allclose(plane.vel, vel_before + vel_delta)
+
+    # Restore and ensure we end up back at the starting values.
+    plane.pos -= pos_delta
+    plane.vel -= vel_delta
+
+    assert np.allclose(plane.pos, pos_before)
+    assert np.allclose(plane.vel, vel_before)


### PR DESCRIPTION
## Summary
- add CLI flags that control positional and velocity telemetry noise with optional RNG seeding
- inject bounded uniform noise into plane telemetry before each mk_telemetry call
- add a regression test for the noise helper and document the new flags in the README

## Testing
- pytest python-sim/tests

------
https://chatgpt.com/codex/tasks/task_e_68d98fa64af88329bc554906e8fabfa9