### PR TITLE
Remove stray duplicate message handler from viewer reconnect logic

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -270,12 +270,6 @@ function reconnectToBroker(){
   connect();
 }
 
-    handleMsg(msg);
-  } catch (err) {
-    console.warn('bad msg', err);
-  }
-}
-
 function handleSocketInterrupted(options = {}){
   const wasAlreadyScheduled = Boolean(reconnectTimerId);
   socket = null;


### PR DESCRIPTION
## Summary
- remove the duplicated handleMsg try/catch that was accidentally appended after reconnectToBroker
- ensure reconnectToBroker cleanly closes before handleSocketInterrupted is declared

## Testing
- node --check viewer/app.js

------
https://chatgpt.com/codex/tasks/task_e_68d9bbb71ecc8329a4f2c20f8bc89e6b