### PR TITLE
Add runtime model switcher and tutorial panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This starter project wires together three pieces so you can focus on gameplay an
 - `go-broker/`: Simple Go WebSocket broker that relays messages and serves the static viewer.
 - `python-sim/`: Python simulation client that publishes telemetry and cake drops.
 - `viewer/`: A minimal three.js web client that subscribes to the broker feed.
-  - Pass `?modelSet=stylized_lowpoly` in the viewer URL to try the built-in procedural low-poly kit without needing a GLTF file.
+  - Switch between available aircraft kits with the **Aircraft Model** dropdown in the viewer. Assets are cached locally so toggling sets is instant, your last choice is remembered in `localStorage`, and the legacy `?modelSet=` query parameter still works for deep links.
 
 ## Prerequisites
 
@@ -101,6 +101,8 @@ Follow these steps to bring the entire stack up locally on one machine:
 5. **Open the viewer** to visualize entities streaming from the simulation:
    - Navigate to `http://localhost:8080/viewer/index.html` in your browser.
    - You should see the 3D scene update in real time as telemetry arrives.
+   - Use the **Aircraft Model** dropdown to hot-swap between model sets. The HUD and console panel reflect loading progress so you know when a kit is ready.
+   - A Quickstart panel in the lower-left corner summarizes manual controls, keyboard shortcuts, and the autopilot loop toggle.
 
 ## Development
 

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -3,6 +3,8 @@ const HUD = document.getElementById('hud');
 const MANUAL_BUTTON = document.getElementById('manual-toggle');
 const ACCELERATE_BUTTON = document.getElementById('accelerate-forward');
 const REROUTE_BUTTON = document.getElementById('reroute-waypoints');
+const MODEL_SET_SELECT = document.getElementById('model-set-select');
+const MODEL_SET_STATUS = document.getElementById('model-set-status');
 const CONTROL_INSTRUCTIONS_LIST = document.getElementById('control-instructions');
 const WS_URL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws';
 
@@ -20,9 +22,17 @@ const MODEL_SETS = {
   },
 };
 const DEFAULT_MODEL_SET_KEY = 'high_fidelity';
