### PR TITLE
Add Terra terrain flyover viewer and shared Three.js helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ The HUD overlays throttle, airspeed, altitude, crash counter, and the same contr
 Looking for a friendlier fixed-camera layout for casual pilots? See [`docs/casual-flight-controls.md`](docs/casual-flight-controls.md) for a beginner-focused scheme with auto-stabilization assists and presentation tips.
 
 
+## Terra terrain flyover (three.js)
+
+Need a spectator-friendly view of the procedural terrain without piloting the aircraft? Launch the Terra explorer to cruise above the same streaming world on a guided camera rail:
+
+```bash
+cd viewer
+npx http-server -p 8080 .
+# or: python -m http.server 8080
+```
+
+Then open [`http://localhost:8080/terra/index.html`](http://localhost:8080/terra/index.html). The camera glides along a slow loop, keeping the horizon framed while the `WorldStreamer` continuously loads and unloads chunks beneath it. This is a handy way to review lighting tweaks, terrain noise, or obstacle distribution without juggling the flight controls.
+
+
 ## Prerequisites
 
 - Go 1.20 or newer

--- a/viewer/sandbox/main.js
+++ b/viewer/sandbox/main.js
@@ -5,22 +5,22 @@ import { ChaseCamera } from './ChaseCamera.js';
 import { WorldStreamer } from './WorldStreamer.js';
 import { CollisionSystem } from './CollisionSystem.js';
 import { HUD } from './HUD.js';
+import {
+  createRenderer,
+  createPerspectiveCamera,
+  enableWindowResizeHandling,
+  requireTHREE,
+} from '../shared/threeSetup.js';
 
-const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
-if (!THREE) throw new Error('Sandbox viewer requires THREE to be loaded globally');
+const THREE = requireTHREE();
 
 const SKY_CEILING = 1800;
 const ORIGIN_REBASE_DISTANCE = 1400;
 const ORIGIN_REBASE_DISTANCE_SQ = ORIGIN_REBASE_DISTANCE * ORIGIN_REBASE_DISTANCE;
 
-const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setSize(window.innerWidth, window.innerHeight);
-renderer.setPixelRatio(window.devicePixelRatio || 1);
-renderer.shadowMap.enabled = true;
-renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 document.body.style.margin = '0';
 document.body.style.overflow = 'hidden';
-document.body.appendChild(renderer.domElement);
+const renderer = createRenderer();
 
 document.body.style.background = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)';
 
@@ -28,7 +28,7 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x90b6ff);
 scene.fog = new THREE.Fog(0xa4c6ff, 1500, 4200);
 
-const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 20000);
+const camera = createPerspectiveCamera({ fov: 60, near: 0.1, far: 20000 });
 
 const hemisphere = new THREE.HemisphereLight(0xdce9ff, 0x2b4a2e, 0.85);
 scene.add(hemisphere);
