### PR TITLE
Add car sandbox mode and mouse orbit camera

### DIFF
--- a/viewer/sandbox/CarController.js
+++ b/viewer/sandbox/CarController.js
@@ -1,0 +1,291 @@
+const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+if (!THREE) throw new Error('Sandbox CarController requires THREE to be loaded globally');
+
+const FORWARD_AXIS = new THREE.Vector3(0, 1, 0);
+const TMP_FORWARD = new THREE.Vector3();
+const TMP_EULER = new THREE.Euler(0, 0, 0, 'ZXY');
+
+export class CarController {
+  constructor({ position = new THREE.Vector3(), yaw = 0 } = {}) {
+    this.position = position.clone();
+    this.yaw = yaw;
+    this.lean = 0;
+    this.velocity = new THREE.Vector3();
+    this.orientation = new THREE.Quaternion();
+    this.speed = 0;
+    this.maxForwardSpeed = 62;
+    this.maxReverseSpeed = 26;
+    this.speedResponse = 4.2;
+    this.brakeStrength = 7.5;
+    this.drag = 1.8;
+    this.turnRate = THREE.MathUtils.degToRad(75);
+    this.turnSmoothing = 8.5;
+    this.leanResponse = 6.5;
+    this.height = 2.1;
+    this.armYaw = 0;
+    this.armPitch = 0;
+    this.armYawLimit = THREE.MathUtils.degToRad(75);
+    this.armPitchLimit = THREE.MathUtils.degToRad(48);
+    this.armResponse = 10;
+    this.currentSteer = 0;
+    this.power = 0;
+    this.wheelRotation = 0;
+    this._updateOrientation();
+  }
+
+  attachMesh(mesh, { stickYaw, stickPitch, towerGroup, towerHead, wheels = [] } = {}) {
+    this.mesh = mesh ?? null;
+    this.stickYaw = stickYaw ?? null;
+    this.stickPitch = stickPitch ?? null;
+    this.towerGroup = towerGroup ?? null;
+    this.towerHead = towerHead ?? null;
+    this.wheels = Array.isArray(wheels) ? wheels : [];
+    if (mesh) {
+      mesh.position.copy(this.position);
+      mesh.quaternion.copy(this.orientation);
+    }
+  }
+
+  reset({ position, yaw = 0 } = {}) {
+    if (position) {
+      this.position.copy(position);
+    }
+    this.yaw = yaw;
+    this.lean = 0;
+    this.speed = 0;
+    this.velocity.set(0, 0, 0);
+    this.currentSteer = 0;
+    this.power = 0;
+    this.wheelRotation = 0;
+    this.armYaw = 0;
+    this.armPitch = 0;
+    this._updateOrientation();
+    if (this.mesh) {
+      this.mesh.position.copy(this.position);
+      this.mesh.quaternion.copy(this.orientation);
+    }
+    this._applyManipulator({ x: 0, y: 0 }, 1);
+  }
+
+  update(dt, input = {}, { sampleGroundHeight } = {}) {
+    if (dt <= 0) return;
+
+    const throttleInput = THREE.MathUtils.clamp(input.throttle ?? 0, -1, 1);
+    const steerInput = THREE.MathUtils.clamp(input.steer ?? 0, -1, 1);
+    const brake = !!input.brake;
+
+    const forwardTarget = throttleInput >= 0
+      ? throttleInput * this.maxForwardSpeed
+      : throttleInput * this.maxReverseSpeed;
+
+    const blend = dt > 0 ? 1 - Math.exp(-this.speedResponse * dt) : 1;
+    this.speed += (forwardTarget - this.speed) * blend;
+
+    if (brake) {
+      const brakeFactor = 1 - Math.exp(-this.brakeStrength * dt);
+      this.speed += (0 - this.speed) * brakeFactor;
+    } else if (Math.abs(throttleInput) < 0.05) {
+      const dragFactor = 1 - Math.exp(-this.drag * dt);
+      this.speed += (0 - this.speed) * dragFactor;
+    }
+
+    this.power = Math.max(0, Math.min(1, Math.abs(throttleInput)));
+
+    this.currentSteer += (steerInput - this.currentSteer) * (dt > 0 ? 1 - Math.exp(-this.turnSmoothing * dt) : 1);
+    const speedFactor = Math.min(1, Math.abs(this.speed) / this.maxForwardSpeed);
+    this.yaw += this.currentSteer * this.turnRate * dt * (0.35 + speedFactor * 0.65);
+
+    this.lean += ((-this.currentSteer * speedFactor * 0.45) - this.lean) * (dt > 0 ? 1 - Math.exp(-this.leanResponse * dt) : 1);
+
+    this._updateOrientation();
+    const forward = TMP_FORWARD.copy(FORWARD_AXIS).applyQuaternion(this.orientation).normalize();
+    this.velocity.copy(forward).multiplyScalar(this.speed);
+    this.position.addScaledVector(this.velocity, dt);
+
+    if (typeof sampleGroundHeight === 'function') {
+      const ground = sampleGroundHeight(this.position.x, this.position.y);
+      if (Number.isFinite(ground)) {
+        this.position.z = ground + this.height;
+      }
+    }
+
+    this._applyManipulator(input.aim ?? { x: 0, y: 0 }, dt);
+    this._updateWheels(dt);
+
+    if (this.mesh) {
+      this.mesh.position.copy(this.position);
+      this.mesh.quaternion.copy(this.orientation);
+    }
+  }
+
+  getState() {
+    return {
+      position: this.position,
+      orientation: this.orientation,
+      velocity: this.velocity,
+      speed: Math.abs(this.velocity.length()),
+      throttle: this.power,
+    };
+  }
+
+  _updateOrientation() {
+    TMP_EULER.set(0, this.lean, this.yaw, 'ZXY');
+    this.orientation.setFromEuler(TMP_EULER);
+  }
+
+  _applyManipulator(aim, dt) {
+    if (!aim) aim = { x: 0, y: 0 };
+    const targetYaw = THREE.MathUtils.clamp(aim.x ?? 0, -1, 1) * this.armYawLimit;
+    const targetPitch = THREE.MathUtils.clamp(aim.y ?? 0, -1, 1) * this.armPitchLimit;
+
+    const blend = dt > 0 ? 1 - Math.exp(-this.armResponse * dt) : 1;
+    this.armYaw += (targetYaw - this.armYaw) * blend;
+    this.armPitch += (targetPitch - this.armPitch) * blend;
+
+    if (this.stickYaw) {
+      this.stickYaw.rotation.z = this.armYaw;
+    }
+    if (this.stickPitch) {
+      this.stickPitch.rotation.x = this.armPitch;
+    }
+    if (this.towerGroup) {
+      this.towerGroup.rotation.x += (this.armPitch * 0.5 - this.towerGroup.rotation.x) * blend;
+      this.towerGroup.rotation.z += (this.armYaw * 0.5 - this.towerGroup.rotation.z) * blend;
+    }
+    if (this.towerHead) {
+      this.towerHead.rotation.x += (-this.armPitch * 0.8 - this.towerHead.rotation.x) * blend;
+      this.towerHead.rotation.z += (this.armYaw * 0.8 - this.towerHead.rotation.z) * blend;
+    }
+  }
+
+  _updateWheels(dt) {
+    if (!Array.isArray(this.wheels) || this.wheels.length === 0) return;
+    const wheelRadius = 1.05;
+    this.wheelRotation += (this.speed * dt) / Math.max(0.2, wheelRadius);
+    for (const wheel of this.wheels) {
+      if (!wheel) continue;
+      wheel.rotation.x = this.wheelRotation;
+    }
+  }
+}
+
+export function createCarRig() {
+  const carGroup = new THREE.Group();
+  carGroup.name = 'groundCar';
+
+  const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0x253347, metalness: 0.2, roughness: 0.5 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: 0xff6b3d, metalness: 0.35, roughness: 0.35 });
+  const glassMaterial = new THREE.MeshStandardMaterial({ color: 0xa3d1ff, metalness: 0.1, roughness: 0.08, transparent: true, opacity: 0.75 });
+  const stickMaterial = new THREE.MeshStandardMaterial({ color: 0xe8d37a, metalness: 0.15, roughness: 0.45 });
+  const towerMaterial = new THREE.MeshStandardMaterial({ color: 0x445c7a, metalness: 0.25, roughness: 0.4 });
+
+  const chassisGeometry = new THREE.BoxGeometry(9, 5.5, 2.4);
+  const chassis = new THREE.Mesh(chassisGeometry, bodyMaterial);
+  chassis.position.set(0, 0, 2.1);
+  chassis.castShadow = true;
+  chassis.receiveShadow = true;
+  carGroup.add(chassis);
+
+  const cabinGeometry = new THREE.BoxGeometry(5.8, 3.6, 2.2);
+  const cabin = new THREE.Mesh(cabinGeometry, glassMaterial);
+  cabin.position.set(0, -0.3, 3.3);
+  cabin.castShadow = true;
+  carGroup.add(cabin);
+
+  const hoodGeometry = new THREE.BoxGeometry(6.2, 2.4, 1.2);
+  const hood = new THREE.Mesh(hoodGeometry, accentMaterial);
+  hood.position.set(0, 3.4, 2.5);
+  hood.castShadow = true;
+  carGroup.add(hood);
+
+  const bumperGeometry = new THREE.BoxGeometry(9.2, 0.8, 1);
+  const bumper = new THREE.Mesh(bumperGeometry, accentMaterial);
+  bumper.position.set(0, 5, 1.8);
+  bumper.castShadow = true;
+  carGroup.add(bumper);
+
+  const wheelGeometry = new THREE.CylinderGeometry(1.05, 1.05, 0.8, 20);
+  const wheelMaterial = new THREE.MeshStandardMaterial({ color: 0x222222, metalness: 0.35, roughness: 0.7 });
+  const wheelOffsets = [
+    [2.8, 3.4, 1.05],
+    [-2.8, 3.4, 1.05],
+    [2.8, -3.4, 1.05],
+    [-2.8, -3.4, 1.05],
+  ];
+  const wheels = [];
+  for (const [x, y, z] of wheelOffsets) {
+    const wheel = new THREE.Mesh(wheelGeometry, wheelMaterial);
+    wheel.rotation.z = Math.PI / 2;
+    wheel.position.set(x, y, z);
+    wheel.castShadow = true;
+    wheel.receiveShadow = true;
+    carGroup.add(wheel);
+    wheels.push(wheel);
+  }
+
+  const stickYaw = new THREE.Group();
+  stickYaw.position.set(0, 2.8, 4.1);
+  carGroup.add(stickYaw);
+
+  const stickPitch = new THREE.Group();
+  stickYaw.add(stickPitch);
+
+  const stickGeometry = new THREE.CylinderGeometry(0.18, 0.22, 6.2, 12);
+  const stick = new THREE.Mesh(stickGeometry, stickMaterial);
+  stick.position.set(0, 3.1, 0);
+  stick.castShadow = true;
+  stickPitch.add(stick);
+
+  const stickTip = new THREE.Mesh(new THREE.SphereGeometry(0.45, 14, 12), accentMaterial);
+  stickTip.position.set(0, 3.4, 0);
+  stickTip.castShadow = true;
+  stickPitch.add(stickTip);
+
+  const towerGroup = new THREE.Group();
+  towerGroup.position.set(0, 7.4, 0);
+  carGroup.add(towerGroup);
+
+  const towerBaseGeometry = new THREE.CylinderGeometry(1.4, 1.8, 1.2, 16);
+  const towerBase = new THREE.Mesh(towerBaseGeometry, towerMaterial);
+  towerBase.position.set(0, 0, 0.6);
+  towerBase.castShadow = true;
+  towerBase.receiveShadow = true;
+  towerGroup.add(towerBase);
+
+  const towerColumnGeometry = new THREE.CylinderGeometry(0.75, 0.75, 5.6, 18);
+  const towerColumn = new THREE.Mesh(towerColumnGeometry, towerMaterial);
+  towerColumn.position.set(0, 0, 3.7);
+  towerColumn.castShadow = true;
+  towerColumn.receiveShadow = true;
+  towerGroup.add(towerColumn);
+
+  const towerHead = new THREE.Group();
+  towerHead.position.set(0, 0, 6.8);
+  towerGroup.add(towerHead);
+
+  const towerCrossGeometry = new THREE.BoxGeometry(0.6, 3.8, 0.6);
+  const towerCross = new THREE.Mesh(towerCrossGeometry, accentMaterial);
+  towerCross.castShadow = true;
+  towerHead.add(towerCross);
+
+  const towerStickGeometry = new THREE.CylinderGeometry(0.16, 0.16, 5.4, 12);
+  const towerStick = new THREE.Mesh(towerStickGeometry, stickMaterial);
+  towerStick.rotation.x = Math.PI / 2;
+  towerStick.position.set(0, 0, -0.3);
+  towerStick.castShadow = true;
+  towerHead.add(towerStick);
+
+  const towerOrb = new THREE.Mesh(new THREE.SphereGeometry(0.55, 18, 14), new THREE.MeshStandardMaterial({ color: 0xfff0c0, emissive: 0xffc860, emissiveIntensity: 0.4 }));
+  towerOrb.position.set(0, 0, 0.7);
+  towerOrb.castShadow = true;
+  towerHead.add(towerOrb);
+
+  return {
+    carMesh: carGroup,
+    wheels,
+    stickYaw,
+    stickPitch,
+    towerGroup,
+    towerHead,
+  };
+}

