### PR TITLE
Add autopilot commands and viewer integration

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -11,6 +11,60 @@ Messages are JSON. Key types used in the starter:
 3) Command (viewer -> sim)
 { "type":"command", "cmd":"drop_cake", "from":"viewer-A", "target_id":"target-3", "params":{} }
 
+## Commands
+
+The simulator understands a small set of verbs sent through ``type":"command``
+messages. All commands are acknowledged with a ``command_status`` response (see
+below) so tooling can confirm whether a payload was applied successfully.
+
+### ``drop_cake``
+
+Triggers a cake drop event. Optional fields:
+
+* ``params.landing_pos`` – override landing coordinates ``[x, y, z]``.
+
+### ``set_waypoints``
+
+Updates the autopilot route managed by ``FlightPathPlanner``. The viewer's new
+"Cycle Autopilot Route" button emits this verb with preset loops so the plane
+reacts immediately without manual editing.
+
+Required fields:
+
+* ``params.waypoints`` – array of ``[x, y, z]`` triplets. At least one waypoint
+  is required.
+
+Optional fields:
+
+* ``params.loop`` – boolean override to enable/disable looped navigation.
+* ``params.arrival_tolerance`` – numeric distance threshold in simulation units
+  that determines when the planner advances to the next waypoint.
+
+### ``set_speed``
+
+Adjusts the ``CruiseController`` tuning at runtime. The viewer toggles this
+command whenever the forward acceleration control is engaged so the simulated
+aircraft speeds up in sync with on-screen thrust cues.
+
+At least one of the following fields must be supplied:
+
+* ``params.max_speed`` – new cruise speed cap.
+* ``params.acceleration`` – acceleration magnitude applied while ramping up to
+  ``max_speed``.
+
+## Command acknowledgements
+
+Every command elicits a ``command_status`` message. ``status`` is ``"ok"`` for
+successes and ``"error"`` otherwise. ``command_id`` echoes the optional
+identifier supplied by the sender to simplify correlation.
+
+Example:
+
+{ "type":"command_status", "cmd":"set_waypoints", "status":"ok",
+  "from":"plane-1", "target_id":"plane-1", "command_id":"viewer-4",
+  "detail":"updated flight path", "result":{"waypoint_count":4,
+  "loop":true, "arrival_tolerance":80.0} }
+
 The broker simply relays messages to all connected clients in this starter.
 
 ## Broker liveness

--- a/go-broker/control_docs.go
+++ b/go-broker/control_docs.go
@@ -29,17 +29,23 @@ var defaultControlDocs = []ControlDoc{
 		Description: "Engage viewer-driven manual control so keyboard movement is applied on top of telemetry.",
 		Shortcut:    "Button / keyboard M",
 	},
-	{
-		ID:          "accelerate-forward",
-		Label:       "Forward Acceleration",
-		Description: "Toggle a scripted thrust curve that pushes the aircraft down the runway.",
-		Shortcut:    "Button / keyboard T",
-	},
-	{
-		ID:          "keyboard",
-		Label:       "Flight Keys",
-		Description: "WASD for planar movement, RF/Space/Shift for altitude, QE for yaw, arrow keys for pitch and roll.",
-	},
+        {
+                ID:          "accelerate-forward",
+                Label:       "Forward Acceleration",
+                Description: "Toggle a scripted thrust curve that pushes the aircraft down the runway.",
+                Shortcut:    "Button / keyboard T",
+        },
+        {
+                ID:          "reroute-waypoints",
+                Label:       "Cycle Autopilot Route",
+                Description: "Send preset waypoint loops to the simulator using the set_waypoints command.",
+                Shortcut:    "Button",
+        },
+        {
+                ID:          "keyboard",
+                Label:       "Flight Keys",
+                Description: "WASD for planar movement, RF/Space/Shift for altitude, QE for yaw, arrow keys for pitch and roll.",
+        },
 }
 
 // registerControlDocEndpoints registers the HTTP handlers used by the viewer to