-const SELECTED_MODEL_SET_KEY = resolveModelSetKey();
-const SELECTED_MODEL_SET = MODEL_SETS[SELECTED_MODEL_SET_KEY] || MODEL_SETS[DEFAULT_MODEL_SET_KEY];
-const MODEL_SET_LABEL = SELECTED_MODEL_SET.label;
+const MODEL_SET_STORAGE_KEY = 'driftpursuit:modelSet';
+const modelSetAssetCache = new Map();
+let modelSetStorageUnavailable = false;
+let runtimeModelSetKey = null;
+let currentModelSetKey = resolveModelSetKey();
+let currentModelSet = MODEL_SETS[currentModelSetKey] || MODEL_SETS[DEFAULT_MODEL_SET_KEY];
+if (!MODEL_SETS[currentModelSetKey]) {
+  currentModelSetKey = DEFAULT_MODEL_SET_KEY;
+  currentModelSet = MODEL_SETS[DEFAULT_MODEL_SET_KEY];
+}
+persistModelSetKey(currentModelSetKey);
 const MOVEMENT_KEY_CODES = new Set([
   'KeyW','KeyA','KeyS','KeyD',      // planar translation
   'KeyR','KeyF',                    // altitude adjustments
@@ -78,20 +88,8 @@ let cakes = {};
 
 // ----- Aircraft model (optional GLTF or procedural set) -----
 let gltfLoader = null;
+let gltfLoaderUnavailable = false;
 let aircraftLoadError = false;
-if (SELECTED_MODEL_SET.type === 'gltf') {
-  try {
-    if (typeof THREE !== 'undefined' && typeof THREE.GLTFLoader === 'function') {
-      gltfLoader = new THREE.GLTFLoader();
-    } else {
-      console.warn('GLTFLoader not found; will use fallback mesh.');
-      aircraftLoadError = true;
-    }
-  } catch (err) {
-    console.warn('Failed to init GLTFLoader; using fallback mesh.', err);
-    aircraftLoadError = true;
-  }
-}
 let aircraftTemplate = null;
 let aircraftLoadPromise = null;
 const pendingTelemetry = [];
@@ -158,13 +156,14 @@ const AUTOPILOT_PRESETS = [
 
 updateHudStatus();
 wireButtonHandlers();
+setupModelSetPicker();
 loadControlDocs();
 
 window.addEventListener('keydown', handleKeyDown);
 window.addEventListener('keyup', handleKeyUp);
 
 initThree();
-if (SELECTED_MODEL_SET.type === 'procedural' || gltfLoader) beginAircraftLoad();
+beginAircraftLoad();
 
 connect();
 
@@ -469,50 +468,146 @@ function syncCruiseControllerTarget(options = {}){
 }
 
 function beginAircraftLoad(){
-  if (aircraftTemplate || aircraftLoadPromise || aircraftLoadError) return aircraftLoadPromise;
+  const activeKey = currentModelSetKey;
+  currentModelSet = MODEL_SETS[activeKey] || MODEL_SETS[DEFAULT_MODEL_SET_KEY];
 
-  if (SELECTED_MODEL_SET.type === 'gltf') {
-    if (!gltfLoader){
+  if (!currentModelSet){
+    aircraftLoadError = true;
+    flushPendingTelemetry();
+    updateHudStatus();
+    return null;
+  }
+
+  if (aircraftTemplate && !aircraftLoadError){
+    const cachedTemplate = modelSetAssetCache.get(activeKey);
+    if (!cachedTemplate || cachedTemplate.template !== aircraftTemplate){
+      modelSetAssetCache.set(activeKey, { template: aircraftTemplate });
+    }
+    updateHudStatus();
+    return Promise.resolve(aircraftTemplate);
+  }
+
+  const cached = modelSetAssetCache.get(activeKey);
+  if (cached?.template){
+    aircraftTemplate = cached.template;
+    aircraftLoadError = false;
+    rebuildActiveAircraftInstances();
+    flushPendingTelemetry();
+    updateHudStatus();
+    return Promise.resolve(aircraftTemplate);
+  }
+
+  if (cached?.promise){
+    aircraftLoadPromise = cached.promise;
+    return aircraftLoadPromise;
+  }
+
+  let loadPromise;
+  if (currentModelSet.type === 'gltf') {
+    const loader = ensureGltfLoader();
+    if (!loader){
       aircraftLoadError = true;
+      modelSetAssetCache.set(activeKey, { error: new Error('GLTFLoader unavailable') });
       flushPendingTelemetry();
+      updateHudStatus();
       return null;
     }
-    aircraftLoadPromise = new Promise((resolve, reject) => {
-      gltfLoader.load(SELECTED_MODEL_SET.path, (gltf) => {
-        aircraftTemplate = prepareAircraftTemplate(gltf.scene);
-        resolve(aircraftTemplate);
+    loadPromise = new Promise((resolve, reject) => {
+      loader.load(currentModelSet.path, (gltf) => {
+        resolve(prepareAircraftTemplate(gltf.scene));
       }, undefined, (err) => reject(err));
     });
-  } else if (SELECTED_MODEL_SET.type === 'procedural') {
-    aircraftLoadPromise = new Promise((resolve, reject) => {
+  } else if (currentModelSet.type === 'procedural') {
+    loadPromise = new Promise((resolve, reject) => {
       try {
-        aircraftTemplate = prepareAircraftTemplate(SELECTED_MODEL_SET.builder());
-        resolve(aircraftTemplate);
+        resolve(prepareAircraftTemplate(currentModelSet.builder()));
       } catch (builderErr) {
         reject(builderErr);
       }
     });
   } else {
     aircraftLoadError = true;
+    modelSetAssetCache.set(activeKey, { error: new Error('Unsupported model set type') });
     flushPendingTelemetry();
+    updateHudStatus();
     return null;
   }
 
-  aircraftLoadPromise.then(() => {
-    flushPendingTelemetry();
+  const trackedPromise = loadPromise.then((template) => {
+    modelSetAssetCache.set(activeKey, { template });
+    if (currentModelSetKey === activeKey){
+      aircraftTemplate = template;
+      aircraftLoadError = false;
+      rebuildActiveAircraftInstances();
+      flushPendingTelemetry();
+      updateHudStatus();
+    }
+    return template;
   }).catch((err) => {
-    aircraftLoadError = true;
     console.error('Failed to load aircraft model', err);
-    flushPendingTelemetry();
+    modelSetAssetCache.set(activeKey, { error: err });
+    if (currentModelSetKey === activeKey){
+      aircraftLoadError = true;
+      flushPendingTelemetry();
+      updateHudStatus();
+    }
+    throw err;
+  }).finally(() => {
+    if (currentModelSetKey === activeKey){
+      aircraftLoadPromise = null;
+    }
   });
 
-  return aircraftLoadPromise;
+  modelSetAssetCache.set(activeKey, { promise: trackedPromise });
+  if (currentModelSetKey === activeKey){
+    aircraftLoadPromise = trackedPromise;
+  }
+  updateHudStatus();
+  return trackedPromise;
 }
 
 function flushPendingTelemetry(){
   if (!pendingTelemetry.length) return;
   const queued = pendingTelemetry.splice(0, pendingTelemetry.length);
   queued.forEach((queuedMsg) => handleMsg(queuedMsg));
+}
+
+function ensureGltfLoader(){
+  if (gltfLoader) return gltfLoader;
+  if (gltfLoaderUnavailable) return null;
+  try {
+    if (typeof THREE !== 'undefined' && typeof THREE.GLTFLoader === 'function') {
+      gltfLoader = new THREE.GLTFLoader();
+      return gltfLoader;
+    }
+    console.warn('GLTFLoader not found; using fallback mesh.');
+  } catch (err) {
+    console.warn('Failed to init GLTFLoader; using fallback mesh.', err);
+  }
+  gltfLoaderUnavailable = true;
+  return null;
+}
+
+function rebuildActiveAircraftInstances(){
+  if (!aircraftTemplate || aircraftLoadError || !scene) return;
+  planeMeshes.forEach((mesh, id) => {
+    if (!mesh) return;
+    const previousPosition = mesh.position.clone();
+    const previousQuaternion = mesh.quaternion.clone();
+    const previousScale = mesh.scale.clone();
+
+    scene.remove(mesh);
+    disposePlaneResources(id);
+
+    const { object, geometries, materials, textures } = createAircraftInstance();
+    object.position.copy(previousPosition);
+    object.quaternion.copy(previousQuaternion);
+    object.scale.copy(previousScale);
+
+    planeMeshes.set(id, object);
+    planeResources.set(id, { geometries, materials, textures });
+    scene.add(object);
+  });
 }
 
 function prepareAircraftTemplate(root){
@@ -1173,7 +1268,40 @@ function updateHudStatus(){
   const simOverrideLabel = simManualOverrideActive
     ? 'Simulator override: MANUAL'
     : 'Simulator override: autopilot';
-  HUD.innerText = `${connectionStatus}\nMode: ${controlMode}\nModel set: ${MODEL_SET_LABEL}\n${accelLabel}\n${simOverrideLabel}\n[M] toggle manual · [T] toggle thrust · WASD/RF move · QE yaw · arrows pitch/roll`;
+  const modelStatus = computeModelSetStatus();
+  const modelLine = modelStatus.note
+    ? `${modelStatus.label} ${modelStatus.note}`.trim()
+    : modelStatus.label;
+  HUD.innerText = `${connectionStatus}\nMode: ${controlMode}\nModel set: ${modelLine}\n${accelLabel}\n${simOverrideLabel}\n[M] toggle manual · [T] toggle thrust · WASD/RF move · QE yaw · arrows pitch/roll`;
+  if (MODEL_SET_STATUS){
+    MODEL_SET_STATUS.textContent = `Active aircraft: ${modelLine}`.trim();
+  }
+  syncModelSetPicker();
+}
+
+function computeModelSetStatus(){
+  const activeSet = MODEL_SETS[currentModelSetKey] || MODEL_SETS[DEFAULT_MODEL_SET_KEY];
+  if (!activeSet){
+    return { label: 'Unavailable', note: '(not configured)' };
+  }
+  if (aircraftLoadError){
+    return { label: activeSet.label, note: '(fallback active)' };
+  }
+  const cacheEntry = modelSetAssetCache.get(currentModelSetKey);
+  if (cacheEntry?.promise){
+    return { label: activeSet.label, note: '(loading…)' };
+  }
+  if (cacheEntry?.template || aircraftTemplate){
+    return { label: activeSet.label, note: '(ready)' };
+  }
+  return { label: activeSet.label, note: '(initializing…)' };
+}
+
+function syncModelSetPicker(){
+  if (!MODEL_SET_SELECT || !MODEL_SET_SELECT.options?.length) return;
+  if (MODEL_SET_SELECT.value !== currentModelSetKey){
+    MODEL_SET_SELECT.value = currentModelSetKey;
+  }
 }
 
 function wireButtonHandlers(){
@@ -1200,6 +1328,40 @@ function wireButtonHandlers(){
   updateManualButtonState();
   updateAccelerationButtonState();
   updateRerouteButtonState();
+}
+
+function setupModelSetPicker(){
+  if (!MODEL_SET_SELECT) return;
+  MODEL_SET_SELECT.innerHTML = '';
+  Object.entries(MODEL_SETS).forEach(([key, set]) => {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = set.label;
+    MODEL_SET_SELECT.appendChild(option);
+  });
+  MODEL_SET_SELECT.addEventListener('change', (event) => {
+    const desiredKey = event.target.value;
+    handleModelSetSelection(desiredKey);
+  });
+  syncModelSetPicker();
+}
+
+function handleModelSetSelection(desiredKey){
+  const resolvedKey = resolveModelSetKey(desiredKey);
+  const nextKey = MODEL_SETS[resolvedKey] ? resolvedKey : DEFAULT_MODEL_SET_KEY;
+  currentModelSetKey = nextKey;
+  currentModelSet = MODEL_SETS[currentModelSetKey] || MODEL_SETS[DEFAULT_MODEL_SET_KEY];
+  runtimeModelSetKey = currentModelSetKey;
+  persistModelSetKey(currentModelSetKey);
+
+  aircraftTemplate = null;
+  aircraftLoadPromise = null;
+  aircraftLoadError = false;
+
+  syncModelSetPicker();
+  updateHudStatus();
+
+  beginAircraftLoad();
 }
 
 function loadControlDocs(){
@@ -1240,15 +1402,74 @@ function updateAccelerationButtonState(){
   ACCELERATE_BUTTON.classList.toggle('is-active', accelerationEngaged);
 }
 
-function resolveModelSetKey(){
+function resolveModelSetKey(preferredKey){
+  if (preferredKey && MODEL_SETS[preferredKey]) {
+    runtimeModelSetKey = preferredKey;
+    return preferredKey;
+  }
+
+  if (preferredKey && !MODEL_SETS[preferredKey]) {
+    runtimeModelSetKey = DEFAULT_MODEL_SET_KEY;
+    return DEFAULT_MODEL_SET_KEY;
+  }
+
+  if (runtimeModelSetKey && MODEL_SETS[runtimeModelSetKey]) {
+    return runtimeModelSetKey;
+  }
+
+  let queryKey = null;
   try {
     const params = new URLSearchParams(window.location.search);
-    const key = params.get('modelSet') || params.get('modelset');
-    if (key && MODEL_SETS[key]) return key;
+    queryKey = params.get('modelSet') || params.get('modelset');
   } catch (err) {
     console.warn('Unable to parse modelSet parameter', err);
   }
+  if (queryKey && MODEL_SETS[queryKey]){
+    runtimeModelSetKey = queryKey;
+    return queryKey;
+  }
+
+  const storedKey = readPersistedModelSetKey();
+  if (storedKey && MODEL_SETS[storedKey]){
+    runtimeModelSetKey = storedKey;
+    return storedKey;
+  }
+
+  runtimeModelSetKey = DEFAULT_MODEL_SET_KEY;
   return DEFAULT_MODEL_SET_KEY;
+}
+
+function readPersistedModelSetKey(){
+  if (modelSetStorageUnavailable) return null;
+  try {
+    if (typeof window === 'undefined' || !window.localStorage){
+      modelSetStorageUnavailable = true;
+      return null;
+    }
+    return window.localStorage.getItem(MODEL_SET_STORAGE_KEY);
+  } catch (err) {
+    if (!modelSetStorageUnavailable) {
+      console.warn('Unable to read model set from storage', err);
+    }
+    modelSetStorageUnavailable = true;
+  }
+  return null;
+}
+
+function persistModelSetKey(key){
+  if (modelSetStorageUnavailable) return;
+  try {
+    if (typeof window === 'undefined' || !window.localStorage){
+      modelSetStorageUnavailable = true;
+      return;
+    }
+    window.localStorage.setItem(MODEL_SET_STORAGE_KEY, key);
+  } catch (err) {
+    if (!modelSetStorageUnavailable) {
+      console.warn('Unable to persist model set selection', err);
+    }
+    modelSetStorageUnavailable = true;
+  }
 }
 
 function createStylizedLowpolyTemplate(){

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -45,6 +45,39 @@
       color: #30456b;
     }
 
+    #model-set-picker {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .control-label {
+      font-size: 12px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      font-weight: 700;
+      color: #30456b;
+    }
+
+    .control-select {
+      border: 1px solid rgba(48, 69, 107, 0.3);
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-size: 14px;
+      font-weight: 600;
+      color: #1c2d4d;
+      background: rgba(255, 255, 255, 0.96);
+      box-shadow: inset 0 1px 1px rgba(16, 33, 61, 0.08);
+      cursor: pointer;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+
+    .control-select:focus {
+      outline: none;
+      border-color: rgba(65, 105, 225, 0.6);
+      box-shadow: 0 0 0 2px rgba(65, 105, 225, 0.18);
+    }
+
     .control-button {
       border: none;
       border-radius: 6px;
@@ -68,6 +101,16 @@
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 10px 24px rgba(34, 119, 46, 0.45);
     }
 
+    .controls-subtext {
+      font-size: 12px;
+      color: #3d4e6f;
+      margin: 0;
+    }
+
+    #model-set-status {
+      min-height: 16px;
+    }
+
     #control-instructions {
       margin: 0;
       padding-left: 20px;
@@ -85,9 +128,37 @@
     }
 
     #controls-footnote {
-      font-size: 12px;
-      color: #3d4e6f;
       margin: 0;
+    }
+
+    #tutorial-panel {
+      left: 16px;
+      bottom: 16px;
+      width: 260px;
+      line-height: 1.5;
+    }
+
+    #tutorial-panel h2 {
+      margin: 0 0 8px;
+      font-size: 15px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #30456b;
+    }
+
+    #tutorial-panel ol {
+      margin: 0;
+      padding-left: 18px;
+      color: #1d2c45;
+      font-size: 13px;
+    }
+
+    #tutorial-panel li {
+      margin-bottom: 6px;
+    }
+
+    #tutorial-panel li:last-child {
+      margin-bottom: 0;
     }
   </style>
 </head>
@@ -95,11 +166,25 @@
   <div id="hud" class="panel">DriftPursuit Viewer - connecting...</div>
   <div id="controls-panel" class="panel">
     <h2>Pilot Console</h2>
+    <div id="model-set-picker">
+      <label for="model-set-select" class="control-label">Aircraft Model</label>
+      <select id="model-set-select" class="control-select"></select>
+      <p id="model-set-status" class="controls-subtext">Preparing…</p>
+    </div>
     <button id="manual-toggle" class="control-button">Enable Manual Control</button>
     <button id="accelerate-forward" class="control-button">Start Forward Acceleration</button>
     <button id="reroute-waypoints" class="control-button">Cycle Autopilot Route</button>
     <ul id="control-instructions"></ul>
-    <p id="controls-footnote">All controls are mirrored via keyboard shortcuts. Buttons update in real time as modes change.</p>
+    <p id="controls-footnote" class="controls-subtext">All controls are mirrored via keyboard shortcuts. Buttons update in real time as modes change.</p>
+  </div>
+  <div id="tutorial-panel" class="panel">
+    <h2>Quickstart</h2>
+    <ol>
+      <li>Select an aircraft model to load its assets.</li>
+      <li>Watch the HUD for “ready”, then toggle Manual Control or use keyboard shortcuts.</li>
+      <li>Use WASD/RF for translation, QE for yaw, and arrow keys for pitch/roll.</li>
+      <li>Cycle the autopilot route to see preset waypoint loops.</li>
+    </ol>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/GLTFLoader.js"></script>


### PR DESCRIPTION
## Summary
- add an Aircraft Model dropdown to the viewer with HUD status updates and persisted selection
- cache GLTF/procedural templates and rebuild active aircraft when switching sets for snappier toggles
- document the workflow in the README and surface a quickstart tutorial panel in the viewer UI

## Testing
- not run (viewer-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9a21371ac832995deb0b52a8d49e1