### PR TITLE
Add endless flight sandbox demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ The viewer shows a status banner while it connects to the Go broker. Earlier rev
 
 Store the screenshot wherever you publish your documentation or knowledge base—keeping it out of the repository avoids unnecessary binary churn.
 
+## Sandbox flight demo (three.js)
+
+For a self-contained arcade flight sandbox that satisfies the open-world brief, serve the `viewer/` directory with any static file server and open the sandbox entry point:
+
+```bash
+cd viewer
+npx http-server -p 8080 .
+# or: python -m http.server 8080
+```
+
+Then visit [`http://localhost:8080/sandbox/index.html`](http://localhost:8080/sandbox/index.html).
+
+Controls:
+
+- **W / S (or ↑ / ↓)** – Pitch nose down / up
+- **A / D (or ← / →)** – Roll left / right
+- **Q / E** – Rudder yaw
+- **R / F** – Increase / decrease throttle
+- **X** – Hold for airbrake (cuts throttle quickly)
+
+The HUD overlays throttle, airspeed, altitude, crash counter, and the same control reference. The world streams procedurally generated hills and mountain ridges around the aircraft, rebasing the origin automatically so you can keep flying without running into floating point precision issues. Colliding with terrain or props triggers an instant crash/restart and increments the counter.
+
 ## Prerequisites
 
 - Go 1.20 or newer

--- a/viewer/sandbox/ChaseCamera.js
+++ b/viewer/sandbox/ChaseCamera.js
@@ -1,0 +1,42 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+
+const TMP_FORWARD = new THREE.Vector3();
+const TMP_UP = new THREE.Vector3(0, 0, 1);
+const TMP_TARGET = new THREE.Vector3();
+
+export class ChaseCamera {
+  constructor(camera, { distance = 55, height = 24, stiffness = 4, lookAhead = 14 } = {}){
+    this.camera = camera;
+    this.distance = distance;
+    this.height = height;
+    this.stiffness = stiffness;
+    this.lookAhead = lookAhead;
+    this.currentPosition = camera.position.clone();
+  }
+
+  update({ position, orientation, velocity }, dt){
+    if (!this.camera || !position || !orientation) return;
+    const forward = TMP_FORWARD.set(0, 1, 0).applyQuaternion(orientation).normalize();
+    const desired = TMP_TARGET.copy(position)
+      .addScaledVector(forward, -this.distance)
+      .addScaledVector(TMP_UP, this.height);
+
+    const lerpFactor = 1 - Math.exp(-this.stiffness * dt);
+    if (Number.isFinite(lerpFactor)){
+      this.currentPosition.lerp(desired, lerpFactor);
+    } else {
+      this.currentPosition.copy(desired);
+    }
+
+    this.camera.position.copy(this.currentPosition);
+
+    const lookTarget = TMP_TARGET.copy(position);
+    if (velocity){
+      const speed = velocity.length();
+      if (speed > 0.1){
+        lookTarget.addScaledVector(forward, this.lookAhead + Math.min(speed * 0.2, 30));
+      }
+    }
+    this.camera.lookAt(lookTarget);
+  }
+}

--- a/viewer/sandbox/CollisionSystem.js
+++ b/viewer/sandbox/CollisionSystem.js
@@ -1,0 +1,51 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+
+const TMP_VECTOR = new THREE.Vector3();
+
+export class CollisionSystem {
+  constructor({ world, crashMargin = 1.8, obstaclePadding = 2.2 } = {}){
+    this.world = world;
+    this.crashMargin = crashMargin;
+    this.obstaclePadding = obstaclePadding;
+  }
+
+  evaluate(planeState){
+    if (!planeState || !this.world) return { crashed: false };
+    const { position } = planeState;
+    const groundHeight = this.world.getHeightAt(position.x, position.y);
+    const altitude = position.z - groundHeight;
+
+    if (altitude <= this.crashMargin){
+      return {
+        crashed: true,
+        reason: 'ground',
+        altitude,
+        groundHeight,
+      };
+    }
+
+    const originOffset = this.world.getOriginOffset();
+    const planeWorld = TMP_VECTOR.copy(position).add(originOffset);
+
+    const obstacles = this.world.getObstaclesNear(position.x, position.y, 120);
+    for (const obstacle of obstacles){
+      const dx = obstacle.worldPosition.x - planeWorld.x;
+      const dy = obstacle.worldPosition.y - planeWorld.y;
+      const horizontalSq = dx * dx + dy * dy;
+      const radius = obstacle.radius + this.obstaclePadding;
+      if (horizontalSq <= radius * radius){
+        if (planeWorld.z <= obstacle.topHeight + this.obstaclePadding){
+          return {
+            crashed: true,
+            reason: 'obstacle',
+            altitude,
+            groundHeight,
+            obstacle,
+          };
+        }
+      }
+    }
+
+    return { crashed: false, altitude, groundHeight };
+  }
+}

--- a/viewer/sandbox/HUD.js
+++ b/viewer/sandbox/HUD.js
@@ -1,0 +1,132 @@
+const PANEL_STYLE = `
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  padding: 16px 20px;
+  background: rgba(18, 30, 52, 0.6);
+  color: #e8f1ff;
+  font-family: 'Segoe UI', sans-serif;
+  border-radius: 12px;
+  min-width: 260px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(10px);
+`;
+
+const MESSAGE_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 18px 24px;
+  font-size: 24px;
+  font-weight: 700;
+  color: #fff9f2;
+  background: rgba(210, 60, 60, 0.82);
+  border-radius: 12px;
+  box-shadow: 0 22px 60px rgba(210, 60, 60, 0.45);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+`;
+
+const LIST_STYLE = `
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 6px;
+`;
+
+export class HUD {
+  constructor({ controls = [] } = {}){
+    this.container = document.createElement('div');
+    this.container.id = 'hud-panel';
+    this.container.setAttribute('style', PANEL_STYLE);
+
+    this.status = document.createElement('div');
+    this.status.style.fontSize = '14px';
+    this.status.style.letterSpacing = '0.06em';
+    this.status.style.textTransform = 'uppercase';
+    this.status.style.marginBottom = '10px';
+    this.status.textContent = 'Initializing flight systems…';
+
+    this.metrics = document.createElement('div');
+    this.metrics.style.display = 'grid';
+    this.metrics.style.gap = '4px';
+    this.metrics.style.fontSize = '15px';
+    this.metrics.style.fontWeight = '600';
+
+    this.throttleBar = document.createElement('div');
+    this.throttleBar.style.height = '6px';
+    this.throttleBar.style.background = 'rgba(255,255,255,0.2)';
+    this.throttleBar.style.borderRadius = '999px';
+    this.throttleFill = document.createElement('div');
+    this.throttleFill.style.height = '100%';
+    this.throttleFill.style.background = 'linear-gradient(90deg, #51d7ff, #5bff90)';
+    this.throttleFill.style.borderRadius = 'inherit';
+    this.throttleFill.style.width = '0%';
+    this.throttleBar.appendChild(this.throttleFill);
+
+    this.controlsTitle = document.createElement('div');
+    this.controlsTitle.textContent = 'Flight Controls';
+    this.controlsTitle.style.marginTop = '14px';
+    this.controlsTitle.style.fontSize = '13px';
+    this.controlsTitle.style.letterSpacing = '0.12em';
+    this.controlsTitle.style.textTransform = 'uppercase';
+    this.controlsTitle.style.opacity = '0.8';
+
+    this.controlsList = document.createElement('ul');
+    this.controlsList.setAttribute('style', LIST_STYLE);
+    this.controlsList.style.fontSize = '14px';
+    this.controlsList.style.opacity = '0.92';
+
+    this.container.appendChild(this.status);
+    this.container.appendChild(this.metrics);
+    this.container.appendChild(this.throttleBar);
+    this.container.appendChild(this.controlsTitle);
+    this.container.appendChild(this.controlsList);
+
+    document.body.appendChild(this.container);
+
+    this.message = document.createElement('div');
+    this.message.id = 'crash-banner';
+    this.message.setAttribute('style', MESSAGE_STYLE);
+    this.message.style.display = 'none';
+    document.body.appendChild(this.message);
+
+    this.controls = controls;
+    this.renderControls();
+    this.messageTimer = null;
+  }
+
+  update({ throttle = 0, speed = 0, altitude = 0, crashCount = 0 }){
+    this.status.textContent = `Throttle ${(throttle * 100).toFixed(0)}% · Speed ${speed.toFixed(0)} kt`;
+    this.metrics.innerHTML = `
+      <div>Altitude <strong>${altitude.toFixed(0)} m</strong></div>
+      <div>Crash Count <strong>${crashCount}</strong></div>
+    `;
+    this.throttleFill.style.width = `${Math.max(4, Math.min(100, throttle * 100))}%`;
+  }
+
+  renderControls(){
+    this.controlsList.innerHTML = '';
+    this.controls.forEach((entry) => {
+      const item = document.createElement('li');
+      item.innerHTML = `<strong>${entry.label}</strong>: ${entry.detail}`;
+      this.controlsList.appendChild(item);
+    });
+  }
+
+  setControls(controls){
+    this.controls = Array.isArray(controls) ? controls : [];
+    this.renderControls();
+  }
+
+  showMessage(text, durationMs = 1200){
+    this.message.textContent = text;
+    this.message.style.display = 'block';
+    clearTimeout(this.messageTimer);
+    this.messageTimer = setTimeout(() => {
+      this.message.style.display = 'none';
+    }, durationMs);
+  }
+}

--- a/viewer/sandbox/InputManager.js
+++ b/viewer/sandbox/InputManager.js
@@ -1,0 +1,93 @@
+const KEY_BINDINGS = {
+  pitchDown: ['KeyW', 'ArrowUp'],
+  pitchUp: ['KeyS', 'ArrowDown'],
+  rollLeft: ['KeyA', 'ArrowLeft'],
+  rollRight: ['KeyD', 'ArrowRight'],
+  yawLeft: ['KeyQ'],
+  yawRight: ['KeyE'],
+  throttleUp: ['KeyR', 'ShiftLeft', 'ShiftRight'],
+  throttleDown: ['KeyF', 'ControlLeft', 'ControlRight'],
+  brake: ['KeyX'],
+};
+
+const DEADZONE = 0.08;
+
+function applyDigitalAxis(positiveKeys, negativeKeys, activeKeys){
+  let value = 0;
+  for (const key of positiveKeys){
+    if (activeKeys.has(key)){
+      value += 1;
+      break;
+    }
+  }
+  for (const key of negativeKeys){
+    if (activeKeys.has(key)){
+      value -= 1;
+      break;
+    }
+  }
+  return value;
+}
+
+function applyDeadzone(value){
+  if (!Number.isFinite(value)) return 0;
+  return Math.abs(value) < DEADZONE ? 0 : Math.max(-1, Math.min(1, value));
+}
+
+export class InputManager {
+  constructor({ element = window } = {}){
+    this.activeKeys = new Set();
+    this.pitch = 0;
+    this.roll = 0;
+    this.yaw = 0;
+    this.throttleAdjust = 0;
+    this.brake = false;
+    this._onKeyDown = this.handleKeyDown.bind(this);
+    this._onKeyUp = this.handleKeyUp.bind(this);
+    element.addEventListener('keydown', this._onKeyDown);
+    element.addEventListener('keyup', this._onKeyUp);
+    this.element = element;
+  }
+
+  dispose(){
+    if (!this.element) return;
+    this.element.removeEventListener('keydown', this._onKeyDown);
+    this.element.removeEventListener('keyup', this._onKeyUp);
+    this.element = null;
+  }
+
+  handleKeyDown(event){
+    this.activeKeys.add(event.code);
+    const preventDefault = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(event.code);
+    if (preventDefault){
+      event.preventDefault();
+    }
+  }
+
+  handleKeyUp(event){
+    this.activeKeys.delete(event.code);
+    const preventDefault = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(event.code);
+    if (preventDefault){
+      event.preventDefault();
+    }
+  }
+
+  readState(){
+    const pitch = applyDeadzone(applyDigitalAxis(KEY_BINDINGS.pitchDown, KEY_BINDINGS.pitchUp, this.activeKeys));
+    const roll = applyDeadzone(applyDigitalAxis(KEY_BINDINGS.rollRight, KEY_BINDINGS.rollLeft, this.activeKeys));
+    const yaw = applyDeadzone(applyDigitalAxis(KEY_BINDINGS.yawRight, KEY_BINDINGS.yawLeft, this.activeKeys));
+    const throttleAdjust = applyDigitalAxis(KEY_BINDINGS.throttleUp, KEY_BINDINGS.throttleDown, this.activeKeys);
+    const brake = KEY_BINDINGS.brake.some((key) => this.activeKeys.has(key));
+    return { pitch, roll, yaw, throttleAdjust, brake };
+  }
+}
+
+export function describeControls(){
+  return [
+    { label: 'Pitch', detail: 'W/S or ↑/↓ adjusts nose' },
+    { label: 'Roll', detail: 'A/D or ←/→ banks the wings' },
+    { label: 'Yaw', detail: 'Q/E rudder twist' },
+    { label: 'Throttle', detail: 'R increases · F decreases' },
+    { label: 'Brake', detail: 'X taps airbrake' },
+  ];
+}

--- a/viewer/sandbox/Noise.js
+++ b/viewer/sandbox/Noise.js
@@ -1,0 +1,71 @@
+const PERMUTATION_TABLE = new Uint8Array(512);
+const BASE_PERM = new Uint8Array(256);
+
+function buildPermutation(seed){
+  let value = seed >>> 0;
+  for (let i = 0; i < 256; i += 1){
+    value = (value * 1664525 + 1013904223) >>> 0;
+    BASE_PERM[i] = value & 0xff;
+  }
+  for (let i = 0; i < 512; i += 1){
+    PERMUTATION_TABLE[i] = BASE_PERM[i & 255];
+  }
+}
+
+const GRADIENTS = [
+  [1, 1], [-1, 1], [1, -1], [-1, -1],
+  [1, 0], [-1, 0], [0, 1], [0, -1],
+];
+
+function fade(t){
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+function lerp(a, b, t){
+  return a + (b - a) * t;
+}
+
+function grad(hash, x, y){
+  const g = GRADIENTS[hash & 7];
+  return g[0] * x + g[1] * y;
+}
+
+export class NoiseGenerator {
+  constructor(seed = 1337){
+    buildPermutation(seed);
+  }
+
+  perlin2(x, y){
+    const xi = Math.floor(x) & 255;
+    const yi = Math.floor(y) & 255;
+    const xf = x - Math.floor(x);
+    const yf = y - Math.floor(y);
+
+    const topRight = PERMUTATION_TABLE[PERMUTATION_TABLE[xi + 1] + yi + 1];
+    const topLeft = PERMUTATION_TABLE[PERMUTATION_TABLE[xi] + yi + 1];
+    const bottomRight = PERMUTATION_TABLE[PERMUTATION_TABLE[xi + 1] + yi];
+    const bottomLeft = PERMUTATION_TABLE[PERMUTATION_TABLE[xi] + yi];
+
+    const u = fade(xf);
+    const v = fade(yf);
+
+    const x1 = lerp(grad(bottomLeft, xf, yf), grad(bottomRight, xf - 1, yf), u);
+    const x2 = lerp(grad(topLeft, xf, yf - 1), grad(topRight, xf - 1, yf - 1), u);
+    return (lerp(x1, x2, v) + 1) / 2;
+  }
+
+  fractal2(x, y, { octaves = 4, persistence = 0.5, lacunarity = 2, scale = 1 } = {}){
+    let amplitude = 1;
+    let frequency = 1;
+    let sum = 0;
+    let maxValue = 0;
+    for (let o = 0; o < octaves; o += 1){
+      sum += this.perlin2(x * frequency * scale, y * frequency * scale) * amplitude;
+      maxValue += amplitude;
+      amplitude *= persistence;
+      frequency *= lacunarity;
+    }
+    if (maxValue === 0) return 0;
+    return sum / maxValue;
+  }
+}

--- a/viewer/sandbox/PlaneController.js
+++ b/viewer/sandbox/PlaneController.js
@@ -1,0 +1,204 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+
+const FORWARD_AXIS = new THREE.Vector3(0, 1, 0);
+const TMP_VECTOR = new THREE.Vector3();
+const TMP_EULER = new THREE.Euler(0, 0, 0, 'ZXY');
+
+export class PlaneController {
+  constructor({ position = new THREE.Vector3(), yaw = 0, pitch = 0, roll = 0 } = {}){
+    this.position = position.clone();
+    this.yaw = yaw;
+    this.pitch = pitch;
+    this.roll = roll;
+    this.orientation = new THREE.Quaternion();
+    this.velocity = new THREE.Vector3();
+    this.speed = 0;
+    this.throttle = 0.5;
+    this.targetThrottle = 0.5;
+    this.minSpeed = 30;
+    this.maxSpeed = 150;
+    this.maxBoostSpeed = 220;
+    this.acceleration = 45;
+    this.throttleResponse = 1.8;
+    this.turnRates = {
+      yaw: THREE.MathUtils.degToRad(85),
+      pitch: THREE.MathUtils.degToRad(110),
+      roll: THREE.MathUtils.degToRad(160),
+    };
+    this.rollStability = 0.45;
+    this.bankTurnFactor = THREE.MathUtils.degToRad(40);
+    this.drag = 0.12;
+    this.brakeDrag = 0.45;
+    this.gravity = 9.8 * 0.6;
+    this.altitude = 0;
+    this._updateOrientation();
+  }
+
+  attachMesh(mesh){
+    this.mesh = mesh;
+    if (mesh){
+      mesh.position.copy(this.position);
+      mesh.quaternion.copy(this.orientation);
+    }
+  }
+
+  reset({ position, yaw = 0, pitch = 0, roll = 0, throttle = 0.35 } = {}){
+    if (position){
+      this.position.copy(position);
+    }
+    this.velocity.set(0, 0, 0);
+    this.speed = this.minSpeed * 0.7;
+    this.throttle = throttle;
+    this.targetThrottle = throttle;
+    this.yaw = yaw;
+    this.pitch = pitch;
+    this.roll = roll;
+    this._updateOrientation();
+    if (this.mesh){
+      this.mesh.position.copy(this.position);
+      this.mesh.quaternion.copy(this.orientation);
+    }
+  }
+
+  update(dt, input, { clampAltitude, sampleGroundHeight }){
+    if (dt <= 0) return;
+    if (!input) input = { pitch: 0, yaw: 0, roll: 0, throttleAdjust: 0, brake: false };
+
+    this.targetThrottle = THREE.MathUtils.clamp(
+      this.targetThrottle + input.throttleAdjust * dt * 0.8,
+      0,
+      1,
+    );
+    if (input.brake){
+      this.targetThrottle = Math.min(this.targetThrottle, 0.2);
+    }
+    const throttleBlend = 1 - Math.exp(-this.throttleResponse * dt);
+    this.throttle += (this.targetThrottle - this.throttle) * throttleBlend;
+    this.throttle = THREE.MathUtils.clamp(this.throttle, 0, 1);
+
+    const brakeApplied = input.brake ? this.brakeDrag : this.drag;
+    const maxSpeed = this.minSpeed + (this.maxSpeed - this.minSpeed) * this.throttle;
+    const boostSpeed = this.minSpeed + (this.maxBoostSpeed - this.minSpeed) * this.throttle;
+
+    const speedTarget = THREE.MathUtils.lerp(maxSpeed, boostSpeed, Math.max(0, this.throttle - 0.85) * 4);
+    const speedBlend = 1 - Math.exp(-this.acceleration * dt / Math.max(1, speedTarget));
+    this.speed += (speedTarget - this.speed) * speedBlend;
+
+    this.speed = Math.max(this.minSpeed * 0.3, this.speed);
+
+    const yawInput = THREE.MathUtils.clamp(input.yaw, -1, 1);
+    const pitchInput = THREE.MathUtils.clamp(input.pitch, -1, 1);
+    const rollInput = THREE.MathUtils.clamp(input.roll, -1, 1);
+
+    this.yaw += yawInput * this.turnRates.yaw * dt;
+    this.pitch += pitchInput * this.turnRates.pitch * dt;
+    this.pitch = THREE.MathUtils.clamp(this.pitch, THREE.MathUtils.degToRad(-70), THREE.MathUtils.degToRad(70));
+
+    this.roll += rollInput * this.turnRates.roll * dt;
+    this.roll -= this.roll * this.rollStability * dt;
+    this.roll = THREE.MathUtils.clamp(this.roll, THREE.MathUtils.degToRad(-110), THREE.MathUtils.degToRad(110));
+
+    const bankTurn = this.roll * this.bankTurnFactor * Math.min(1, this.speed / this.maxSpeed);
+    this.yaw += bankTurn * dt;
+
+    this._updateOrientation();
+
+    const forward = TMP_VECTOR.copy(FORWARD_AXIS).applyQuaternion(this.orientation).normalize();
+    const desiredVelocity = forward.multiplyScalar(this.speed);
+    this.velocity.lerp(desiredVelocity, 1 - Math.exp(-3.5 * dt));
+
+    const gravityVector = TMP_VECTOR.set(0, 0, -this.gravity * dt);
+    this.velocity.add(gravityVector);
+    this.velocity.multiplyScalar(Math.max(0, 1 - brakeApplied * dt));
+
+    this.position.addScaledVector(this.velocity, dt);
+
+    if (typeof sampleGroundHeight === 'function'){
+      const ground = sampleGroundHeight(this.position.x, this.position.y);
+      this.altitude = this.position.z - ground;
+      if (typeof clampAltitude === 'function'){
+        clampAltitude(this, ground);
+      }
+    }
+
+    if (this.mesh){
+      this.mesh.position.copy(this.position);
+      this.mesh.quaternion.copy(this.orientation);
+    }
+  }
+
+  getState(){
+    return {
+      position: this.position,
+      velocity: this.velocity,
+      orientation: this.orientation,
+      speed: this.velocity.length(),
+      throttle: this.throttle,
+      altitude: this.altitude,
+    };
+  }
+
+  _updateOrientation(){
+    TMP_EULER.set(this.pitch, this.roll, this.yaw, 'ZXY');
+    this.orientation.setFromEuler(TMP_EULER);
+  }
+}
+
+export function createPlaneMesh(){
+  const group = new THREE.Group();
+
+  const fuselageMaterial = new THREE.MeshStandardMaterial({ color: 0xf0f3ff, metalness: 0.35, roughness: 0.45 });
+  const noseMaterial = new THREE.MeshStandardMaterial({ color: 0xd13b4a, metalness: 0.4, roughness: 0.3 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: 0x2a4f9b, metalness: 0.45, roughness: 0.32 });
+
+  const fuselageGeometry = new THREE.CapsuleGeometry(2.2, 12, 8, 16);
+  const fuselage = new THREE.Mesh(fuselageGeometry, fuselageMaterial);
+  fuselage.rotation.z = Math.PI / 2;
+  fuselage.castShadow = true;
+  fuselage.receiveShadow = true;
+  group.add(fuselage);
+
+  const noseGeometry = new THREE.ConeGeometry(2.2, 4.5, 14);
+  const nose = new THREE.Mesh(noseGeometry, noseMaterial);
+  nose.position.set(0, 9.3, 0);
+  nose.rotation.x = Math.PI;
+  nose.castShadow = true;
+  group.add(nose);
+
+  const tailGeometry = new THREE.ConeGeometry(1.4, 3.5, 10);
+  const tail = new THREE.Mesh(tailGeometry, accentMaterial);
+  tail.position.set(0, -7.8, 0);
+  tail.castShadow = true;
+  group.add(tail);
+
+  const wingGeometry = new THREE.BoxGeometry(18, 3, 0.6);
+  const wing = new THREE.Mesh(wingGeometry, accentMaterial);
+  wing.position.set(0, 0.8, 0);
+  wing.castShadow = true;
+  wing.receiveShadow = true;
+  group.add(wing);
+
+  const tailWingGeometry = new THREE.BoxGeometry(8, 2.2, 0.45);
+  const tailWing = new THREE.Mesh(tailWingGeometry, accentMaterial);
+  tailWing.position.set(0, -6.5, 0.2);
+  tailWing.castShadow = true;
+  tailWing.receiveShadow = true;
+  group.add(tailWing);
+
+  const rudderGeometry = new THREE.BoxGeometry(0.6, 2.4, 4.2);
+  const rudder = new THREE.Mesh(rudderGeometry, accentMaterial);
+  rudder.position.set(0, -7.2, 2.1);
+  rudder.castShadow = true;
+  group.add(rudder);
+
+  group.traverse((obj) => {
+    if (obj.isMesh){
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+    }
+  });
+
+  group.name = 'ArcadePlane';
+
+  return group;
+}

--- a/viewer/sandbox/WorldStreamer.js
+++ b/viewer/sandbox/WorldStreamer.js
@@ -1,0 +1,265 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+import { NoiseGenerator } from './Noise.js';
+
+
+function chunkKey(x, y){
+  return `${x}:${y}`;
+}
+
+function createRng(seed){
+  let state = seed >>> 0;
+  return function(){
+    state |= 0;
+    state = (state + 0x6D2B79F5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export class WorldStreamer {
+  constructor({ scene, chunkSize = 600, radius = 2, seed = 1337 } = {}){
+    this.scene = scene;
+    this.chunkSize = chunkSize;
+    this.radius = radius;
+    this.seed = seed;
+    this.noise = new NoiseGenerator(seed);
+    this.worldGroup = new THREE.Group();
+    this.worldGroup.name = 'EndlessTerrain';
+    this.originOffset = new THREE.Vector3();
+    this.chunkMap = new Map();
+    this.disposables = [];
+    this.scene?.add(this.worldGroup);
+  }
+
+  update(focusPosition){
+    if (!focusPosition) return;
+    const globalX = focusPosition.x + this.originOffset.x;
+    const globalY = focusPosition.y + this.originOffset.y;
+    const centerChunkX = Math.floor(globalX / this.chunkSize);
+    const centerChunkY = Math.floor(globalY / this.chunkSize);
+    const needed = new Set();
+
+    for (let dx = -this.radius; dx <= this.radius; dx += 1){
+      for (let dy = -this.radius; dy <= this.radius; dy += 1){
+        const chunkX = centerChunkX + dx;
+        const chunkY = centerChunkY + dy;
+        const key = chunkKey(chunkX, chunkY);
+        needed.add(key);
+        let chunk = this.chunkMap.get(key);
+        if (!chunk){
+          chunk = this._spawnChunk(chunkX, chunkY);
+          this.chunkMap.set(key, chunk);
+          this.worldGroup.add(chunk.group);
+        }
+        this._positionChunk(chunk);
+      }
+    }
+
+    this.chunkMap.forEach((chunk, key) => {
+      if (!needed.has(key)){
+        this._disposeChunk(chunk);
+        this.chunkMap.delete(key);
+      }
+    });
+  }
+
+  handleOriginShift(shift){
+    if (!shift) return;
+    this.originOffset.add(shift);
+    this.chunkMap.forEach((chunk) => {
+      if (chunk?.group){
+        chunk.group.position.sub(shift);
+      }
+    });
+  }
+
+  getHeightAt(x, y){
+    const worldX = x + this.originOffset.x;
+    const worldY = y + this.originOffset.y;
+    return this._sampleHeight(worldX, worldY);
+  }
+
+  getOriginOffset(){
+    return this.originOffset.clone();
+  }
+
+  getObstaclesNear(x, y, radius = this.chunkSize){
+    const globalX = x + this.originOffset.x;
+    const globalY = y + this.originOffset.y;
+    const chunkX = Math.floor(globalX / this.chunkSize);
+    const chunkY = Math.floor(globalY / this.chunkSize);
+    const results = [];
+    for (let dx = -1; dx <= 1; dx += 1){
+      for (let dy = -1; dy <= 1; dy += 1){
+        const chunk = this.chunkMap.get(chunkKey(chunkX + dx, chunkY + dy));
+        if (chunk?.obstacles){
+          chunk.obstacles.forEach((obstacle) => {
+            const dxWorld = obstacle.worldPosition.x - globalX;
+            const dyWorld = obstacle.worldPosition.y - globalY;
+            const horizontalSq = dxWorld * dxWorld + dyWorld * dyWorld;
+            if (horizontalSq <= (radius + obstacle.radius) * (radius + obstacle.radius)){
+              results.push(obstacle);
+            }
+          });
+        }
+      }
+    }
+    return results;
+  }
+
+  dispose(){
+    this.chunkMap.forEach((chunk) => this._disposeChunk(chunk));
+    this.chunkMap.clear();
+    if (this.scene){
+      this.scene.remove(this.worldGroup);
+    }
+    this.disposables.forEach((item) => item.dispose?.());
+    this.disposables = [];
+  }
+
+  _positionChunk(chunk){
+    const worldX = chunk.coords.x * this.chunkSize;
+    const worldY = chunk.coords.y * this.chunkSize;
+    chunk.group.position.set(worldX - this.originOffset.x, worldY - this.originOffset.y, -this.originOffset.z);
+  }
+
+  _spawnChunk(chunkX, chunkY){
+    const coords = { x: chunkX, y: chunkY };
+    const group = new THREE.Group();
+    group.name = `TerrainChunk_${chunkX}_${chunkY}`;
+    const rng = createRng((chunkX * 928371 + chunkY * 123123 + this.seed) >>> 0);
+
+    const terrain = this._createTerrainMesh(chunkX, chunkY);
+    group.add(terrain.mesh);
+
+    const obstacles = this._scatterObstacles({ chunkX, chunkY, rng, group });
+
+    return { coords, group, obstacles, terrain };
+  }
+
+  _disposeChunk(chunk){
+    if (!chunk) return;
+    if (chunk.group){
+      this.worldGroup.remove(chunk.group);
+      chunk.group.traverse((child) => {
+        if (child.isMesh){
+          child.geometry?.dispose?.();
+          child.material?.dispose?.();
+        }
+      });
+    }
+  }
+
+  _createTerrainMesh(chunkX, chunkY){
+    const resolution = 64;
+    const geometry = new THREE.PlaneGeometry(this.chunkSize, this.chunkSize, resolution, resolution);
+    const colors = new Float32Array(geometry.attributes.position.count * 3);
+    const positions = geometry.attributes.position;
+    const chunkOriginX = chunkX * this.chunkSize;
+    const chunkOriginY = chunkY * this.chunkSize;
+
+    for (let i = 0; i < positions.count; i += 1){
+      const localX = positions.getX(i);
+      const localY = positions.getY(i);
+      const worldX = chunkOriginX + localX;
+      const worldY = chunkOriginY + localY;
+      const height = this._sampleHeight(worldX, worldY);
+      positions.setZ(i, height);
+
+      const colorIndex = i * 3;
+      const color = this._sampleColor(height);
+      colors[colorIndex] = color.r;
+      colors[colorIndex + 1] = color.g;
+      colors[colorIndex + 2] = color.b;
+    }
+
+    geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    geometry.computeVertexNormals();
+
+    const material = new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      roughness: 0.92,
+      metalness: 0.05,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.receiveShadow = true;
+    mesh.castShadow = false;
+
+    return { mesh, geometry, material };
+  }
+
+  _scatterObstacles({ chunkX, chunkY, rng, group }){
+    const count = Math.floor(rng() * 4);
+    const obstacles = [];
+    for (let i = 0; i < count; i += 1){
+      const localX = (rng() - 0.5) * this.chunkSize * 0.8;
+      const localY = (rng() - 0.5) * this.chunkSize * 0.8;
+      const worldX = chunkX * this.chunkSize + localX;
+      const worldY = chunkY * this.chunkSize + localY;
+      const baseHeight = this._sampleHeight(worldX, worldY);
+      const steepness = this._slopeMagnitude(worldX, worldY);
+      if (steepness < 0.08) continue;
+      const peakHeight = baseHeight + 40 + rng() * 80;
+      const radius = 10 + rng() * 20;
+
+      const geometry = new THREE.ConeGeometry(radius, peakHeight - baseHeight, 8);
+      const material = new THREE.MeshStandardMaterial({ color: 0x9d9385, roughness: 0.7, metalness: 0.15 });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.set(localX, localY, baseHeight + (peakHeight - baseHeight) / 2);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      group.add(mesh);
+
+      obstacles.push({
+        mesh,
+        radius: radius * 0.9,
+        worldPosition: new THREE.Vector3(worldX, worldY, peakHeight / 2 + baseHeight / 2),
+        topHeight: peakHeight,
+        baseHeight,
+      });
+    }
+    return obstacles;
+  }
+
+  _sampleHeight(worldX, worldY){
+    const hills = this.noise.fractal2(worldX * 0.0012, worldY * 0.0012, { octaves: 4, persistence: 0.55, lacunarity: 2.1 });
+    const mountains = this.noise.fractal2(worldX * 0.00045 + 40, worldY * 0.00045 - 60, { octaves: 5, persistence: 0.52, lacunarity: 2.05 });
+    const ridges = Math.pow(Math.abs(this.noise.perlin2(worldX * 0.0025, worldY * 0.0025) * 2 - 1), 1.6);
+    let height = hills * 55 + Math.pow(mountains, 3.2) * 340 + ridges * 20;
+
+    const distance = Math.sqrt(worldX * worldX + worldY * worldY);
+    const flatRadius = 160;
+    const blendRadius = 340;
+    if (distance < blendRadius){
+      const t = THREE.MathUtils.clamp((distance - flatRadius) / Math.max(1, blendRadius - flatRadius), 0, 1);
+      height = THREE.MathUtils.lerp(8, height, t);
+    }
+
+    return height;
+  }
+
+  _slopeMagnitude(worldX, worldY){
+    const delta = 2;
+    const center = this._sampleHeight(worldX, worldY);
+    const dx = this._sampleHeight(worldX + delta, worldY) - center;
+    const dy = this._sampleHeight(worldX, worldY + delta) - center;
+    return Math.sqrt(dx * dx + dy * dy) / delta;
+  }
+
+  _sampleColor(height){
+    const low = new THREE.Color(0x2f5b2f);
+    const mid = new THREE.Color(0x4e7741);
+    const high = new THREE.Color(0xc2c5c7);
+    if (height < 30){
+      return low.clone();
+    }
+    if (height < 140){
+      const t = THREE.MathUtils.clamp((height - 30) / 110, 0, 1);
+      return low.clone().lerp(mid, t);
+    }
+    const t = THREE.MathUtils.clamp((height - 140) / 160, 0, 1);
+    return mid.clone().lerp(high, t);
+  }
+}

--- a/viewer/sandbox/index.html
+++ b/viewer/sandbox/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>DriftPursuit Sandbox Flight</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #90b6ff;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/viewer/sandbox/main.js
+++ b/viewer/sandbox/main.js
@@ -1,0 +1,149 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+import { InputManager, describeControls } from './InputManager.js';
+import { PlaneController, createPlaneMesh } from './PlaneController.js';
+import { ChaseCamera } from './ChaseCamera.js';
+import { WorldStreamer } from './WorldStreamer.js';
+import { CollisionSystem } from './CollisionSystem.js';
+import { HUD } from './HUD.js';
+
+const SKY_CEILING = 1800;
+const ORIGIN_REBASE_DISTANCE = 1400;
+const ORIGIN_REBASE_DISTANCE_SQ = ORIGIN_REBASE_DISTANCE * ORIGIN_REBASE_DISTANCE;
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(window.devicePixelRatio || 1);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+document.body.style.margin = '0';
+document.body.style.overflow = 'hidden';
+document.body.appendChild(renderer.domElement);
+
+document.body.style.background = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x90b6ff);
+scene.fog = new THREE.Fog(0xa4c6ff, 1200, 2800);
+
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 20000);
+
+const hemisphere = new THREE.HemisphereLight(0xdce9ff, 0x2b4a2e, 0.85);
+scene.add(hemisphere);
+
+const sun = new THREE.DirectionalLight(0xffffff, 1.05);
+sun.position.set(-420, 580, 780);
+sun.castShadow = true;
+sun.shadow.mapSize.set(2048, 2048);
+sun.shadow.camera.left = -800;
+sun.shadow.camera.right = 800;
+sun.shadow.camera.top = 800;
+sun.shadow.camera.bottom = -800;
+sun.shadow.camera.far = 2200;
+scene.add(sun);
+
+const world = new WorldStreamer({ scene, chunkSize: 640, radius: 2, seed: 982451653 });
+
+const planeMesh = createPlaneMesh();
+scene.add(planeMesh);
+
+const planeController = new PlaneController();
+planeController.attachMesh(planeMesh);
+
+const input = new InputManager();
+const chaseCamera = new ChaseCamera(camera, { distance: 70, height: 26, stiffness: 3.6, lookAhead: 18 });
+const hud = new HUD({ controls: describeControls() });
+const collisionSystem = new CollisionSystem({ world, crashMargin: 2.2, obstaclePadding: 3 });
+
+const startAnchor = new THREE.Vector3(0, -320, 0);
+let crashCount = 0;
+let crashCooldown = 0;
+
+function computeStartPosition(){
+  const spawn = startAnchor.clone();
+  const ground = world.getHeightAt(spawn.x, spawn.y);
+  spawn.z = ground + 52;
+  return spawn;
+}
+
+function resetPlane(){
+  const spawn = computeStartPosition();
+  planeController.reset({ position: spawn, yaw: 0, pitch: THREE.MathUtils.degToRad(2), throttle: 0.42 });
+  chaseCamera.currentPosition.copy(spawn.clone().add(new THREE.Vector3(-40, -60, 30)));
+  camera.position.copy(chaseCamera.currentPosition);
+  crashCooldown = 0.8;
+  world.update(planeController.position);
+  chaseCamera.update(planeController.getState(), 0.016);
+}
+
+resetPlane();
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+function clampAltitude(controller, ground){
+  if (controller.position.z > SKY_CEILING){
+    controller.position.z = SKY_CEILING;
+    if (controller.velocity.z > 0) controller.velocity.z = 0;
+  }
+}
+
+let lastTime = performance.now();
+
+function animate(now){
+  requestAnimationFrame(animate);
+  const dt = Math.min(0.08, (now - lastTime) / 1000 || 0);
+  lastTime = now;
+
+  const inputState = crashCooldown > 0 ? { pitch: 0, yaw: 0, roll: 0, throttleAdjust: 0, brake: false } : input.readState();
+  planeController.update(dt, inputState, {
+    sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
+    clampAltitude,
+  });
+
+  const planeState = planeController.getState();
+
+  if (crashCooldown > 0){
+    crashCooldown = Math.max(0, crashCooldown - dt);
+  }
+
+  if (crashCooldown <= 0){
+    const collision = collisionSystem.evaluate(planeState);
+    if (collision.crashed){
+      crashCount += 1;
+      hud.showMessage('Crashed! Restarting…');
+      resetPlane();
+    }
+  }
+
+  rebaseWorldIfNeeded();
+
+  world.update(planeState.position);
+  chaseCamera.update(planeState, dt);
+
+  hud.update({
+    throttle: planeState.throttle,
+    speed: planeState.speed,
+    altitude: planeState.altitude ?? 0,
+    crashCount,
+  });
+
+  renderer.render(scene, camera);
+}
+
+function rebaseWorldIfNeeded(){
+  const pos = planeController.position;
+  const distanceSq = pos.x * pos.x + pos.y * pos.y;
+  if (distanceSq > ORIGIN_REBASE_DISTANCE_SQ){
+    const shift = new THREE.Vector3(pos.x, pos.y, 0);
+    planeController.position.sub(shift);
+    planeMesh.position.copy(planeController.position);
+    chaseCamera.currentPosition.sub(shift);
+    camera.position.sub(shift);
+    world.handleOriginShift(shift);
+  }
+}
+
+requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- add a standalone three.js sandbox at `viewer/sandbox/` with arcade plane physics, chase camera, and HUD
- stream procedural terrain tiles with rolling hills, tall ridges, and obstacle meshes while rebasing the origin for endless flight
- implement collision handling that resets the plane on ground or obstacle impact and update the README with launch and control instructions

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9e915954483298cee969ffc28609c