--- a/python-sim/test_client.py
+++ b/python-sim/test_client.py
@@ -1,0 +1,109 @@
+"""Tests for the command processing helpers used by the simulation client."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from queue import Queue
+
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.append(str(THIS_DIR))
+
+import client  # noqa: E402  - imported after path adjustments
+from navigation import (  # noqa: E402
+    CruiseController,
+    FlightPathPlanner,
+    build_default_waypoints,
+)
+
+
+class DummyWebSocket:
+    """Capture messages that would normally be sent over the network."""
+
+    def __init__(self) -> None:
+        self.sent_messages: list[str] = []
+
+    def send(self, message: str) -> None:
+        self.sent_messages.append(message)
+
+
+def _build_sim_context():
+    plane = client.Plane("plane-1")
+    planner = FlightPathPlanner(build_default_waypoints(), loop=True, arrival_tolerance=80.0)
+    cruise = CruiseController(acceleration=18.0, max_speed=250.0)
+    ws = DummyWebSocket()
+    queue: Queue = Queue()
+    return plane, planner, cruise, ws, queue
+
+
+def _last_status(ws: DummyWebSocket) -> dict:
+    status_payloads = []
+    for raw in ws.sent_messages:
+        payload = json.loads(raw)
+        if payload.get("type") == "command_status":
+            status_payloads.append(payload)
+    assert status_payloads, "expected at least one command_status message"
+    return status_payloads[-1]
+
+
+def test_process_pending_commands_handles_drop_cake():
+    plane, planner, cruise, ws, queue = _build_sim_context()
+    queue.put({"type": "command", "cmd": "drop_cake", "from": "tester", "params": {}})
+
+    client.process_pending_commands(plane, planner, cruise, ws, queue)
+
+    assert len(ws.sent_messages) == 2
+    cake = json.loads(ws.sent_messages[0])
+    assert cake["type"] == "cake_drop"
+    status = _last_status(ws)
+    assert status["cmd"] == "drop_cake"
+    assert status["status"] == "ok"
+
+
+def test_set_waypoints_command_updates_planner():
+    plane, planner, cruise, ws, queue = _build_sim_context()
+    new_waypoints = [[10, 20, 30], [40, 50, 60]]
+    queue.put(
+        {
+            "type": "command",
+            "cmd": "set_waypoints",
+            "from": "tester",
+            "params": {"waypoints": new_waypoints, "loop": False, "arrival_tolerance": 42},
+        }
+    )
+
+    client.process_pending_commands(plane, planner, cruise, ws, queue)
+
+    target = planner.current_target()
+    assert (target.x, target.y, target.z) == (10.0, 20.0, 30.0)
+    status = _last_status(ws)
+    assert status["cmd"] == "set_waypoints"
+    assert status["status"] == "ok"
+    assert status["result"]["waypoint_count"] == len(new_waypoints)
+    assert status["result"]["loop"] is False
+    assert status["result"]["arrival_tolerance"] == 42.0
+
+
+def test_set_speed_command_updates_cruise_controller():
+    plane, planner, cruise, ws, queue = _build_sim_context()
+    queue.put(
+        {
+            "type": "command",
+            "cmd": "set_speed",
+            "from": "tester",
+            "params": {"max_speed": 310, "acceleration": 25},
+        }
+    )
+
+    client.process_pending_commands(plane, planner, cruise, ws, queue)
+
+    assert cruise.max_speed == 310
+    assert cruise.acceleration == 25
+    status = _last_status(ws)
+    assert status["cmd"] == "set_speed"
+    assert status["status"] == "ok"
+    assert status["result"]["max_speed"] == 310
+    assert status["result"]["acceleration"] == 25

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -97,6 +97,7 @@
     <h2>Pilot Console</h2>
     <button id="manual-toggle" class="control-button">Enable Manual Control</button>
     <button id="accelerate-forward" class="control-button">Start Forward Acceleration</button>
+    <button id="reroute-waypoints" class="control-button">Cycle Autopilot Route</button>
     <ul id="control-instructions"></ul>
     <p id="controls-footnote">All controls are mirrored via keyboard shortcuts. Buttons update in real time as modes change.</p>
   </div>


### PR DESCRIPTION
## Summary
- document the new `set_waypoints` and `set_speed` commands along with command_status acknowledgements
- teach the Python sim to apply planner/cruise updates, acknowledge commands, and cover them with tests
- update the viewer and broker control docs so the UI can emit the new autopilot commands end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d98fa31c8083299b871b551654f011