### PR TITLE
Remove connection banner image from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,20 @@
 
 This starter project wires together three pieces so you can focus on gameplay and visual polish:
 
-> **Documentation asset note:** The connection flow banner screenshot is now managed outside of this repository so it can be updated manually without touching version control.
-
 - `go-broker/`: Simple Go WebSocket broker that relays messages and serves the static viewer.
 - `python-sim/`: Python simulation client that publishes telemetry and cake drops.
 - `viewer/`: A minimal three.js web client that subscribes to the broker feed.
   - Switch between available aircraft kits with the **Aircraft Model** dropdown in the viewer. Assets are cached locally so toggling sets is instant, your last choice is remembered in `localStorage`, and the legacy `?modelSet=` query parameter still works for deep links.
+
+## Viewer connection banner
+
+The viewer shows a status banner while it connects to the Go broker. Earlier revisions of this documentation embedded a PNG screenshot from `docs/images/connection-banner.png`, but that asset is no longer versioned with the project. To capture a fresh banner image for release notes or runbooks:
+
+1. Start the broker and viewer locally (see **Local Setup** below).
+2. Launch the viewer at `http://localhost:8080/viewer/index.html`.
+3. Grab a screenshot once the HUD panel reads “DriftPursuit Viewer – connecting…”.
+
+Store the screenshot wherever you publish your documentation or knowledge base—keeping it out of the repository avoids unnecessary binary churn.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- remove the stale callout about a committed connection banner screenshot
- add guidance for capturing the viewer connection banner without storing the asset in the repo

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9a97225288329a3e924aa5af9a12d