### PR TITLE
feat(viewer): add chase camera and manual flight controls

### DIFF
--- a/viewer/camera/ChaseCam.js
+++ b/viewer/camera/ChaseCam.js
@@ -1,0 +1,100 @@
+const DEFAULT_BACK_OFFSET = 40;
+const DEFAULT_UP_OFFSET = 20;
+const SPRING_STRENGTH = 6.5;
+const SPRING_DAMPING = 3.5;
+const LOOK_AHEAD_DISTANCE = 55;
+const LOOK_LERP_RATE = 6;
+const THREE_NS = (typeof window !== 'undefined' ? window.THREE : null) || (typeof THREE !== 'undefined' ? THREE : null);
+if (!THREE_NS) {
+  throw new Error('ChaseCam requires THREE to be loaded globally');
+}
+const { Vector3 } = THREE_NS;
+
+const tmpDesired = new Vector3();
+const tmpStretch = new Vector3();
+const tmpForward = new Vector3();
+const tmpLook = new Vector3();
+
+export class ChaseCam {
+  constructor(camera) {
+    this.camera = camera;
+    this.target = null;
+    this.backOffset = DEFAULT_BACK_OFFSET;
+    this.upOffset = DEFAULT_UP_OFFSET;
+    this.position = new Vector3();
+    this.velocity = new Vector3();
+    this.lookTarget = new Vector3();
+    this.initialized = false;
+  }
+
+  follow(target) {
+    if (this.target !== target) {
+      this.target = target || null;
+      this.initialized = false;
+    }
+    if (this.target && !this.initialized) {
+      this.snapToTarget();
+    }
+  }
+
+  setOffsets(back, up) {
+    if (typeof back === 'number') {
+      this.backOffset = Math.max(0, back);
+    }
+    if (typeof up === 'number') {
+      this.upOffset = up;
+    }
+  }
+
+  snapToTarget() {
+    if (!this.target) return;
+    const desired = this.computeDesiredPosition(tmpDesired);
+    this.position.copy(desired);
+    this.velocity.set(0, 0, 0);
+    this.lookTarget.copy(this.target.position);
+    this.camera.position.copy(desired);
+    this.camera.lookAt(this.lookTarget);
+    this.initialized = true;
+  }
+
+  update(dt) {
+    if (!this.target || !Number.isFinite(dt)) return;
+    if (!this.initialized) {
+      this.snapToTarget();
+      return;
+    }
+    const desired = this.computeDesiredPosition(tmpDesired);
+    tmpStretch.subVectors(desired, this.position);
+    const acceleration = tmpStretch.multiplyScalar(SPRING_STRENGTH);
+    this.velocity.addScaledVector(acceleration, dt);
+    const damping = Math.exp(-SPRING_DAMPING * dt);
+    this.velocity.multiplyScalar(damping);
+    this.position.addScaledVector(this.velocity, dt);
+
+    this.camera.position.copy(this.position);
+
+    this.computeLookTarget(tmpLook, dt);
+    this.camera.lookAt(this.lookTarget);
+  }
+
+  computeDesiredPosition(out = new Vector3()) {
+    if (!this.target) return out.set(0, 0, 0);
+    tmpForward.set(0, -this.backOffset, this.upOffset);
+    tmpForward.applyQuaternion(this.target.quaternion);
+    out.copy(this.target.position).add(tmpForward);
+    return out;
+  }
+
+  computeLookTarget(out, dt) {
+    if (!this.target) return this.lookTarget.set(0, 0, 0);
+    tmpForward.set(0, 1, 0).applyQuaternion(this.target.quaternion);
+    out.copy(this.target.position).addScaledVector(tmpForward, LOOK_AHEAD_DISTANCE);
+    const lerpT = 1 - Math.exp(-LOOK_LERP_RATE * (Number.isFinite(dt) ? dt : 0));
+    if (!Number.isFinite(lerpT) || lerpT <= 0) {
+      this.lookTarget.copy(out);
+    } else {
+      this.lookTarget.lerp(out, lerpT);
+    }
+    return this.lookTarget;
+  }
+}