@@ -154,11 +154,7 @@ function focusCameraOnCar(){
 resetPlane();
 resetCar();
 
-window.addEventListener('resize', () => {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-});
+enableWindowResizeHandling({ renderer, camera });
 
 function clampAltitude(controller, ground){
   if (controller.position.z > SKY_CEILING){

--- a/viewer/shared/threeSetup.js
+++ b/viewer/shared/threeSetup.js
@@ -1,0 +1,62 @@
+const getGlobalTHREE = () => {
+  const THREE = (typeof window !== 'undefined' ? window.THREE : globalThis?.THREE) ?? null;
+  if (!THREE) throw new Error('Three.js must be loaded globally before using viewer helpers');
+  return THREE;
+};
+
+export function createRenderer({
+  antialias = true,
+  parentElement = typeof document !== 'undefined' ? document.body : null,
+  autoAppend = true,
+  pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
+  size = typeof window !== 'undefined'
+    ? { width: window.innerWidth, height: window.innerHeight }
+    : { width: 1, height: 1 },
+  enableShadows = true,
+} = {}){
+  const THREE = getGlobalTHREE();
+  const renderer = new THREE.WebGLRenderer({ antialias });
+  renderer.setSize(size.width, size.height);
+  renderer.setPixelRatio(pixelRatio);
+  if (enableShadows){
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  }
+  if (autoAppend && parentElement){
+    parentElement.appendChild(renderer.domElement);
+  }
+  return renderer;
+}
+
+export function createPerspectiveCamera({
+  fov = 60,
+  aspect = typeof window !== 'undefined' ? window.innerWidth / window.innerHeight : 1,
+  near = 0.1,
+  far = 20000,
+} = {}){
+  const THREE = getGlobalTHREE();
+  return new THREE.PerspectiveCamera(fov, aspect, near, far);
+}
+
+export function enableWindowResizeHandling({
+  renderer,
+  camera,
+  getSize = () => ({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1,
+    height: typeof window !== 'undefined' ? window.innerHeight : 1,
+  }),
+} = {}){
+  if (typeof window === 'undefined' || !renderer) return;
+  window.addEventListener('resize', () => {
+    const size = getSize();
+    renderer.setSize(size.width, size.height);
+    if (camera){
+      camera.aspect = size.width / size.height;
+      camera.updateProjectionMatrix();
+    }
+  });
+}
+
+export function requireTHREE(){
+  return getGlobalTHREE();
+}

--- a/viewer/terra/index.html
+++ b/viewer/terra/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>DriftPursuit Terra Explorer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #90b6ff;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/viewer/terra/main.js
+++ b/viewer/terra/main.js
@@ -1,0 +1,84 @@
+import { WorldStreamer } from '../sandbox/WorldStreamer.js';
+import {
+  createRenderer,
+  createPerspectiveCamera,
+  enableWindowResizeHandling,
+  requireTHREE,
+} from '../shared/threeSetup.js';
+
+const THREE = requireTHREE();
+
+document.body.style.margin = '0';
+document.body.style.overflow = 'hidden';
+document.body.style.background = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)';
+
+const renderer = createRenderer();
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x90b6ff);
+scene.fog = new THREE.Fog(0xa4c6ff, 1500, 4200);
+
+const camera = createPerspectiveCamera({ fov: 55, near: 0.1, far: 24000 });
+
+const hemisphere = new THREE.HemisphereLight(0xdce9ff, 0x2b4a2e, 0.85);
+scene.add(hemisphere);
+
+const sun = new THREE.DirectionalLight(0xffffff, 1.05);
+sun.position.set(-420, 580, 780);
+sun.castShadow = true;
+sun.shadow.mapSize.set(2048, 2048);
+sun.shadow.camera.left = -800;
+sun.shadow.camera.right = 800;
+sun.shadow.camera.top = 800;
+sun.shadow.camera.bottom = -800;
+sun.shadow.camera.far = 2400;
+scene.add(sun);
+
+const world = new WorldStreamer({ scene, chunkSize: 640, radius: 3, seed: 982451653 });
+
+const focusPoint = new THREE.Vector3(0, 0, 0);
+const lookTarget = new THREE.Vector3();
+
+camera.position.set(520, -520, 340);
+lookTarget.copy(focusPoint);
+camera.lookAt(lookTarget);
+
+enableWindowResizeHandling({ renderer, camera });
+
+const TRAVEL_RADIUS = 900;
+const ORBIT_RADIUS = 520;
+const BASE_HEIGHT = 320;
+const HEIGHT_SWAY = 46;
+let travelAngle = 0;
+let lastTime = performance.now();
+
+function animate(now){
+  requestAnimationFrame(animate);
+  const dt = Math.min(0.08, (now - lastTime) / 1000 || 0);
+  lastTime = now;
+
+  travelAngle += dt * 0.05;
+
+  focusPoint.set(
+    Math.cos(travelAngle) * TRAVEL_RADIUS,
+    Math.sin(travelAngle) * TRAVEL_RADIUS,
+    0,
+  );
+
+  const groundHeight = world.getHeightAt(focusPoint.x, focusPoint.y);
+  lookTarget.set(focusPoint.x, focusPoint.y, groundHeight + 42);
+
+  const orbitAngle = travelAngle + Math.PI / 3;
+  camera.position.set(
+    focusPoint.x + Math.cos(orbitAngle) * ORBIT_RADIUS,
+    focusPoint.y + Math.sin(orbitAngle) * ORBIT_RADIUS,
+    BASE_HEIGHT + Math.sin(travelAngle * 0.6) * HEIGHT_SWAY,
+  );
+  camera.lookAt(lookTarget);
+
+  world.update(focusPoint);
+  renderer.render(scene, camera);
+}
+
+world.update(focusPoint);
+requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- add a Terra viewer entry point that loops a guided camera over the procedural world
- factor the sandbox renderer and camera setup into reusable helpers for future viewers
- document how to launch the Terra flyover in the project README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da1e0361948329b9de155abcddc10e