### PR TITLE
Add plane selector UI and follow manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Follow these steps to bring the entire stack up locally on one machine:
 5. **Open the viewer** to visualize entities streaming from the simulation:
    - Navigate to `http://localhost:8080/viewer/index.html` in your browser.
    - You should see the 3D scene update in real time as telemetry arrives.
-   - Use the **Aircraft Model** dropdown to hot-swap between model sets. The HUD and console panel reflect loading progress so you know when a kit is ready.
-   - A Quickstart panel in the lower-left corner summarizes manual controls, keyboard shortcuts, and the autopilot loop toggle.
+- Use the **Aircraft Model** dropdown to hot-swap between model sets. The HUD and console panel reflect loading progress so you know when a kit is ready.
+- Use the **Tracked Aircraft** dropdown (or press `]` / `[`) to cycle the camera between active planes. The viewer keeps your selection even as new telemetry arrives, and stale planes are flagged in the list until they drop out.
+- A Quickstart panel in the lower-left corner summarizes manual controls, keyboard shortcuts, and the autopilot loop toggle.
 
 ## Development
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -51,6 +51,12 @@
       gap: 6px;
     }
 
+    #plane-selector {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
     .control-label {
       font-size: 12px;
       letter-spacing: 0.05em;
@@ -76,6 +82,14 @@
       outline: none;
       border-color: rgba(65, 105, 225, 0.6);
       box-shadow: 0 0 0 2px rgba(65, 105, 225, 0.18);
+    }
+
+    #plane-follow-select option[data-state="stale"] {
+      color: #a03b20;
+    }
+
+    #plane-follow-select option[data-state="active"] {
+      color: #1c2d4d;
     }
 
     .control-button {
@@ -171,6 +185,11 @@
       <select id="model-set-select" class="control-select"></select>
       <p id="model-set-status" class="controls-subtext">Preparing…</p>
     </div>
+    <div id="plane-selector">
+      <label for="plane-follow-select" class="control-label">Tracked Aircraft</label>
+      <select id="plane-follow-select" class="control-select" aria-label="Choose aircraft to follow"></select>
+      <p id="plane-selector-status" class="controls-subtext" aria-live="polite">Waiting for telemetry…</p>
+    </div>
     <button id="manual-toggle" class="control-button">Enable Manual Control</button>
     <button id="accelerate-forward" class="control-button">Start Forward Acceleration</button>
     <button id="reroute-waypoints" class="control-button">Cycle Autopilot Route</button>
@@ -182,12 +201,14 @@
     <ol>
       <li>Select an aircraft model to load its assets.</li>
       <li>Watch the HUD for “ready”, then toggle Manual Control or use keyboard shortcuts.</li>
+      <li>Use the Tracked Aircraft dropdown (or press ] / [) to switch the camera between active planes.</li>
       <li>Use WASD/RF for translation, QE for yaw, and arrow keys for pitch/roll.</li>
       <li>Cycle the autopilot route to see preset waypoint loops.</li>
     </ol>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/GLTFLoader.js"></script>
+  <script src="planeState.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/viewer/planeState.js
+++ b/viewer/planeState.js
@@ -1,0 +1,158 @@
+(function (globalScope, factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory();
+  } else {
+    globalScope.PlaneState = factory();
+  }
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  function createFollowManager(options = {}) {
+    const planeLastSeen = options.planeLastSeen || new Map();
+    const staleTimeoutMs = typeof options.staleTimeoutMs === 'number' ? options.staleTimeoutMs : 5000;
+    const removalTimeoutMs = typeof options.removalTimeoutMs === 'number' ? options.removalTimeoutMs : staleTimeoutMs;
+    const nowProvider = typeof options.nowProvider === 'function' ? options.nowProvider : () => Date.now();
+
+    let followId = null;
+
+    function ensureFollow(preferredId = null) {
+      let changed = false;
+      let candidate = preferredId;
+      if (candidate && !planeLastSeen.has(candidate)) {
+        candidate = null;
+      }
+      if (candidate && planeLastSeen.has(candidate)) {
+        if (followId !== candidate) {
+          followId = candidate;
+          changed = true;
+        }
+        return changed;
+      }
+
+      if (followId && planeLastSeen.has(followId)) {
+        return false;
+      }
+
+      const firstEntry = planeLastSeen.keys().next();
+      if (!firstEntry.done) {
+        const nextId = firstEntry.value;
+        if (followId !== nextId) {
+          followId = nextId;
+          changed = true;
+        }
+        return changed;
+      }
+
+      if (followId !== null) {
+        followId = null;
+        changed = true;
+      }
+
+      return changed;
+    }
+
+    function onPlaneSeen(id, timestamp) {
+      const seenAt = typeof timestamp === 'number' ? timestamp : nowProvider();
+      const previous = planeLastSeen.get(id);
+      const isNew = previous === undefined;
+      const wasStale = previous !== undefined && (seenAt - previous) > staleTimeoutMs;
+      planeLastSeen.set(id, seenAt);
+      const preferId = planeLastSeen.size === 1 ? id : null;
+      const followChanged = ensureFollow(preferId);
+      return {
+        isNew,
+        followChanged,
+        statusChanged: isNew || wasStale,
+        followId,
+      };
+    }
+
+    function reapStalePlanes(currentTime) {
+      const now = typeof currentTime === 'number' ? currentTime : nowProvider();
+      const removedIds = [];
+      for (const [id, last] of planeLastSeen.entries()) {
+        if ((now - last) > removalTimeoutMs) {
+          planeLastSeen.delete(id);
+          removedIds.push(id);
+        }
+      }
+
+      let followChanged = false;
+      if (removedIds.length > 0) {
+        followChanged = ensureFollow();
+      } else if (!followId || !planeLastSeen.has(followId)) {
+        followChanged = ensureFollow();
+      }
+
+      return { removedIds, followChanged, followId };
+    }
+
+    function setFollow(id) {
+      const next = id || null;
+      if (next && !planeLastSeen.has(next)) {
+        return { followChanged: false, followId };
+      }
+      const changed = ensureFollow(next);
+      return { followChanged: changed, followId };
+    }
+
+    function cycleFollow(delta) {
+      const ids = Array.from(planeLastSeen.keys());
+      if (ids.length === 0) {
+        const changed = followId !== null;
+        followId = null;
+        return { followChanged: changed, followId };
+      }
+
+      if (!followId || !planeLastSeen.has(followId)) {
+        const changed = ensureFollow();
+        return { followChanged: changed, followId };
+      }
+
+      if (!delta) {
+        return { followChanged: false, followId };
+      }
+
+      let index = ids.indexOf(followId);
+      if (index === -1) {
+        index = 0;
+      }
+      const length = ids.length;
+      let nextIndex = (index + delta) % length;
+      if (nextIndex < 0) nextIndex += length;
+      const nextId = ids[nextIndex];
+      const changed = followId !== nextId;
+      followId = nextId;
+      return { followChanged: changed, followId };
+    }
+
+    function getPlaneStatuses(currentTime) {
+      const now = typeof currentTime === 'number' ? currentTime : nowProvider();
+      const statuses = [];
+      for (const [id, last] of planeLastSeen.entries()) {
+        statuses.push({
+          id,
+          stale: (now - last) > staleTimeoutMs,
+          lastSeen: last,
+        });
+      }
+      return statuses;
+    }
+
+    function getFollow() {
+      if (followId && !planeLastSeen.has(followId)) {
+        ensureFollow();
+      }
+      return followId;
+    }
+
+    return {
+      onPlaneSeen,
+      reapStalePlanes,
+      setFollow,
+      cycleFollow,
+      getPlaneStatuses,
+      getFollow,
+    };
+  }
+
+  return { createFollowManager };
+});

