### PR TITLE
Support external waypoint files in Python simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Follow these steps to bring the entire stack up locally on one machine:
    export SIM_ORIGIN=https://example.com
    python client.py
    ```
+   To supply a custom autopilot loop, pass a waypoint file (see `docs/waypoints-format.md` for details):
+   ```bash
+   python client.py --waypoints-file path/to/loop.yaml
+   ```
 
 5. **Open the viewer** to visualize entities streaming from the simulation:
    - Navigate to `http://localhost:8080/viewer/index.html` in your browser.

--- a/docs/waypoints-format.md
+++ b/docs/waypoints-format.md
@@ -1,0 +1,47 @@
+# DriftPursuit waypoint file format
+
+The simulation client's autopilot can load external waypoint loops from a JSON
+or YAML file. Each waypoint describes the desired `x`, `y`, and `z`
+coordinates in the same coordinate space used by the viewer.
+
+## Schema
+
+- The file must contain a top-level list.
+- Each entry in the list can be either:
+  - an object with explicit `x`, `y`, and `z` fields, or
+  - a sequence of exactly three numbers in the order `[x, y, z]`.
+- Coordinate values are converted to floating-point numbers and must be
+  finite.
+
+## Example (YAML)
+
+```yaml
+- x: -800
+  y: -400
+  z: 1200
+- [200, 0, 1300]
+- x: 500
+  y: 350
+  z: 1150
+```
+
+## Example (JSON)
+
+```json
+[
+  {"x": -800, "y": -400, "z": 1200},
+  [200, 0, 1300],
+  {"x": 500, "y": 350, "z": 1150}
+]
+```
+
+## Usage
+
+Pass the file path to the simulation client when launching it:
+
+```bash
+python client.py --waypoints-file path/to/loop.yaml
+```
+
+If the flag is omitted, the client uses the built-in scenic loop defined in
+`navigation.build_default_waypoints()`.

--- a/python-sim/tests/test_navigation.py
+++ b/python-sim/tests/test_navigation.py
@@ -1,0 +1,77 @@
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock, TestCase
+
+SIM_DIR = Path(__file__).resolve().parents[1]
+if str(SIM_DIR) not in sys.path:
+    sys.path.insert(0, str(SIM_DIR))
+
+import client  # type: ignore  # noqa: E402
+import navigation  # type: ignore  # noqa: E402
+
+
+class LoadWaypointsTests(TestCase):
+    def test_loads_json_waypoints(self) -> None:
+        data = [
+            {"x": -10, "y": 5, "z": 1000},
+            [20, 0, 900],
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "loop.json")
+            path.write_text(json.dumps(data))
+
+            result = navigation.load_waypoints_from_file(path)
+
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(wp, navigation.Waypoint) for wp in result))
+        self.assertEqual(result[0], navigation.Waypoint(-10.0, 5.0, 1000.0))
+        self.assertEqual(result[1], navigation.Waypoint(20.0, 0.0, 900.0))
+
+    def test_loads_yaml_waypoints(self) -> None:
+        yaml_payload = """
+        - x: 1
+          y: 2
+          z: 3
+        - [4, 5, 6]
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "loop.yaml")
+            path.write_text(yaml_payload)
+
+            result = navigation.load_waypoints_from_file(path)
+
+        self.assertEqual(result, [
+            navigation.Waypoint(1.0, 2.0, 3.0),
+            navigation.Waypoint(4.0, 5.0, 6.0),
+        ])
+
+    def test_rejects_non_finite_coordinate(self) -> None:
+        data = [{"x": 1, "y": "nan", "z": 2}]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "loop.json")
+            path.write_text(json.dumps(data))
+
+            with self.assertRaisesRegex(ValueError, "non-finite"):
+                navigation.load_waypoints_from_file(path)
+
+
+class ResolveWaypointsTests(TestCase):
+    def test_defaults_to_builtin_waypoints(self) -> None:
+        with mock.patch("client.build_default_waypoints") as default_builder:
+            default_builder.return_value = [
+                navigation.Waypoint(1.0, 2.0, 3.0),
+                navigation.Waypoint(4.0, 5.0, 6.0),
+            ]
+
+            result = client.resolve_waypoints(None)
+
+        self.assertEqual(result, default_builder.return_value)
+        default_builder.assert_called_once_with()
+
+    def test_returns_copy_of_custom_waypoints(self) -> None:
+        custom_waypoints = [navigation.Waypoint(0.0, 0.0, 1.0)]
+        result = client.resolve_waypoints(custom_waypoints)
+        self.assertEqual(result, custom_waypoints)
+        self.assertIsNot(result, custom_waypoints)


### PR DESCRIPTION
## Summary
- add a --waypoints-file flag and waypoint resolution helper for the simulator client
- implement waypoint file loading with validation for JSON and simple YAML inputs
- document the waypoint format and add unit tests for defaults and custom loops

## Testing
- python -m unittest discover python-sim/tests

------
https://chatgpt.com/codex/tasks/task_e_68d98fa443d4832990dd9388e87785a9