### PR TITLE
Fix viewer connection status label helper

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -99,6 +99,11 @@ const UI_STRINGS = {
   },
 };
 
+function getConnectionStatusLabel(statusKey) {
+  const statusEntry = UI_STRINGS.connectionStatus[statusKey];
+  return statusEntry ? statusEntry.label : 'Connecting…';
+}
+
 const manualOverrideStateByPlane = new Map();
 const DEFAULT_CONTROL_DOCS = [
   {


### PR DESCRIPTION
## Summary
- add a helper to resolve connection status labels from UI_STRINGS
- initialize the viewer connection status through the helper to prevent reference errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9bf15da24832998095668c3a28e19