--- a/viewer/control/Input.js
+++ b/viewer/control/Input.js
@@ -1,0 +1,132 @@
+const CONTROL_KEY_SET = new Set([
+  'KeyW', 'KeyS',
+  'KeyA', 'KeyD',
+  'ArrowUp', 'ArrowDown',
+  'ArrowLeft', 'ArrowRight',
+  'KeyQ', 'KeyE'
+]);
+
+const PREVENT_DEFAULT_KEYS = new Set(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight']);
+
+const activeKeys = new Set();
+let invertAxes = false;
+let throttleHold = false;
+
+const DEADZONE = 0.15;
+
+function applyDigitalAxis(positiveKeys, negativeKeys) {
+  let value = 0;
+  for (const key of positiveKeys) {
+    if (activeKeys.has(key)) {
+      value += 1;
+      break;
+    }
+  }
+  for (const key of negativeKeys) {
+    if (activeKeys.has(key)) {
+      value -= 1;
+      break;
+    }
+  }
+  return value;
+}
+
+function applyDeadzone(value) {
+  if (!Number.isFinite(value)) return 0;
+  if (Math.abs(value) < DEADZONE) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+function findFirstGamepad() {
+  if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') {
+    return null;
+  }
+  const pads = navigator.getGamepads();
+  if (!pads) return null;
+  for (const pad of pads) {
+    if (pad) return pad;
+  }
+  return null;
+}
+
+function extractGamepadState() {
+  const pad = findFirstGamepad();
+  if (!pad) return null;
+  const axes = pad.axes || [];
+  const buttons = pad.buttons || [];
+  const yaw = applyDeadzone(axes[0] || 0);
+  const pitch = applyDeadzone(-(axes[1] || 0));
+  const roll = applyDeadzone(axes[2] !== undefined ? axes[2] : axes[3] || 0);
+  let throttle = null;
+  if (buttons[7] && typeof buttons[7].value === 'number') {
+    throttle = Math.max(0, Math.min(1, buttons[7].value));
+  } else if (axes[5] !== undefined) {
+    throttle = Math.max(0, Math.min(1, (axes[5] + 1) / 2));
+  }
+  return { yaw, pitch, roll, throttle };
+}
+
+export function onKeyDown(code) {
+  if (!CONTROL_KEY_SET.has(code)) {
+    return { handled: false };
+  }
+  activeKeys.add(code);
+  return { handled: true, preventDefault: PREVENT_DEFAULT_KEYS.has(code) };
+}
+
+export function onKeyUp(code) {
+  if (!CONTROL_KEY_SET.has(code)) {
+    return { handled: false };
+  }
+  activeKeys.delete(code);
+  return { handled: true, preventDefault: PREVENT_DEFAULT_KEYS.has(code) };
+}
+
+export function setInvertAxes(enabled) {
+  invertAxes = Boolean(enabled);
+}
+
+export function setThrottleHold(enabled) {
+  throttleHold = Boolean(enabled);
+}
+
+export function getThrottleHold() {
+  return throttleHold;
+}
+
+export function isControlKey(code) {
+  return CONTROL_KEY_SET.has(code);
+}
+
+export function readControls() {
+  const digitalYaw = applyDigitalAxis(['KeyE'], ['KeyQ']);
+  const digitalPitch = applyDigitalAxis(['KeyW', 'ArrowUp'], ['KeyS', 'ArrowDown']);
+  const digitalRoll = applyDigitalAxis(['KeyD', 'ArrowRight'], ['KeyA', 'ArrowLeft']);
+
+  const gamepad = extractGamepadState();
+  let yaw = digitalYaw;
+  let pitch = digitalPitch;
+  let roll = digitalRoll;
+  if (gamepad) {
+    if (Math.abs(gamepad.yaw) > Math.abs(yaw)) yaw = gamepad.yaw;
+    if (Math.abs(gamepad.pitch) > Math.abs(pitch)) pitch = gamepad.pitch;
+    if (Math.abs(gamepad.roll) > Math.abs(roll)) roll = gamepad.roll;
+  }
+
+  if (invertAxes) {
+    pitch *= -1;
+    roll *= -1;
+  }
+
+  yaw = Math.max(-1, Math.min(1, yaw));
+  pitch = Math.max(-1, Math.min(1, pitch));
+  roll = Math.max(-1, Math.min(1, roll));
+
+  let throttle = throttleHold ? 1 : 0;
+  if (gamepad && typeof gamepad.throttle === 'number') {
+    throttle = gamepad.throttle;
+  }
+  throttle = Math.max(0, Math.min(1, throttle));
+
+  return { yaw, pitch, roll, throttle };
+}

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -291,6 +291,6 @@
 
   <script src="vendor/GLTFLoader.js"></script>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce a spring-damped ChaseCam helper and convert the viewer to use module scripts
- add a shared Input helper that normalizes keyboard and gamepad flight controls
- replace the manual movement shim with a throttle-based flight integrator and update the HUD with throttle and airspeed feedback

## Testing
- pytest *(fails: go broker port did not open in time)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e136225c8329b8fd3aec81bd1ad6