### PR TITLE
Add manual override command loop and integration test

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -52,6 +52,32 @@ At least one of the following fields must be supplied:
 * ``params.acceleration`` – acceleration magnitude applied while ramping up to
   ``max_speed``.
 
+### ``manual_override``
+
+Enables or disables manual flight overrides sourced from the viewer. The
+browser emits this command whenever keyboard or HUD inputs change so the
+simulator can suspend the autopilot and adopt the requested velocity/attitude.
+
+Required fields:
+
+* ``params.enabled`` – boolean flag indicating whether manual override should
+  be active.
+
+Conditional fields (required when ``params.enabled`` is ``true``):
+
+* ``params.velocity`` – desired ``[vx, vy, vz]`` velocity vector in simulation
+  units. Values follow the same coordinate system as telemetry payloads.
+
+Optional fields:
+
+* ``params.orientation`` – explicit ``[yaw, pitch, roll]`` Euler angles (in
+  radians). When omitted the simulator derives orientation from the velocity
+  vector for smoother blending.
+
+While an override is active the simulator adds the ``manual:override`` tag to
+its telemetry payloads so downstream consumers (like the viewer HUD) can render
+appropriate feedback.
+
 ## Command acknowledgements
 
 Every command elicits a ``command_status`` message. ``status`` is ``"ok"`` for
@@ -65,7 +91,9 @@ Example:
   "detail":"updated flight path", "result":{"waypoint_count":4,
   "loop":true, "arrival_tolerance":80.0} }
 
-The broker simply relays messages to all connected clients in this starter.
+The broker simply relays messages to all connected clients in this starter and
+forwards command payloads without modifying their JSON structure, preserving any
+application-specific fields the viewer includes.
 
 ## Broker liveness
 

--- a/go-broker/main.go
+++ b/go-broker/main.go
@@ -281,13 +281,7 @@ func (b *Broker) serveWS(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			normalized, err := json.Marshal(envelope)
-			if err != nil {
-				log.Printf("failed to normalize message from %s: %v", client.id, err)
-				continue
-			}
-
-			b.broadcast(normalized)
+                        b.broadcast(msg)
 		}
 	}()
 
@@ -472,7 +466,3 @@ func resolveViewerDir() (string, error) {
 	return viewerDir, nil
 }
 
-// --- Optional: keep this stub if that function isn't implemented elsewhere.
-func registerControlDocEndpoints(mux *http.ServeMux) {
-	// no-op for now; add your handlers here later
-}

--- a/python-sim/test_client.py
+++ b/python-sim/test_client.py
@@ -53,7 +53,7 @@ def test_process_pending_commands_handles_drop_cake():
     plane, planner, cruise, ws, queue = _build_sim_context()
     queue.put({"type": "command", "cmd": "drop_cake", "from": "tester", "params": {}})
 
-    client.process_pending_commands(plane, planner, cruise, ws, queue)
+    client.process_pending_commands(plane, planner, cruise, ws, queue, None)
 
     assert len(ws.sent_messages) == 2
     cake = json.loads(ws.sent_messages[0])
@@ -75,7 +75,7 @@ def test_set_waypoints_command_updates_planner():
         }
     )
 
-    client.process_pending_commands(plane, planner, cruise, ws, queue)
+    client.process_pending_commands(plane, planner, cruise, ws, queue, None)
 
     target = planner.current_target()
     assert (target.x, target.y, target.z) == (10.0, 20.0, 30.0)
@@ -98,7 +98,7 @@ def test_set_speed_command_updates_cruise_controller():
         }
     )
 
-    client.process_pending_commands(plane, planner, cruise, ws, queue)
+    client.process_pending_commands(plane, planner, cruise, ws, queue, None)
 
     assert cruise.max_speed == 310
     assert cruise.acceleration == 25

