### PR TITLE
Enhance sandbox world streaming features

### DIFF
--- a/viewer/sandbox/WorldStreamer.js
+++ b/viewer/sandbox/WorldStreamer.js
@@ -20,7 +20,7 @@ function createRng(seed){
 }
 
 export class WorldStreamer {
-  constructor({ scene, chunkSize = 600, radius = 2, seed = 1337 } = {}){
+  constructor({ scene, chunkSize = 600, radius = 3, seed = 1337 } = {}){
     this.scene = scene;
     this.chunkSize = chunkSize;
     this.radius = radius;
@@ -31,6 +31,9 @@ export class WorldStreamer {
     this.originOffset = new THREE.Vector3();
     this.chunkMap = new Map();
     this.disposables = [];
+    this.materials = this._createSharedMaterials();
+    this.sharedMaterials = new Set(Object.values(this.materials));
+    this.disposables.push(...this.sharedMaterials);
     this.scene?.add(this.worldGroup);
   }
 
@@ -135,7 +138,7 @@ export class WorldStreamer {
     const terrain = this._createTerrainMesh(chunkX, chunkY);
     group.add(terrain.mesh);
 
-    const obstacles = this._scatterObstacles({ chunkX, chunkY, rng, group });
+    const { obstacles } = this._scatterTerrainFeatures({ chunkX, chunkY, rng, group });
 
     return { coords, group, obstacles, terrain };
   }
@@ -147,7 +150,7 @@ export class WorldStreamer {
       chunk.group.traverse((child) => {
         if (child.isMesh){
           child.geometry?.dispose?.();
-          child.material?.dispose?.();
+          this._disposeMaterialIfOwned(child.material);
         }
       });
     }
@@ -192,37 +195,230 @@ export class WorldStreamer {
     return { mesh, geometry, material };
   }
 
-  _scatterObstacles({ chunkX, chunkY, rng, group }){
-    const count = Math.floor(rng() * 4);
-    const obstacles = [];
-    for (let i = 0; i < count; i += 1){
-      const localX = (rng() - 0.5) * this.chunkSize * 0.8;
-      const localY = (rng() - 0.5) * this.chunkSize * 0.8;
-      const worldX = chunkX * this.chunkSize + localX;
-      const worldY = chunkY * this.chunkSize + localY;
-      const baseHeight = this._sampleHeight(worldX, worldY);
-      const steepness = this._slopeMagnitude(worldX, worldY);
-      if (steepness < 0.08) continue;
-      const peakHeight = baseHeight + 40 + rng() * 80;
-      const radius = 10 + rng() * 20;
+  _createSharedMaterials(){
+    return {
+      mountain: new THREE.MeshStandardMaterial({ color: 0x8f8375, roughness: 0.85, metalness: 0.08, flatShading: true }),
+      rock: new THREE.MeshStandardMaterial({ color: 0x6b6156, roughness: 0.95, metalness: 0.04, flatShading: true }),
+      building: new THREE.MeshStandardMaterial({ color: 0xb69a7a, roughness: 0.6, metalness: 0.08 }),
+      roof: new THREE.MeshStandardMaterial({ color: 0x7a3529, roughness: 0.4, metalness: 0.12 }),
+      plaza: new THREE.MeshStandardMaterial({ color: 0xd9c9a7, roughness: 0.85, metalness: 0.02 }),
+      water: new THREE.MeshStandardMaterial({ color: 0x3f75d6, emissive: 0x0, roughness: 0.18, metalness: 0.05, transparent: true, opacity: 0.82 })
+    };
+  }
 
-      const geometry = new THREE.ConeGeometry(radius, peakHeight - baseHeight, 8);
-      const material = new THREE.MeshStandardMaterial({ color: 0x9d9385, roughness: 0.7, metalness: 0.15 });
-      const mesh = new THREE.Mesh(geometry, material);
-      mesh.position.set(localX, localY, baseHeight + (peakHeight - baseHeight) / 2);
+  _disposeMaterialIfOwned(material){
+    if (!material) return;
+    if (Array.isArray(material)){
+      material.forEach((mat) => this._disposeMaterialIfOwned(mat));
+      return;
+    }
+    if (this.sharedMaterials?.has(material)) return;
+    material.dispose?.();
+  }
+
+  _scatterTerrainFeatures({ chunkX, chunkY, rng, group }){
+    const obstacles = [];
+
+    this._maybeAddMountain({ chunkX, chunkY, rng, group, obstacles });
+    this._scatterRocks({ chunkX, chunkY, rng, group, obstacles });
+    this._maybeAddTown({ chunkX, chunkY, rng, group, obstacles });
+    this._maybeAddRiver({ chunkX, chunkY, rng, group });
+
+    return { obstacles };
+  }
+
+  _maybeAddMountain({ chunkX, chunkY, rng, group, obstacles }){
+    const centerX = (chunkX + 0.5) * this.chunkSize;
+    const centerY = (chunkY + 0.5) * this.chunkSize;
+    const mountainNoise = this.noise.fractal2(centerX * 0.00032 + 300, centerY * 0.00032 - 220, { octaves: 5, persistence: 0.58, lacunarity: 2.18 });
+    if (mountainNoise < 0.64) return;
+
+    const clusterCount = mountainNoise > 0.78 ? 2 : 1;
+    for (let c = 0; c < clusterCount; c += 1){
+      const location = this._findLocation({ chunkX, chunkY, rng, attempts: 10, minHeight: 120, maxSlope: 0.55 });
+      if (!location) break;
+
+      const baseHeight = location.height;
+      const heightGain = 120 + rng() * 220;
+      const radius = 60 + rng() * 90;
+      const segments = 8 + Math.floor(rng() * 4);
+      const geometry = new THREE.ConeGeometry(radius, heightGain, segments);
+      const mesh = new THREE.Mesh(geometry, this.materials.mountain);
       mesh.castShadow = true;
       mesh.receiveShadow = true;
+      mesh.position.set(location.localX, location.localY, baseHeight + heightGain / 2);
       group.add(mesh);
 
+      const peakHeight = baseHeight + heightGain;
       obstacles.push({
         mesh,
-        radius: radius * 0.9,
-        worldPosition: new THREE.Vector3(worldX, worldY, peakHeight / 2 + baseHeight / 2),
+        radius: radius * 0.95,
+        worldPosition: new THREE.Vector3(location.worldX, location.worldY, peakHeight),
         topHeight: peakHeight,
         baseHeight,
       });
     }
-    return obstacles;
+  }
+
+  _scatterRocks({ chunkX, chunkY, rng, group, obstacles }){
+    const centerX = (chunkX + 0.5) * this.chunkSize;
+    const centerY = (chunkY + 0.5) * this.chunkSize;
+    const rockDensity = this.noise.perlin2(centerX * 0.0014 + 1200, centerY * 0.0014 - 860);
+    const count = Math.floor(2 + rockDensity * 6);
+    for (let i = 0; i < count; i += 1){
+      const location = this._findLocation({ chunkX, chunkY, rng, attempts: 6, maxSlope: 0.45 });
+      if (!location) break;
+      const size = 6 + rng() * 18;
+      const detail = rng() > 0.55 ? 1 : 0;
+      const geometry = new THREE.DodecahedronGeometry(size, detail);
+      const mesh = new THREE.Mesh(geometry, this.materials.rock);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      mesh.position.set(location.localX, location.localY, location.height + size * 0.45);
+      group.add(mesh);
+
+      obstacles.push({
+        mesh,
+        radius: size * 0.8,
+        worldPosition: new THREE.Vector3(location.worldX, location.worldY, location.height + size),
+        topHeight: location.height + size * 1.2,
+        baseHeight: location.height,
+      });
+    }
+  }
+
+  _maybeAddTown({ chunkX, chunkY, rng, group, obstacles }){
+    const centerX = (chunkX + 0.5) * this.chunkSize;
+    const centerY = (chunkY + 0.5) * this.chunkSize;
+    const settlementNoise = this.noise.fractal2(centerX * 0.00022 + 1480, centerY * 0.00022 - 930, { octaves: 4, persistence: 0.6, lacunarity: 2.3 });
+    if (settlementNoise < 0.66) return;
+
+    const anchor = this._findLocation({ chunkX, chunkY, rng, attempts: 12, maxSlope: 0.18, maxHeight: 180 });
+    if (!anchor) return;
+
+    const townGroup = new THREE.Group();
+    townGroup.name = `Town_${chunkX}_${chunkY}`;
+    group.add(townGroup);
+
+    const plazaRadius = 16 + rng() * 10;
+    const plazaGeometry = new THREE.CircleGeometry(plazaRadius, 24);
+    const plaza = new THREE.Mesh(plazaGeometry, this.materials.plaza);
+    plaza.position.set(anchor.localX, anchor.localY, anchor.height + 0.4);
+    plaza.receiveShadow = true;
+    townGroup.add(plaza);
+
+    const buildingCount = 4 + Math.floor(rng() * 5);
+    for (let i = 0; i < buildingCount; i += 1){
+      const angle = rng() * Math.PI * 2;
+      const distance = plazaRadius + 8 + rng() * 35;
+      const worldX = anchor.worldX + Math.cos(angle) * distance;
+      const worldY = anchor.worldY + Math.sin(angle) * distance;
+      const slope = this._slopeMagnitude(worldX, worldY);
+      if (slope > 0.24) continue;
+      const height = this._sampleHeight(worldX, worldY);
+      const width = 12 + rng() * 14;
+      const depth = 10 + rng() * 18;
+      const wallHeight = 12 + rng() * 10;
+      const roofHeight = wallHeight * 0.6;
+
+      const base = new THREE.Mesh(new THREE.BoxGeometry(width, depth, wallHeight), this.materials.building);
+      const localX = worldX - chunkX * this.chunkSize;
+      const localY = worldY - chunkY * this.chunkSize;
+      base.position.set(localX, localY, height + wallHeight / 2);
+      base.castShadow = true;
+      base.receiveShadow = true;
+      townGroup.add(base);
+
+      const roofRadius = Math.max(width, depth) * 0.75;
+      const roof = new THREE.Mesh(new THREE.ConeGeometry(roofRadius, roofHeight, 4), this.materials.roof);
+      roof.position.set(localX, localY, height + wallHeight + roofHeight / 2);
+      roof.rotation.y = Math.PI / 4;
+      roof.castShadow = true;
+      roof.receiveShadow = true;
+      townGroup.add(roof);
+
+      obstacles.push({
+        mesh: base,
+        radius: Math.max(width, depth) * 0.6,
+        worldPosition: new THREE.Vector3(worldX, worldY, height + wallHeight),
+        topHeight: height + wallHeight + roofHeight,
+        baseHeight: height,
+      });
+    }
+  }
+
+  _maybeAddRiver({ chunkX, chunkY, rng, group }){
+    const centerX = (chunkX + 0.5) * this.chunkSize;
+    const centerY = (chunkY + 0.5) * this.chunkSize;
+    const riverNoise = this.noise.perlin2(centerX * 0.00038 - 510, centerY * 0.00038 + 740) - 0.5;
+    const closeness = Math.abs(riverNoise);
+    if (closeness > 0.085) return;
+
+    const angleNoise = this.noise.perlin2(centerX * 0.00062 + 2200, centerY * 0.00062 - 1800);
+    const angle = angleNoise * Math.PI * 2;
+    const dirX = Math.cos(angle);
+    const dirY = Math.sin(angle);
+    const perpX = -dirY;
+    const perpY = dirX;
+    const length = this.chunkSize * 1.5;
+    const width = THREE.MathUtils.lerp(26, 58, 1 - THREE.MathUtils.clamp(closeness / 0.085, 0, 1));
+    const halfWidth = width / 2;
+    const segments = 18;
+
+    const positions = new Float32Array((segments + 1) * 2 * 3);
+    const indices = [];
+
+    for (let i = 0; i <= segments; i += 1){
+      const t = (i / segments - 0.5) * length;
+      const meander = (this.noise.perlin2(centerX * 0.0012 + t * 0.002, centerY * 0.0012 - t * 0.002) - 0.5) * width * 0.6;
+      const centerWorldX = centerX + dirX * t + perpX * meander;
+      const centerWorldY = centerY + dirY * t + perpY * meander;
+      for (let side = 0; side < 2; side += 1){
+        const sign = side === 0 ? -1 : 1;
+        const worldX = centerWorldX + perpX * sign * halfWidth;
+        const worldY = centerWorldY + perpY * sign * halfWidth;
+        const height = this._sampleHeight(worldX, worldY) - 2.8;
+        const localX = worldX - chunkX * this.chunkSize;
+        const localY = worldY - chunkY * this.chunkSize;
+        const index = (i * 2 + side) * 3;
+        positions[index] = localX;
+        positions[index + 1] = localY;
+        positions[index + 2] = height;
+      }
+    }
+
+    for (let i = 0; i < segments; i += 1){
+      const a = i * 2;
+      const b = a + 1;
+      const c = a + 2;
+      const d = a + 3;
+      indices.push(a, b, d, a, d, c);
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setIndex(indices);
+    geometry.computeVertexNormals();
+
+    const mesh = new THREE.Mesh(geometry, this.materials.water);
+    mesh.receiveShadow = false;
+    mesh.castShadow = false;
+    group.add(mesh);
+  }
+
+  _findLocation({ chunkX, chunkY, rng, attempts = 8, minHeight = -Infinity, maxHeight = Infinity, maxSlope = 0.5 }){
+    for (let attempt = 0; attempt < attempts; attempt += 1){
+      const localX = (rng() - 0.5) * this.chunkSize * 0.9;
+      const localY = (rng() - 0.5) * this.chunkSize * 0.9;
+      const worldX = chunkX * this.chunkSize + localX;
+      const worldY = chunkY * this.chunkSize + localY;
+      const height = this._sampleHeight(worldX, worldY);
+      if (height < minHeight || height > maxHeight) continue;
+      const slope = this._slopeMagnitude(worldX, worldY);
+      if (slope > maxSlope) continue;
+      return { localX, localY, worldX, worldY, height, slope };
+    }
+    return null;
   }
 
   _sampleHeight(worldX, worldY){

--- a/viewer/sandbox/main.js
+++ b/viewer/sandbox/main.js
@@ -25,7 +25,7 @@ document.body.style.background = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x90b6ff);
-scene.fog = new THREE.Fog(0xa4c6ff, 1200, 2800);
+scene.fog = new THREE.Fog(0xa4c6ff, 1500, 4200);
 
 const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 20000);
 
@@ -43,7 +43,7 @@ sun.shadow.camera.bottom = -800;
 sun.shadow.camera.far = 2200;
 scene.add(sun);
 
-const world = new WorldStreamer({ scene, chunkSize: 640, radius: 2, seed: 982451653 });
+const world = new WorldStreamer({ scene, chunkSize: 640, radius: 3, seed: 982451653 });
 
 const planeMesh = createPlaneMesh();
 scene.add(planeMesh);


### PR DESCRIPTION
## Summary
- enrich the sandbox world streamer with shared materials and new procedural features such as mountains, towns, rocks, and rivers
- adjust chunk radius defaults and fog distance so the endless terrain remains visible farther into the distance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da074765e88329aceab5e62c9790a6