### PR TITLE
Remove connection banner screenshot from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This starter project wires together three pieces so you can focus on gameplay and visual polish:
 
+> **Documentation asset note:** The connection flow banner screenshot is now managed outside of this repository so it can be updated manually without touching version control.
+
 - `go-broker/`: Simple Go WebSocket broker that relays messages and serves the static viewer.
 - `python-sim/`: Python simulation client that publishes telemetry and cake drops.
 - `viewer/`: A minimal three.js web client that subscribes to the broker feed.


### PR DESCRIPTION
## Summary
- note that the connection banner screenshot is now managed outside of version control so it can be updated manually

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9a7d855a48329891ff90099bd0b76