--- a/viewer/sandbox/ChaseCamera.js
+++ b/viewer/sandbox/ChaseCamera.js
@@ -6,6 +6,9 @@ const TMP_FLAT_FORWARD = new THREE.Vector3();
 const TMP_UP = new THREE.Vector3(0, 0, 1);
 const TMP_TARGET = new THREE.Vector3();
 const TMP_LOOK = new THREE.Vector3();
+const TMP_RIGHT = new THREE.Vector3();
+const TMP_QUAT = new THREE.Quaternion();
+const TMP_QUAT2 = new THREE.Quaternion();
 
 export class ChaseCamera {
   constructor(camera, {
@@ -26,9 +29,55 @@ export class ChaseCamera {
     this.currentPosition = camera.position.clone();
     this.currentForward = new THREE.Vector3(0, 1, 0);
     this.currentLookTarget = new THREE.Vector3();
+    this.orbitYaw = 0;
+    this.orbitPitch = 0;
+    this.maxOrbitYaw = THREE.MathUtils.degToRad(160);
+    this.maxOrbitPitch = THREE.MathUtils.degToRad(70);
+    this.orbitReturnSpeed = 2.6;
   }
 
-  update({ position, orientation, velocity }, dt){
+  setConfig({ distance, height, stiffness, lookStiffness, forwardResponsiveness, pitchInfluence } = {}) {
+    if (Number.isFinite(distance)) this.distance = distance;
+    if (Number.isFinite(height)) this.height = height;
+    if (Number.isFinite(stiffness)) this.stiffness = stiffness;
+    if (Number.isFinite(lookStiffness)) this.lookStiffness = lookStiffness;
+    if (Number.isFinite(forwardResponsiveness)) this.forwardResponsiveness = forwardResponsiveness;
+    if (Number.isFinite(pitchInfluence)) this.pitchInfluence = pitchInfluence;
+  }
+
+  resetOrbit() {
+    this.orbitYaw = 0;
+    this.orbitPitch = 0;
+  }
+
+  snapTo(state) {
+    if (!state?.position) return;
+    if (!this.camera) return;
+    if (state.orientation) {
+      const forward = TMP_FORWARD.set(0, 1, 0).applyQuaternion(state.orientation).normalize();
+      const flat = TMP_FLAT_FORWARD.copy(forward);
+      flat.z = 0;
+      if (flat.lengthSq() > 1e-4) {
+        flat.normalize();
+        this.currentForward.copy(flat);
+      } else {
+        this.currentForward.set(0, 1, 0);
+      }
+      const pitchFactor = THREE.MathUtils.clamp(forward.z, -0.75, 0.75);
+      const desired = TMP_TARGET.copy(state.position)
+        .addScaledVector(this.currentForward, -this.distance)
+        .addScaledVector(TMP_UP, this.height + pitchFactor * this.distance * this.pitchInfluence);
+      this.currentPosition.copy(desired);
+    } else {
+      this.currentPosition.copy(state.position).addScaledVector(TMP_UP, this.height);
+    }
+    this.camera.position.copy(this.currentPosition);
+    this.currentLookTarget.copy(state.position);
+    this.camera.up.copy(TMP_UP);
+    this.camera.lookAt(this.currentLookTarget);
+  }
+
+  update({ position, orientation, velocity }, dt, orbitInput){
     if (!this.camera || !position || !orientation) return;
     const rawForward = TMP_FORWARD.set(0, 1, 0).applyQuaternion(orientation).normalize();
 
@@ -48,11 +97,29 @@ export class ChaseCamera {
     }
     this.currentForward.normalize();
 
+    this._updateOrbit(orbitInput, dt);
+
+    const rotatedForward = TMP_FORWARD.copy(this.currentForward);
+    if (this.orbitYaw !== 0) {
+      rotatedForward.applyQuaternion(TMP_QUAT.setFromAxisAngle(TMP_UP, this.orbitYaw));
+    }
+    rotatedForward.normalize();
+    if (this.orbitPitch !== 0) {
+      const right = TMP_RIGHT.crossVectors(rotatedForward, TMP_UP);
+      if (right.lengthSq() > 1e-5) {
+        right.normalize();
+        rotatedForward.applyQuaternion(TMP_QUAT2.setFromAxisAngle(right, this.orbitPitch));
+      }
+    }
+    rotatedForward.normalize();
+
     const pitchFactor = THREE.MathUtils.clamp(rawForward.z, -0.75, 0.75);
-    const heightOffset = this.height + pitchFactor * this.distance * this.pitchInfluence;
+    const heightOffset = this.height
+      + pitchFactor * this.distance * this.pitchInfluence
+      + Math.sin(this.orbitPitch) * this.distance * 0.6;
 
     const desired = TMP_TARGET.copy(position)
-      .addScaledVector(this.currentForward, -this.distance)
+      .addScaledVector(rotatedForward, -this.distance)
       .addScaledVector(TMP_UP, heightOffset);
 
     const lerpFactor = dt > 0 ? 1 - Math.exp(-this.stiffness * dt) : 1;
@@ -64,7 +131,7 @@ export class ChaseCamera {
 
     this.camera.position.copy(this.currentPosition);
 
-    const target = TMP_LOOK.copy(position);
+    const target = TMP_LOOK.copy(position).addScaledVector(TMP_UP, Math.sin(this.orbitPitch) * 10);
 
     const lookBlend = dt > 0 ? 1 - Math.exp(-this.lookStiffness * dt) : 1;
     if (!Number.isFinite(this.currentLookTarget.lengthSq())){
@@ -78,5 +145,23 @@ export class ChaseCamera {
 
     this.camera.up.copy(TMP_UP);
     this.camera.lookAt(this.currentLookTarget);
+  }
+
+  _updateOrbit(orbitInput, dt) {
+    if (!orbitInput) {
+      const decay = dt > 0 ? 1 - Math.exp(-this.orbitReturnSpeed * dt) : 1;
+      this.orbitYaw += (0 - this.orbitYaw) * decay;
+      this.orbitPitch += (0 - this.orbitPitch) * decay;
+      return;
+    }
+
+    if (orbitInput.active) {
+      this.orbitYaw = THREE.MathUtils.clamp(this.orbitYaw + (orbitInput.yawDelta ?? 0), -this.maxOrbitYaw, this.maxOrbitYaw);
+      this.orbitPitch = THREE.MathUtils.clamp(this.orbitPitch + (orbitInput.pitchDelta ?? 0), -this.maxOrbitPitch, this.maxOrbitPitch);
+    } else {
+      const decay = dt > 0 ? 1 - Math.exp(-this.orbitReturnSpeed * dt) : 1;
+      this.orbitYaw += (0 - this.orbitYaw) * decay;
+      this.orbitPitch += (0 - this.orbitPitch) * decay;
+    }
   }
 }

--- a/viewer/sandbox/main.js
+++ b/viewer/sandbox/main.js
@@ -1,5 +1,6 @@
 import { InputManager, describeControls } from './InputManager.js';
 import { PlaneController, createPlaneMesh } from './PlaneController.js';
+import { CarController, createCarRig } from './CarController.js';
 import { ChaseCamera } from './ChaseCamera.js';
 import { WorldStreamer } from './WorldStreamer.js';
 import { CollisionSystem } from './CollisionSystem.js';
@@ -51,16 +52,42 @@ scene.add(planeMesh);
 const planeController = new PlaneController();
 planeController.attachMesh(planeMesh);
 
-const input = new InputManager();
-const chaseCamera = new ChaseCamera(camera, {
+const carRig = createCarRig();
+scene.add(carRig.carMesh);
+carRig.carMesh.visible = false;
+
+const carController = new CarController();
+carController.attachMesh(carRig.carMesh, {
+  stickYaw: carRig.stickYaw,
+  stickPitch: carRig.stickPitch,
+  towerGroup: carRig.towerGroup,
+  towerHead: carRig.towerHead,
+  wheels: carRig.wheels,
+});
+
+const planeCameraConfig = {
   distance: 78,
   height: 24,
   stiffness: 3.8,
   lookStiffness: 7,
   forwardResponsiveness: 5.2,
   pitchInfluence: 0.42,
-});
-const hud = new HUD({ controls: describeControls() });
+};
+
+const carCameraConfig = {
+  distance: 36,
+  height: 12,
+  stiffness: 5.6,
+  lookStiffness: 7.6,
+  forwardResponsiveness: 6.2,
+  pitchInfluence: 0.2,
+};
+
+const input = new InputManager();
+const chaseCamera = new ChaseCamera(camera, planeCameraConfig);
+const planeControls = describeControls('plane');
+const carControls = describeControls('car');
+const hud = new HUD({ controls: planeControls });
 const collisionSystem = new CollisionSystem({ world, crashMargin: 2.2, obstaclePadding: 3 });
 
 const startAnchor = new THREE.Vector3(0, -320, 0);
@@ -69,6 +96,12 @@ let crashCooldown = 0;
 let elapsedFlightTime = 0;
 let traveledDistance = 0;
 const lastPlanePosition = new THREE.Vector3();
+let elapsedDriveTime = 0;
+let drivenDistance = 0;
+const lastCarPosition = new THREE.Vector3();
+
+const VEHICLE_MODES = { PLANE: 'plane', CAR: 'car' };
+let activeVehicle = VEHICLE_MODES.PLANE;
 
 function computeStartPosition(){
   const spawn = startAnchor.clone();
@@ -80,19 +113,46 @@ function computeStartPosition(){
 function resetPlane(){
   const spawn = computeStartPosition();
   planeController.reset({ position: spawn, yaw: 0, pitch: THREE.MathUtils.degToRad(2), throttle: 0.42 });
-  chaseCamera.currentPosition.copy(spawn.clone().add(new THREE.Vector3(-40, -60, 30)));
-  chaseCamera.currentForward.set(0, 1, 0);
-  chaseCamera.currentLookTarget.copy(planeController.position);
-  camera.position.copy(chaseCamera.currentPosition);
   crashCooldown = 0.8;
   elapsedFlightTime = 0;
   traveledDistance = 0;
   lastPlanePosition.copy(planeController.position);
   world.update(planeController.position);
-  chaseCamera.update(planeController.getState(), 0);
+  focusCameraOnPlane();
+}
+
+function computeCarStartPosition(){
+  const spawn = startAnchor.clone().add(new THREE.Vector3(80, -110, 0));
+  const ground = world.getHeightAt(spawn.x, spawn.y);
+  spawn.z = ground + carController.height;
+  return spawn;
+}
+
+function resetCar({ alignCamera = false } = {}){
+  const spawn = computeCarStartPosition();
+  carController.reset({ position: spawn, yaw: 0 });
+  elapsedDriveTime = 0;
+  drivenDistance = 0;
+  lastCarPosition.copy(carController.position);
+  if (alignCamera){
+    focusCameraOnCar();
+  }
+}
+
+function focusCameraOnPlane(){
+  chaseCamera.setConfig(planeCameraConfig);
+  chaseCamera.resetOrbit();
+  chaseCamera.snapTo(planeController.getState());
+}
+
+function focusCameraOnCar(){
+  chaseCamera.setConfig(carCameraConfig);
+  chaseCamera.resetOrbit();
+  chaseCamera.snapTo(carController.getState());
 }
 
 resetPlane();
+resetCar();
 
 window.addEventListener('resize', () => {
   camera.aspect = window.innerWidth / window.innerHeight;
@@ -109,69 +169,122 @@ function clampAltitude(controller, ground){
 
 let lastTime = performance.now();
 
+function setActiveVehicle(mode){
+  if (mode === activeVehicle) return;
+  if (mode === VEHICLE_MODES.PLANE){
+    activeVehicle = VEHICLE_MODES.PLANE;
+    planeMesh.visible = true;
+    carRig.carMesh.visible = false;
+    hud.setControls(planeControls);
+    focusCameraOnPlane();
+  } else if (mode === VEHICLE_MODES.CAR){
+    activeVehicle = VEHICLE_MODES.CAR;
+    planeMesh.visible = false;
+    carRig.carMesh.visible = true;
+    hud.setControls(carControls);
+    focusCameraOnCar();
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.code === 'Digit1'){
+    setActiveVehicle(VEHICLE_MODES.PLANE);
+  } else if (event.code === 'Digit2'){
+    setActiveVehicle(VEHICLE_MODES.CAR);
+  }
+});
+
 function animate(now){
   requestAnimationFrame(animate);
   const dt = Math.min(0.08, (now - lastTime) / 1000 || 0);
   lastTime = now;
 
-  const inputState = crashCooldown > 0
-    ? { pitch: 0, yaw: 0, roll: 0, throttleAdjust: 0, brake: false }
-    : input.readState(dt);
-  planeController.update(dt, inputState, {
-    sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
-    clampAltitude,
-  });
-
-  const planeState = planeController.getState();
+  const inputSample = input.readState(dt);
+  const planeInput = crashCooldown > 0 ? { pitch: 0, yaw: 0, roll: 0, throttleAdjust: 0, brake: false } : inputSample.plane;
 
   if (crashCooldown > 0){
     crashCooldown = Math.max(0, crashCooldown - dt);
   }
 
-  if (crashCooldown <= 0){
-    const collision = collisionSystem.evaluate(planeState);
-    if (collision.crashed){
-      crashCount += 1;
-      hud.showMessage('Crashed! Restarting…');
-      resetPlane();
-    }
-  }
+  if (activeVehicle === VEHICLE_MODES.PLANE){
+    planeController.update(dt, planeInput, {
+      sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
+      clampAltitude,
+    });
 
-  if (crashCooldown <= 0){
-    elapsedFlightTime += dt;
-    const frameDistance = planeState.position.distanceTo(lastPlanePosition);
+    const planeState = planeController.getState();
+
+    if (crashCooldown <= 0){
+      const collision = collisionSystem.evaluate(planeState);
+      if (collision.crashed){
+        crashCount += 1;
+        hud.showMessage('Crashed! Restarting…');
+        resetPlane();
+      }
+    }
+
+    if (crashCooldown <= 0){
+      elapsedFlightTime += dt;
+      const frameDistance = planeState.position.distanceTo(lastPlanePosition);
+      if (Number.isFinite(frameDistance)){
+        traveledDistance += frameDistance;
+      }
+    }
+    lastPlanePosition.copy(planeState.position);
+
+    rebaseWorldIfNeeded(planeController.position);
+    world.update(planeState.position);
+    chaseCamera.update(planeState, dt, inputSample.cameraOrbit);
+
+    hud.update({
+      throttle: planeState.throttle,
+      speed: planeState.speed,
+      crashCount,
+      elapsedTime: elapsedFlightTime,
+      distance: traveledDistance,
+    });
+  } else {
+    carController.update(dt, inputSample.car, {
+      sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
+    });
+
+    const carState = carController.getState();
+    elapsedDriveTime += dt;
+    const frameDistance = carState.position.distanceTo(lastCarPosition);
     if (Number.isFinite(frameDistance)){
-      traveledDistance += frameDistance;
+      drivenDistance += frameDistance;
     }
+    lastCarPosition.copy(carState.position);
+
+    rebaseWorldIfNeeded(carController.position);
+    world.update(carState.position);
+    chaseCamera.update(carState, dt, inputSample.cameraOrbit);
+
+    hud.update({
+      throttle: carState.throttle,
+      speed: carState.speed,
+      crashCount: 0,
+      elapsedTime: elapsedDriveTime,
+      distance: drivenDistance,
+    });
   }
-  lastPlanePosition.copy(planeState.position);
-
-  rebaseWorldIfNeeded();
-
-  world.update(planeState.position);
-  chaseCamera.update(planeState, dt);
-
-  hud.update({
-    throttle: planeState.throttle,
-    speed: planeState.speed,
-    crashCount,
-    elapsedTime: elapsedFlightTime,
-    distance: traveledDistance,
-  });
 
   renderer.render(scene, camera);
 }
 
-function rebaseWorldIfNeeded(){
-  const pos = planeController.position;
+function rebaseWorldIfNeeded(referencePosition){
+  const pos = referencePosition ?? planeController.position;
   const distanceSq = pos.x * pos.x + pos.y * pos.y;
   if (distanceSq > ORIGIN_REBASE_DISTANCE_SQ){
     const shift = new THREE.Vector3(pos.x, pos.y, 0);
     planeController.position.sub(shift);
     planeMesh.position.copy(planeController.position);
+    carController.position.sub(shift);
+    carRig.carMesh.position.copy(carController.position);
     chaseCamera.currentPosition.sub(shift);
     camera.position.sub(shift);
     lastPlanePosition.sub(shift);
+    lastCarPosition.sub(shift);
     world.handleOriginShift(shift);
   }
 }


### PR DESCRIPTION
## Summary
- refactor the sandbox input manager to support keyboard-centric plane controls, mouse-wheel throttle, camera orbiting, and per-vehicle help text
- add a ground-car controller and rig so the sandbox can spawn a non-flying vehicle with a mouse-driven tower stick
- update the chase camera, HUD, and sandbox main loop to switch between plane/car modes while enabling left-click camera orbiting

## Testing
- python -m http.server 4173 (manual sandbox preview)


------
https://chatgpt.com/codex/tasks/task_e_68da12b3d38c8329ae443e752f3251f4