--- a/tests/test_manual_override_integration.py
+++ b/tests/test_manual_override_integration.py
@@ -1,0 +1,217 @@
+import json
+import os
+import select
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Ensure the python-sim package is importable when running tests from repo root.
+SIM_PATH = Path(__file__).resolve().parents[1] / "python-sim"
+if str(SIM_PATH) not in sys.path:
+    sys.path.insert(0, str(SIM_PATH))
+
+websocket = pytest.importorskip("websocket")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BROKER_ROOT = REPO_ROOT / "go-broker"
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_output(proc: subprocess.Popen, needle: str, timeout: float = 30.0):
+    deadline = time.time() + timeout
+    captured: list[str] = []
+    stream = proc.stdout
+    assert stream is not None
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"Process exited early with code {proc.returncode}. Output: {''.join(captured)}"
+            )
+        remaining = max(0.0, deadline - time.time())
+        ready, _, _ = select.select([stream], [], [], remaining)
+        if ready:
+            line = stream.readline()
+            if not line:
+                continue
+            captured.append(line)
+            if needle in line:
+                return captured
+    raise TimeoutError(f"Timed out waiting for '{needle}'. Output so far: {''.join(captured)}")
+
+
+def await_message(ws, predicate, timeout: float = 10.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        remaining = max(0.0, deadline - time.time())
+        ws.settimeout(max(0.1, remaining))
+        try:
+            raw = ws.recv()
+        except websocket.WebSocketTimeoutException:
+            continue
+        last = json.loads(raw)
+        if predicate(last):
+            return last
+    raise AssertionError(f"Did not observe expected message before timeout. Last payload: {last}")
+
+
+def test_manual_override_roundtrip():
+    port = find_free_port()
+    broker_cmd = [
+        "go",
+        "run",
+        ".",
+        "--addr",
+        f"127.0.0.1:{port}",
+    ]
+    broker_env = os.environ.copy()
+    broker_env.setdefault("GO111MODULE", "on")
+    broker_proc = subprocess.Popen(
+        broker_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        cwd=BROKER_ROOT,
+        env=broker_env,
+    )
+
+    sim_proc = None
+    viewer_ws = None
+    try:
+        deadline = time.time() + 30.0
+        while time.time() < deadline:
+            if broker_proc.poll() is not None:
+                raise RuntimeError(
+                    f"Broker exited early with code {broker_proc.returncode}"
+                )
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=1.0):
+                    break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            raise TimeoutError("Timed out waiting for broker TCP port to open")
+
+        sim_cmd = [
+            sys.executable,
+            "python-sim/client.py",
+            "--broker-url",
+            f"ws://127.0.0.1:{port}/ws",
+        ]
+        sim_env = os.environ.copy()
+        sim_env.setdefault("PYTHONUNBUFFERED", "1")
+        sim_proc = subprocess.Popen(
+            sim_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            cwd=REPO_ROOT,
+            env=sim_env,
+        )
+
+        wait_for_output(sim_proc, "Connected to")
+
+        viewer_ws = websocket.create_connection(
+            f"ws://127.0.0.1:{port}/ws",
+            origin="http://localhost",
+        )
+
+        await_message(
+            viewer_ws,
+            lambda msg: msg.get("type") == "telemetry" and msg.get("id") == "plane-1",
+            timeout=15.0,
+        )
+
+        enable_command = {
+            "type": "command",
+            "id": "plane-1",
+            "cmd": "manual_override",
+            "from": "integration-test",
+            "target_id": "plane-1",
+            "params": {
+                "enabled": True,
+                "velocity": [150.0, 25.0, 0.0],
+                "orientation": [0.0, 0.0, 0.0],
+            },
+            "command_id": "integration-1",
+        }
+        viewer_ws.send(json.dumps(enable_command))
+
+        await_message(
+            viewer_ws,
+            lambda msg: msg.get("type") == "command_status"
+            and msg.get("cmd") == "manual_override"
+            and msg.get("status") == "ok",
+        )
+
+        target_velocity = [150.0, 25.0, 0.0]
+
+        def velocity_matches(msg):
+            if msg.get("type") != "telemetry" or msg.get("id") != "plane-1":
+                return False
+            if "manual:override" not in (msg.get("tags") or []):
+                return False
+            vel = msg.get("vel")
+            if not vel:
+                return False
+            return all(abs(float(vel[i]) - target_velocity[i]) < 5.0 for i in range(3))
+
+        manual_msg = await_message(viewer_ws, velocity_matches, timeout=10.0)
+        assert manual_msg is not None
+        assert "manual:override" in manual_msg.get("tags", [])
+
+        disable_command = {
+            "type": "command",
+            "id": "plane-1",
+            "cmd": "manual_override",
+            "from": "integration-test",
+            "target_id": "plane-1",
+            "params": {"enabled": False},
+            "command_id": "integration-2",
+        }
+        viewer_ws.send(json.dumps(disable_command))
+
+        await_message(
+            viewer_ws,
+            lambda msg: msg.get("type") == "command_status"
+            and msg.get("cmd") == "manual_override"
+            and msg.get("status") == "ok",
+        )
+
+        cleared_msg = await_message(
+            viewer_ws,
+            lambda msg: msg.get("type") == "telemetry"
+            and msg.get("id") == "plane-1"
+            and "manual:override" not in (msg.get("tags") or []),
+            timeout=10.0,
+        )
+        assert "manual:override" not in cleared_msg.get("tags", [])
+    finally:
+        if viewer_ws is not None:
+            try:
+                viewer_ws.close()
+            except Exception:
+                pass
+        if sim_proc is not None:
+            try:
+                sim_proc.send_signal(signal.SIGINT)
+                sim_proc.wait(timeout=10.0)
+            except Exception:
+                sim_proc.kill()
+        broker_proc.terminate()
+        try:
+            broker_proc.wait(timeout=10.0)
+        except Exception:
+            broker_proc.kill()


### PR DESCRIPTION
## Summary
- emit manual_override commands from the viewer when manual inputs or state change and surface simulator override status in the HUD
- forward viewer commands unchanged through the broker and teach the simulator to apply manual overrides and tag telemetry accordingly
- document the manual_override schema and add an integration test that exercises the viewer→broker→simulator loop

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d9985c4a188329864015bc11fae3cf