--- a/viewer/tests/planeState.test.mjs
+++ b/viewer/tests/planeState.test.mjs
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import PlaneStateModule from '../planeState.js';
+
+const { createFollowManager } = PlaneStateModule;
+
+test('keeps manual follow when new telemetry arrives', () => {
+  let now = 0;
+  const planeLastSeen = new Map();
+  const manager = createFollowManager({
+    planeLastSeen,
+    staleTimeoutMs: 50,
+    removalTimeoutMs: 150,
+    nowProvider: () => now,
+  });
+
+  manager.onPlaneSeen('plane-1', now);
+  assert.equal(manager.getFollow(), 'plane-1');
+
+  now += 5;
+  manager.setFollow('plane-1');
+
+  now += 5;
+  manager.onPlaneSeen('plane-2', now);
+  assert.equal(manager.getFollow(), 'plane-1', 'new plane should not override manual selection');
+});
+
+test('reports stale planes before removal and eventually prunes them', () => {
+  let now = 0;
+  const planeLastSeen = new Map();
+  const manager = createFollowManager({
+    planeLastSeen,
+    staleTimeoutMs: 50,
+    removalTimeoutMs: 150,
+    nowProvider: () => now,
+  });
+
+  manager.onPlaneSeen('plane-1', now);
+  assert.equal(manager.getFollow(), 'plane-1');
+
+  now = 80;
+  const statuses = manager.getPlaneStatuses();
+  assert.equal(statuses[0].stale, true, 'plane should be flagged stale before removal');
+
+  const midRemoval = manager.reapStalePlanes();
+  assert.deepEqual(midRemoval.removedIds, [], 'stale plane should remain until removal timeout passes');
+
+  now = 180;
+  const finalRemoval = manager.reapStalePlanes();
+  assert.deepEqual(finalRemoval.removedIds, ['plane-1']);
+  assert.equal(manager.getFollow(), null);
+});
+
+test('reassigns follow to another active plane when current plane expires', () => {
+  let now = 0;
+  const planeLastSeen = new Map();
+  const manager = createFollowManager({
+    planeLastSeen,
+    staleTimeoutMs: 50,
+    removalTimeoutMs: 150,
+    nowProvider: () => now,
+  });
+
+  manager.onPlaneSeen('plane-1', now);
+  now = 10;
+  manager.onPlaneSeen('plane-2', now);
+  manager.setFollow('plane-2');
+  assert.equal(manager.getFollow(), 'plane-2');
+
+  now = 120;
+  manager.onPlaneSeen('plane-1', now);
+
+  now = 200;
+  const result = manager.reapStalePlanes();
+  assert.deepEqual(result.removedIds, ['plane-2']);
+  assert.equal(manager.getFollow(), 'plane-1', 'follow should move to remaining active plane');
+});
+
+test('cycles through planes in insertion order and recovers when follow entry is missing', () => {
+  let now = 0;
+  const planeLastSeen = new Map();
+  const manager = createFollowManager({
+    planeLastSeen,
+    staleTimeoutMs: 50,
+    removalTimeoutMs: 150,
+    nowProvider: () => now,
+  });
+
+  manager.onPlaneSeen('plane-1', now);
+  now = 10;
+  manager.onPlaneSeen('plane-2', now);
+
+  assert.equal(manager.getFollow(), 'plane-1');
+
+  manager.cycleFollow(1);
+  assert.equal(manager.getFollow(), 'plane-2');
+
+  manager.cycleFollow(-1);
+  assert.equal(manager.getFollow(), 'plane-1');
+
+  // Simulate losing the tracked plane without informing the manager so it must recover.
+  planeLastSeen.delete('plane-1');
+  manager.cycleFollow(1);
+  assert.equal(manager.getFollow(), 'plane-2');
+});


### PR DESCRIPTION
## Summary
- add a follow manager module to track active aircraft and maintain the camera target across telemetry updates
- expose a tracked-aircraft selector in the viewer UI with stale indicators and keyboard shortcuts for cycling
- document the selector workflow and add tests covering follow persistence and cycling behaviour

## Testing
- node --test viewer/tests/planeState.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d9a74ce2ec8329b84ffe4fee3ca3e8