### PR TITLE
Improve sandbox flight controls and HUD

### DIFF
--- a/viewer/sandbox/ChaseCamera.js
+++ b/viewer/sandbox/ChaseCamera.js
@@ -2,27 +2,60 @@ const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE)
 if (!THREE) throw new Error('Sandbox ChaseCamera requires THREE to be loaded globally');
 
 const TMP_FORWARD = new THREE.Vector3();
+const TMP_FLAT_FORWARD = new THREE.Vector3();
 const TMP_UP = new THREE.Vector3(0, 0, 1);
 const TMP_TARGET = new THREE.Vector3();
+const TMP_LOOK = new THREE.Vector3();
 
 export class ChaseCamera {
-  constructor(camera, { distance = 55, height = 24, stiffness = 4, lookAhead = 14 } = {}){
+  constructor(camera, {
+    distance = 55,
+    height = 24,
+    stiffness = 4,
+    lookStiffness = 6,
+    forwardResponsiveness = 4.5,
+    pitchInfluence = 0.35,
+  } = {}){
     this.camera = camera;
     this.distance = distance;
     this.height = height;
     this.stiffness = stiffness;
-    this.lookAhead = lookAhead;
+    this.lookStiffness = lookStiffness;
+    this.forwardResponsiveness = forwardResponsiveness;
+    this.pitchInfluence = pitchInfluence;
     this.currentPosition = camera.position.clone();
+    this.currentForward = new THREE.Vector3(0, 1, 0);
+    this.currentLookTarget = new THREE.Vector3();
   }
 
   update({ position, orientation, velocity }, dt){
     if (!this.camera || !position || !orientation) return;
-    const forward = TMP_FORWARD.set(0, 1, 0).applyQuaternion(orientation).normalize();
-    const desired = TMP_TARGET.copy(position)
-      .addScaledVector(forward, -this.distance)
-      .addScaledVector(TMP_UP, this.height);
+    const rawForward = TMP_FORWARD.set(0, 1, 0).applyQuaternion(orientation).normalize();
 
-    const lerpFactor = 1 - Math.exp(-this.stiffness * dt);
+    const flatForward = TMP_FLAT_FORWARD.copy(rawForward);
+    flatForward.z = 0;
+    if (flatForward.lengthSq() < 1e-5){
+      flatForward.copy(this.currentForward);
+    } else {
+      flatForward.normalize();
+    }
+
+    const forwardBlend = dt > 0 ? 1 - Math.exp(-this.forwardResponsiveness * dt) : 1;
+    if (Number.isFinite(forwardBlend)){
+      this.currentForward.lerp(flatForward, forwardBlend);
+    } else {
+      this.currentForward.copy(flatForward);
+    }
+    this.currentForward.normalize();
+
+    const pitchFactor = THREE.MathUtils.clamp(rawForward.z, -0.75, 0.75);
+    const heightOffset = this.height + pitchFactor * this.distance * this.pitchInfluence;
+
+    const desired = TMP_TARGET.copy(position)
+      .addScaledVector(this.currentForward, -this.distance)
+      .addScaledVector(TMP_UP, heightOffset);
+
+    const lerpFactor = dt > 0 ? 1 - Math.exp(-this.stiffness * dt) : 1;
     if (Number.isFinite(lerpFactor)){
       this.currentPosition.lerp(desired, lerpFactor);
     } else {
@@ -31,13 +64,19 @@ export class ChaseCamera {
 
     this.camera.position.copy(this.currentPosition);
 
-    const lookTarget = TMP_TARGET.copy(position);
-    if (velocity){
-      const speed = velocity.length();
-      if (speed > 0.1){
-        lookTarget.addScaledVector(forward, this.lookAhead + Math.min(speed * 0.2, 30));
-      }
+    const target = TMP_LOOK.copy(position);
+
+    const lookBlend = dt > 0 ? 1 - Math.exp(-this.lookStiffness * dt) : 1;
+    if (!Number.isFinite(this.currentLookTarget.lengthSq())){
+      this.currentLookTarget.set(0, 0, 0);
     }
-    this.camera.lookAt(lookTarget);
+    if (Number.isFinite(lookBlend)){
+      this.currentLookTarget.lerp(target, lookBlend);
+    } else {
+      this.currentLookTarget.copy(target);
+    }
+
+    this.camera.up.copy(TMP_UP);
+    this.camera.lookAt(this.currentLookTarget);
   }
 }

--- a/viewer/sandbox/HUD.js
+++ b/viewer/sandbox/HUD.js
@@ -1,15 +1,143 @@
-const PANEL_STYLE = `
+const OVERLAY_STYLE = `
   position: absolute;
-  top: 16px;
-  left: 16px;
-  padding: 16px 20px;
-  background: rgba(18, 30, 52, 0.6);
-  color: #e8f1ff;
-  font-family: 'Segoe UI', sans-serif;
-  border-radius: 12px;
-  min-width: 260px;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+  inset: 0;
+  pointer-events: none;
+  font-family: 'Segoe UI', 'Roboto', sans-serif;
+  color: #f0f6ff;
+  text-shadow: 0 0 8px rgba(0, 0, 0, 0.55);
+`;
+
+const CENTER_GROUP_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 280px;
+  height: 280px;
+  transform: translate(-50%, -50%);
+`;
+
+const RETICLE_RING_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 210px;
+  height: 210px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.32);
+  box-shadow: 0 0 36px rgba(0, 0, 0, 0.45) inset, 0 0 24px rgba(60, 150, 255, 0.25);
+  backdrop-filter: blur(6px);
+`;
+
+const RETICLE_CORE_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 46px;
+  height: 46px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 0 20px rgba(80, 180, 255, 0.35);
+`;
+
+const RETICLE_LINE_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 210px;
+  height: 2px;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.7) 50%, rgba(255, 255, 255, 0) 100%);
+`;
+
+const RETICLE_LINE_VERTICAL_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 210px;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.7) 50%, rgba(255, 255, 255, 0) 100%);
+`;
+
+const THROTTLE_RING_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 230px;
+  height: 230px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  filter: drop-shadow(0 0 18px rgba(0, 0, 0, 0.45));
+  mask: radial-gradient(circle at center, transparent 64%, rgba(0, 0, 0, 0.85) 66%, rgba(0, 0, 0, 0.85) 100%);
+  -webkit-mask: radial-gradient(circle at center, transparent 64%, rgba(0, 0, 0, 0.85) 66%, rgba(0, 0, 0, 0.85) 100%);
+`;
+
+const METRIC_STYLE = `
+  position: absolute;
+  padding: 10px 16px;
+  background: rgba(12, 22, 42, 0.6);
+  border-radius: 14px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.38);
+  min-width: 136px;
+  text-align: center;
+`;
+
+const METRIC_TITLE_STYLE = `
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0.72;
+`;
+
+const METRIC_VALUE_STYLE = `
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-top: 4px;
+`;
+
+const THROTTLE_TEXT_STYLE = `
+  position: absolute;
+  top: calc(50% + 72px);
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #9bfffc;
+`;
+
+const CONTROLS_PANEL_STYLE = `
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 22px;
+  border-radius: 14px;
+  background: rgba(10, 20, 36, 0.64);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.42);
   backdrop-filter: blur(10px);
