### PR TITLE
Add configurable tick rate for Python sim client

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Follow these steps to bring the entire stack up locally on one machine:
    export SIM_ORIGIN=https://example.com
    python client.py
    ```
+   Adjust the simulation cadence with ``--tick-rate`` (in Hertz) to slow down or
+   speed up the autopilot loop:
+
+   ```bash
+   python client.py --tick-rate 60  # run at 60 Hz instead of the 30 Hz default
+   ```
+
    To supply a custom autopilot loop, pass a waypoint file (see `docs/waypoints-format.md` for details):
    ```bash
    python client.py --waypoints-file path/to/loop.yaml


### PR DESCRIPTION
## Summary
- add a --tick-rate option to the Python simulator, validating the range and threading the resulting interval through the main loop
- document the new option and expose helpers so tests can assert the derived sleep interval
- extend unit tests to cover default, custom, and invalid tick-rate values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9b600d378832992d863ec094b343a