### PR TITLE
Integrate sandbox world streamer into main viewer

### DIFF
--- a/viewer/sandbox/ChaseCamera.js
+++ b/viewer/sandbox/ChaseCamera.js
@@ -1,4 +1,5 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox ChaseCamera requires THREE to be loaded globally');
 
 const TMP_FORWARD = new THREE.Vector3();
 const TMP_UP = new THREE.Vector3(0, 0, 1);

--- a/viewer/sandbox/CollisionSystem.js
+++ b/viewer/sandbox/CollisionSystem.js
@@ -1,4 +1,5 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox CollisionSystem requires THREE to be loaded globally');
 
 const TMP_VECTOR = new THREE.Vector3();
 

--- a/viewer/sandbox/PlaneController.js
+++ b/viewer/sandbox/PlaneController.js
@@ -1,4 +1,5 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox PlaneController requires THREE to be loaded globally');
 
 const FORWARD_AXIS = new THREE.Vector3(0, 1, 0);
 const TMP_VECTOR = new THREE.Vector3();

--- a/viewer/sandbox/WorldStreamer.js
+++ b/viewer/sandbox/WorldStreamer.js
@@ -1,5 +1,7 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
 import { NoiseGenerator } from './Noise.js';
+
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox WorldStreamer requires THREE to be loaded globally');
 
 
 function chunkKey(x, y){

--- a/viewer/sandbox/index.html
+++ b/viewer/sandbox/index.html
@@ -14,6 +14,7 @@
     </style>
   </head>
   <body>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/viewer/sandbox/main.js
+++ b/viewer/sandbox/main.js
@@ -1,10 +1,12 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
 import { InputManager, describeControls } from './InputManager.js';
 import { PlaneController, createPlaneMesh } from './PlaneController.js';
 import { ChaseCamera } from './ChaseCamera.js';
 import { WorldStreamer } from './WorldStreamer.js';
 import { CollisionSystem } from './CollisionSystem.js';
 import { HUD } from './HUD.js';
+
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox viewer requires THREE to be loaded globally');
 
 const SKY_CEILING = 1800;
 const ORIGIN_REBASE_DISTANCE = 1400;

--- a/viewer/world/SandboxWorldAdapter.js
+++ b/viewer/world/SandboxWorldAdapter.js
@@ -1,0 +1,50 @@
+import { WorldStreamer } from '../sandbox/WorldStreamer.js';
+
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox world adapter requires THREE to be loaded globally');
+
+export function createSandboxWorld({ scene, descriptor } = {}){
+  if (!scene){
+    throw new Error('createSandboxWorld requires a scene reference');
+  }
+
+  const chunkSize = Number(descriptor?.chunkSize) || Number(descriptor?.tileSize) || 640;
+  const radius = Math.max(1, Math.round(Number(descriptor?.visibleRadius ?? 2)));
+  let seed = descriptor?.seed ?? 982451653;
+  if (typeof seed === 'string'){
+    seed = hashStringToInt(seed);
+  }
+  if (!Number.isFinite(seed)){
+    seed = 982451653;
+  }
+
+  const streamer = new WorldStreamer({ scene, chunkSize, radius, seed });
+
+  return {
+    update(focusPosition){
+      if (!focusPosition) return;
+      streamer.update(focusPosition);
+    },
+    handleOriginShift(shift){
+      streamer.handleOriginShift(shift);
+    },
+    dispose(){
+      streamer.dispose();
+    },
+    getHeightAt(x, y){
+      return streamer.getHeightAt(x, y);
+    },
+    getObstaclesNear(x, y, queryRadius){
+      return streamer.getObstaclesNear(x, y, queryRadius);
+    },
+  };
+}
+
+function hashStringToInt(value){
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1){
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}


### PR DESCRIPTION
## Summary
- reuse the sandbox terrain streamer in the main viewer by defaulting the procedural map to the sandbox generator
- expose sandbox world integration via a new adapter while propagating manifest metadata for generator selection
- align sandbox scripts with the main viewer by loading three.js globally and sharing the helper modules

## Testing
- not run (UI integration)


------
https://chatgpt.com/codex/tasks/task_e_68da008a2c648329a5eb502870192fd1