+  font-size: 14px;
+`;
+
+const CONTROLS_TITLE_STYLE = `
+  font-size: 12px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  opacity: 0.68;
+`;
+
+const CONTROLS_ITEM_STYLE = `
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
 `;
 
 const MESSAGE_STYLE = `
@@ -17,101 +145,167 @@ const MESSAGE_STYLE = `
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  padding: 18px 24px;
+  padding: 18px 26px;
   font-size: 24px;
   font-weight: 700;
   color: #fff9f2;
-  background: rgba(210, 60, 60, 0.82);
-  border-radius: 12px;
+  background: rgba(210, 60, 60, 0.85);
+  border-radius: 14px;
   box-shadow: 0 22px 60px rgba(210, 60, 60, 0.45);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 `;
 
-const LIST_STYLE = `
-  list-style: none;
-  padding: 0;
-  margin: 12px 0 0;
-  display: grid;
-  gap: 6px;
-`;
+function createMetric(label){
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('style', METRIC_STYLE);
+
+  const title = document.createElement('div');
+  title.setAttribute('style', METRIC_TITLE_STYLE);
+  title.textContent = label;
+
+  const value = document.createElement('div');
+  value.setAttribute('style', METRIC_VALUE_STYLE);
+  value.textContent = '--';
+
+  wrapper.appendChild(title);
+  wrapper.appendChild(value);
+
+  return { wrapper, value };
+}
+
+function formatTime(seconds){
+  if (!Number.isFinite(seconds) || seconds <= 0) return '00:00';
+  const totalSeconds = Math.floor(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const secs = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+function formatDistance(meters){
+  if (!Number.isFinite(meters) || meters <= 0) return '0 m';
+  if (meters >= 1000){
+    return `${(meters / 1000).toFixed(meters >= 10000 ? 0 : 1)} km`;
+  }
+  return `${meters.toFixed(0)} m`;
+}
 
 export class HUD {
   constructor({ controls = [] } = {}){
-    this.container = document.createElement('div');
-    this.container.id = 'hud-panel';
-    this.container.setAttribute('style', PANEL_STYLE);
+    this.overlay = document.createElement('div');
+    this.overlay.id = 'hud-overlay';
+    this.overlay.setAttribute('style', OVERLAY_STYLE);
+    document.body.appendChild(this.overlay);
 
-    this.status = document.createElement('div');
-    this.status.style.fontSize = '14px';
-    this.status.style.letterSpacing = '0.06em';
-    this.status.style.textTransform = 'uppercase';
-    this.status.style.marginBottom = '10px';
-    this.status.textContent = 'Initializing flight systems…';
+    this.centerGroup = document.createElement('div');
+    this.centerGroup.setAttribute('style', CENTER_GROUP_STYLE);
+    this.overlay.appendChild(this.centerGroup);
 
-    this.metrics = document.createElement('div');
-    this.metrics.style.display = 'grid';
-    this.metrics.style.gap = '4px';
-    this.metrics.style.fontSize = '15px';
-    this.metrics.style.fontWeight = '600';
+    this.throttleRing = document.createElement('div');
+    this.throttleRing.setAttribute('style', THROTTLE_RING_STYLE);
+    this.centerGroup.appendChild(this.throttleRing);
 
-    this.throttleBar = document.createElement('div');
-    this.throttleBar.style.height = '6px';
-    this.throttleBar.style.background = 'rgba(255,255,255,0.2)';
-    this.throttleBar.style.borderRadius = '999px';
-    this.throttleFill = document.createElement('div');
-    this.throttleFill.style.height = '100%';
-    this.throttleFill.style.background = 'linear-gradient(90deg, #51d7ff, #5bff90)';
-    this.throttleFill.style.borderRadius = 'inherit';
-    this.throttleFill.style.width = '0%';
-    this.throttleBar.appendChild(this.throttleFill);
+    this.reticleRing = document.createElement('div');
+    this.reticleRing.setAttribute('style', RETICLE_RING_STYLE);
+    this.centerGroup.appendChild(this.reticleRing);
+
+    const horizontal = document.createElement('div');
+    horizontal.setAttribute('style', RETICLE_LINE_STYLE);
+    const vertical = document.createElement('div');
+    vertical.setAttribute('style', RETICLE_LINE_VERTICAL_STYLE);
+    this.centerGroup.appendChild(horizontal);
+    this.centerGroup.appendChild(vertical);
+
+    this.reticleCore = document.createElement('div');
+    this.reticleCore.setAttribute('style', RETICLE_CORE_STYLE);
+    this.centerGroup.appendChild(this.reticleCore);
+
+    this.throttleText = document.createElement('div');
+    this.throttleText.setAttribute('style', THROTTLE_TEXT_STYLE);
+    this.throttleText.textContent = 'THR 0%';
+    this.centerGroup.appendChild(this.throttleText);
+
+    this.metrics = {
+      speed: createMetric('Speed'),
+      crashes: createMetric('Crashes'),
+      time: createMetric('Flight Time'),
+      distance: createMetric('Distance'),
+    };
+
+    this.metrics.speed.wrapper.style.top = '-110px';
+    this.metrics.speed.wrapper.style.left = '50%';
+    this.metrics.speed.wrapper.style.transform = 'translate(-50%, 0)';
+
+    this.metrics.time.wrapper.style.bottom = '-110px';
+    this.metrics.time.wrapper.style.left = '50%';
+    this.metrics.time.wrapper.style.transform = 'translate(-50%, 0)';
+
+    this.metrics.distance.wrapper.style.top = '50%';
+    this.metrics.distance.wrapper.style.left = '-120px';
+    this.metrics.distance.wrapper.style.transform = 'translate(-100%, -50%)';
+
+    this.metrics.crashes.wrapper.style.top = '50%';
+    this.metrics.crashes.wrapper.style.right = '-120px';
+    this.metrics.crashes.wrapper.style.transform = 'translate(100%, -50%)';
+
+    Object.values(this.metrics).forEach(({ wrapper }) => {
+      this.centerGroup.appendChild(wrapper);
+    });
+
+    this.controlsPanel = document.createElement('div');
+    this.controlsPanel.id = 'hud-controls';
+    this.controlsPanel.setAttribute('style', CONTROLS_PANEL_STYLE);
 
     this.controlsTitle = document.createElement('div');
+    this.controlsTitle.setAttribute('style', CONTROLS_TITLE_STYLE);
     this.controlsTitle.textContent = 'Flight Controls';
-    this.controlsTitle.style.marginTop = '14px';
-    this.controlsTitle.style.fontSize = '13px';
-    this.controlsTitle.style.letterSpacing = '0.12em';
-    this.controlsTitle.style.textTransform = 'uppercase';
-    this.controlsTitle.style.opacity = '0.8';
+    this.controlsPanel.appendChild(this.controlsTitle);
 
-    this.controlsList = document.createElement('ul');
-    this.controlsList.setAttribute('style', LIST_STYLE);
-    this.controlsList.style.fontSize = '14px';
-    this.controlsList.style.opacity = '0.92';
-
-    this.container.appendChild(this.status);
-    this.container.appendChild(this.metrics);
-    this.container.appendChild(this.throttleBar);
-    this.container.appendChild(this.controlsTitle);
-    this.container.appendChild(this.controlsList);
-
-    document.body.appendChild(this.container);
+    this.controlsList = document.createElement('div');
+    this.controlsList.style.display = 'grid';
+    this.controlsList.style.gap = '4px';
+    this.controlsPanel.appendChild(this.controlsList);
+    this.overlay.appendChild(this.controlsPanel);
 
     this.message = document.createElement('div');
     this.message.id = 'crash-banner';
     this.message.setAttribute('style', MESSAGE_STYLE);
     this.message.style.display = 'none';
-    document.body.appendChild(this.message);
+    this.overlay.appendChild(this.message);
 
     this.controls = controls;
     this.renderControls();
     this.messageTimer = null;
   }
 
-  update({ throttle = 0, speed = 0, altitude = 0, crashCount = 0 }){
-    this.status.textContent = `Throttle ${(throttle * 100).toFixed(0)}% · Speed ${speed.toFixed(0)} kt`;
-    this.metrics.innerHTML = `
-      <div>Altitude <strong>${altitude.toFixed(0)} m</strong></div>
-      <div>Crash Count <strong>${crashCount}</strong></div>
-    `;
-    this.throttleFill.style.width = `${Math.max(4, Math.min(100, throttle * 100))}%`;
+  update({ throttle = 0, speed = 0, crashCount = 0, elapsedTime = 0, distance = 0 }){
+    const throttlePct = Math.round(Math.max(0, Math.min(1, throttle)) * 100);
+    this.throttleText.textContent = `THR ${throttlePct}%`;
+    const sweep = Math.max(0, Math.min(360, throttlePct * 3.6));
+    const arcGradient = `conic-gradient(rgba(80, 255, 200, 0.8) ${sweep}deg, rgba(90, 120, 180, 0.18) ${sweep}deg 360deg)`;
+    this.throttleRing.style.background = arcGradient;
+
+    this.metrics.speed.value.textContent = `${speed.toFixed(0)} kt`;
+    this.metrics.crashes.value.textContent = `${crashCount}`;
+    this.metrics.time.value.textContent = formatTime(elapsedTime);
+    this.metrics.distance.value.textContent = formatDistance(distance);
   }
 
   renderControls(){
     this.controlsList.innerHTML = '';
     this.controls.forEach((entry) => {
-      const item = document.createElement('li');
-      item.innerHTML = `<strong>${entry.label}</strong>: ${entry.detail}`;
+      const item = document.createElement('div');
+      item.setAttribute('style', CONTROLS_ITEM_STYLE);
+      const label = document.createElement('strong');
+      label.textContent = entry.label;
+      label.style.letterSpacing = '0.06em';
+      label.style.textTransform = 'uppercase';
+      label.style.fontSize = '12px';
+      const detail = document.createElement('span');
+      detail.textContent = entry.detail;
+      detail.style.opacity = '0.85';
+      item.appendChild(label);
+      item.appendChild(detail);
       this.controlsList.appendChild(item);
     });
   }

--- a/viewer/sandbox/InputManager.js
+++ b/viewer/sandbox/InputManager.js
@@ -1,16 +1,15 @@
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox InputManager requires THREE to be loaded globally');
+
 const KEY_BINDINGS = {
-  pitchDown: ['KeyW', 'ArrowUp'],
-  pitchUp: ['KeyS', 'ArrowDown'],
-  rollLeft: ['KeyA', 'ArrowLeft'],
-  rollRight: ['KeyD', 'ArrowRight'],
-  yawLeft: ['KeyQ'],
-  yawRight: ['KeyE'],
-  throttleUp: ['KeyR', 'ShiftLeft', 'ShiftRight'],
-  throttleDown: ['KeyF', 'ControlLeft', 'ControlRight'],
-  brake: ['KeyX'],
+  rollLeft: ['KeyA'],
+  rollRight: ['KeyD'],
+  throttleUp: ['KeyW'],
+  throttleDown: ['KeyS'],
+  brake: ['Space'],
 };
 
-const DEADZONE = 0.08;
+const DEADZONE = 0.06;
 
 function applyDigitalAxis(positiveKeys, negativeKeys, activeKeys){
   let value = 0;
@@ -37,15 +36,22 @@ function applyDeadzone(value){
 export class InputManager {
   constructor({ element = window } = {}){
     this.activeKeys = new Set();
-    this.pitch = 0;
     this.roll = 0;
     this.yaw = 0;
     this.throttleAdjust = 0;
     this.brake = false;
+    this.pointer = { x: 0, y: 0 };
+    this.pointerTarget = { x: 0, y: 0 };
+    this.pointerSmoothing = 9;
+    this.pointerSensitivity = { yaw: 0.9, pitch: 0.8 };
     this._onKeyDown = this.handleKeyDown.bind(this);
     this._onKeyUp = this.handleKeyUp.bind(this);
+    this._onPointerMove = this.handlePointerMove.bind(this);
+    this._onPointerLeave = this.handlePointerLeave.bind(this);
     element.addEventListener('keydown', this._onKeyDown);
     element.addEventListener('keyup', this._onKeyUp);
+    element.addEventListener('pointermove', this._onPointerMove);
+    element.addEventListener('pointerleave', this._onPointerLeave);
     this.element = element;
   }
 
@@ -53,12 +59,14 @@ export class InputManager {
     if (!this.element) return;
     this.element.removeEventListener('keydown', this._onKeyDown);
     this.element.removeEventListener('keyup', this._onKeyUp);
+    this.element.removeEventListener('pointermove', this._onPointerMove);
+    this.element.removeEventListener('pointerleave', this._onPointerLeave);
     this.element = null;
   }
 
   handleKeyDown(event){
     this.activeKeys.add(event.code);
-    const preventDefault = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(event.code);
+    const preventDefault = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Space'].includes(event.code);
     if (preventDefault){
       event.preventDefault();
     }
@@ -66,28 +74,50 @@ export class InputManager {
 
   handleKeyUp(event){
     this.activeKeys.delete(event.code);
-    const preventDefault = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(event.code);
+    const preventDefault = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Space'].includes(event.code);
     if (preventDefault){
       event.preventDefault();
     }
   }
 
-  readState(){
-    const pitch = applyDeadzone(applyDigitalAxis(KEY_BINDINGS.pitchDown, KEY_BINDINGS.pitchUp, this.activeKeys));
+  handlePointerMove(event){
+    const rect = this.element === window
+      ? { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight }
+      : this.element.getBoundingClientRect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    const nx = ((event.clientX - rect.left) / width - 0.5) * 2;
+    const ny = (0.5 - (event.clientY - rect.top) / height) * 2;
+    this.pointerTarget.x = THREE.MathUtils.clamp(nx, -1.2, 1.2);
+    this.pointerTarget.y = THREE.MathUtils.clamp(ny, -1.2, 1.2);
+  }
+
+  handlePointerLeave(){
+    this.pointerTarget.x = 0;
+    this.pointerTarget.y = 0;
+  }
+
+  readState(dt = 0){
+    const pointerBlend = dt > 0 ? 1 - Math.exp(-this.pointerSmoothing * dt) : 1;
+    this.pointer.x += (this.pointerTarget.x - this.pointer.x) * pointerBlend;
+    this.pointer.y += (this.pointerTarget.y - this.pointer.y) * pointerBlend;
+
     const roll = applyDeadzone(applyDigitalAxis(KEY_BINDINGS.rollRight, KEY_BINDINGS.rollLeft, this.activeKeys));
-    const yaw = applyDeadzone(applyDigitalAxis(KEY_BINDINGS.yawRight, KEY_BINDINGS.yawLeft, this.activeKeys));
     const throttleAdjust = applyDigitalAxis(KEY_BINDINGS.throttleUp, KEY_BINDINGS.throttleDown, this.activeKeys);
     const brake = KEY_BINDINGS.brake.some((key) => this.activeKeys.has(key));
+
+    const yaw = applyDeadzone(this.pointer.x * this.pointerSensitivity.yaw);
+    const pitch = applyDeadzone(this.pointer.y * this.pointerSensitivity.pitch);
+
     return { pitch, roll, yaw, throttleAdjust, brake };
   }
 }
 
 export function describeControls(){
   return [
-    { label: 'Pitch', detail: 'W/S or ↑/↓ adjusts nose' },
-    { label: 'Roll', detail: 'A/D or ←/→ banks the wings' },
-    { label: 'Yaw', detail: 'Q/E rudder twist' },
-    { label: 'Throttle', detail: 'R increases · F decreases' },
-    { label: 'Brake', detail: 'X taps airbrake' },
+    { label: 'Aim', detail: 'Move mouse to steer nose' },
+    { label: 'Roll', detail: 'A banks left · D banks right' },
+    { label: 'Throttle', detail: 'Hold W to accelerate · S to decelerate' },
+    { label: 'Brake', detail: 'Space for airbrake' },
   ];
 }


### PR DESCRIPTION
## Summary
- add mouse-driven pitch/yaw aiming with streamlined keyboard throttle and roll bindings
- implement a stabilized chase camera that keeps the plane centered while damping motion
- redesign the HUD into a centered overlay with speed, throttle, crash count, elapsed time, and distance tracking

## Testing
- not run (sandbox-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da08edfe6483299b0d51be42364fcc