### PR TITLE
Add Terra HUD ammo toolbar and configurable projectile behaviours

### DIFF
--- a/viewer/terra/Projectiles.js
+++ b/viewer/terra/Projectiles.js
@@ -12,18 +12,148 @@ const PROJECTILE_SPEED = 320;
 const PROJECTILE_LIFESPAN = 6;
 const PROJECTILE_RADIUS = 0.45;
 
+function normalizeScale(scale){
+  if (Array.isArray(scale) && scale.length >= 3){
+    return { x: scale[0] ?? 1, y: scale[1] ?? 1, z: scale[2] ?? 1 };
+  }
+  if (typeof scale === 'object' && scale){
+    return {
+      x: Number.isFinite(scale.x) ? scale.x : 1,
+      y: Number.isFinite(scale.y) ? scale.y : 1,
+      z: Number.isFinite(scale.z) ? scale.z : 1,
+    };
+  }
+  if (Number.isFinite(scale)){
+    return { x: scale, y: scale, z: scale };
+  }
+  return { x: 1, y: 1, z: 1 };
+}
+
+function normalizeAmmoConfig(config = {}){
+  const scale = normalizeScale(config.scale);
+  const collisionRadius = Number.isFinite(config.collisionRadius)
+    ? config.collisionRadius
+    : PROJECTILE_RADIUS * Math.max(scale.x, scale.y, scale.z);
+
+  return {
+    id: config.id ?? 'standard',
+    name: config.name ?? 'Aurora Burst',
+    effect: config.effect ?? 'Balanced energy bolt',
+    color: config.color ?? 0xffd25c,
+    emissive: config.emissive ?? 0xff9b2f,
+    emissiveIntensity: Number.isFinite(config.emissiveIntensity) ? config.emissiveIntensity : 0.95,
+    metalness: Number.isFinite(config.metalness) ? config.metalness : 0.35,
+    roughness: Number.isFinite(config.roughness) ? config.roughness : 0.4,
+    opacity: Number.isFinite(config.opacity) ? config.opacity : 1,
+    transparent: config.transparent ?? false,
+    speed: Number.isFinite(config.speed) ? config.speed : PROJECTILE_SPEED,
+    lifespan: Number.isFinite(config.lifespan) ? config.lifespan : PROJECTILE_LIFESPAN,
+    collisionRadius,
+    scale,
+    stretch: Number.isFinite(config.stretch) ? config.stretch : 1,
+    behavior: config.behavior ? { ...config.behavior } : null,
+  };
+}
+
+const DEFAULT_AMMO_TYPES = [
+  normalizeAmmoConfig({
+    id: 'aurora',
+    name: 'Aurora Burst',
+    effect: 'Balanced energy bolt',
+    color: 0xffd25c,
+    emissive: 0xff9b2f,
+    emissiveIntensity: 1.1,
+    behavior: { type: 'pulse', amplitude: 0.28, speed: 6.2 },
+  }),
+  normalizeAmmoConfig({
+    id: 'ion-lance',
+    name: 'Ion Lance',
+    effect: 'High velocity beam',
+    color: 0xa0f2ff,
+    emissive: 0x4fd7ff,
+    emissiveIntensity: 1.45,
+    speed: 420,
+    lifespan: 7.5,
+    scale: { x: 0.65, y: 1.6, z: 0.65 },
+    collisionRadius: 0.32,
+    behavior: { type: 'fade', fadeStart: 0.55, fadeDuration: 2.4 },
+  }),
+  normalizeAmmoConfig({
+    id: 'meteor-forge',
+    name: 'Meteor Forge',
+    effect: 'Heavy impact slug',
+    color: 0xff7b45,
+    emissive: 0xff5212,
+    emissiveIntensity: 1.05,
+    speed: 250,
+    lifespan: 5,
+    scale: 1.35,
+    collisionRadius: 0.62,
+    behavior: { type: 'ember', flicker: 0.4, speed: 9.5, scaleAmount: 0.12 },
+  }),
+  normalizeAmmoConfig({
+    id: 'frost-bloom',
+    name: 'Frost Bloom',
+    effect: 'Chilled dispersal round',
+    color: 0xd6e8ff,
+    emissive: 0x7fc4ff,
+    emissiveIntensity: 0.85,
+    speed: 280,
+    lifespan: 6.8,
+    scale: 1.15,
+    transparent: true,
+    opacity: 0.9,
+    behavior: { type: 'pulse', amplitude: 0.18, speed: 3.4 },
+  }),
+];
+
 export class TerraProjectileManager {
-  constructor({ scene } = {}){
+  constructor({ scene, ammoTypes = [] } = {}){
     this.scene = scene ?? null;
     this.projectiles = [];
-    this.geometry = new THREE.SphereGeometry(0.36, 12, 12);
-    this.material = new THREE.MeshStandardMaterial({
-      color: 0xffd25c,
-      emissive: 0xff9b2f,
-      emissiveIntensity: 0.85,
-      metalness: 0.25,
-      roughness: 0.35,
+    this.geometry = new THREE.SphereGeometry(0.36, 20, 20);
+    this.ammoTypes = new Map();
+    this.materialCache = new Map();
+    this.currentAmmoId = null;
+    this.setAmmoTypes(ammoTypes.length ? ammoTypes : DEFAULT_AMMO_TYPES);
+  }
+
+  setAmmoTypes(types = []){
+    this.ammoTypes.clear();
+    this.materialCache.clear();
+    types.forEach((entry) => {
+      const normalized = normalizeAmmoConfig(entry);
+      this.ammoTypes.set(normalized.id, normalized);
     });
+    if (this.ammoTypes.size === 0){
+      DEFAULT_AMMO_TYPES.forEach((entry) => {
+        this.ammoTypes.set(entry.id, entry);
+      });
+    }
+    if (!this.currentAmmoId || !this.ammoTypes.has(this.currentAmmoId)){
+      this.currentAmmoId = types[0]?.id ?? DEFAULT_AMMO_TYPES[0].id;
+    }
+    if (!this.ammoTypes.has(this.currentAmmoId)){
+      const fallback = DEFAULT_AMMO_TYPES[0];
+      this.ammoTypes.set(fallback.id, fallback);
+      this.currentAmmoId = fallback.id;
+    }
+  }
+
+  getAmmoTypes(){
+    return Array.from(this.ammoTypes.values());
+  }
+
+  getCurrentAmmoId(){
+    return this.currentAmmoId;
+  }
+
+  setAmmoType(id){
+    if (!id || !this.ammoTypes.has(id)){
+      return false;
+    }
+    this.currentAmmoId = id;
+    return true;
   }
 
   setScene(scene){
@@ -42,15 +172,18 @@ export class TerraProjectileManager {
       direction.copy(FORWARD_AXIS);
     }
 
-    const mesh = new THREE.Mesh(this.geometry, this.material);
+    const ammo = this._getActiveAmmo();
+    const material = this._createMaterial(ammo);
+    const mesh = new THREE.Mesh(this.geometry, material);
     mesh.name = 'terraProjectile';
     mesh.castShadow = true;
     mesh.receiveShadow = false;
     mesh.position.copy(TMP_POSITION);
     mesh.quaternion.setFromUnitVectors(FORWARD_AXIS, direction);
+    mesh.scale.set(ammo.scale.x, ammo.scale.y * ammo.stretch, ammo.scale.z);
     this.scene.add(mesh);
 
-    const velocity = direction.clone().multiplyScalar(PROJECTILE_SPEED);
+    const velocity = direction.clone().multiplyScalar(ammo.speed);
     if (inheritVelocity && typeof inheritVelocity.x === 'number'){
       velocity.add(inheritVelocity);
     }
@@ -60,7 +193,10 @@ export class TerraProjectileManager {
       velocity,
       ownerId,
       age: 0,
-      lifespan: PROJECTILE_LIFESPAN,
+      lifespan: ammo.lifespan,
+      ammo,
+      radius: ammo.collisionRadius,
+      baseScale: { x: mesh.scale.x, y: mesh.scale.y, z: mesh.scale.z },
     };
     this.projectiles.push(projectile);
     return projectile;
@@ -90,6 +226,7 @@ export class TerraProjectileManager {
       }
 
       projectile.mesh.position.addScaledVector(projectile.velocity, dt);
+      this._applyProjectileBehavior(projectile, dt);
 
       if (vehicles){
         const hitVehicle = this._findVehicleHit(projectile, vehicles);
@@ -120,7 +257,7 @@ export class TerraProjectileManager {
       if (!localCenter || !Number.isFinite(radius)) continue;
       TMP_CENTER.copy(localCenter);
       carMesh.localToWorld(TMP_CENTER);
-      const totalRadius = radius + PROJECTILE_RADIUS;
+      const totalRadius = radius + (projectile.radius ?? PROJECTILE_RADIUS);
       if (TMP_CENTER.distanceToSquared(projectilePosition) <= totalRadius * totalRadius){
         return vehicle;
       }
@@ -131,6 +268,88 @@ export class TerraProjectileManager {
   _disposeProjectile(projectile){
     if (projectile.mesh && this.scene){
       this.scene.remove(projectile.mesh);
+      if (projectile.mesh.material){
+        projectile.mesh.material.dispose();
+      }
+    }
+  }
+
+  _getActiveAmmo(){
+    if (this.currentAmmoId && this.ammoTypes.has(this.currentAmmoId)){
+      return this.ammoTypes.get(this.currentAmmoId);
+    }
+    const first = this.ammoTypes.values().next().value;
+    if (first) return first;
+    const fallback = DEFAULT_AMMO_TYPES[0];
+    this.ammoTypes.set(fallback.id, fallback);
+    this.currentAmmoId = fallback.id;
+    return fallback;
+  }
+
+  _createMaterial(ammo){
+    const key = ammo?.id ?? 'default';
+    const cached = this.materialCache.get(key);
+    const baseMaterial = cached ?? new THREE.MeshStandardMaterial({
+      color: ammo.color,
+      emissive: ammo.emissive,
+      emissiveIntensity: ammo.emissiveIntensity,
+      metalness: ammo.metalness,
+      roughness: ammo.roughness,
+      transparent: ammo.transparent || ammo.opacity < 1,
+      opacity: ammo.opacity,
+    });
+    if (!cached){
+      this.materialCache.set(key, baseMaterial);
+    }
+    const material = baseMaterial.clone();
+    material.emissiveIntensity = ammo.emissiveIntensity;
+    material.opacity = ammo.opacity;
+    material.transparent = ammo.transparent || ammo.opacity < 1;
+    return material;
+  }
+
+  _applyProjectileBehavior(projectile, dt){
+    const behavior = projectile.ammo?.behavior;
+    if (!behavior) return;
+    const material = projectile.mesh.material;
+    if (!material) return;
+    switch (behavior.type){
+      case 'pulse': {
+        const amplitude = Number.isFinite(behavior.amplitude) ? behavior.amplitude : 0.2;
+        const speed = Number.isFinite(behavior.speed) ? behavior.speed : 5;
+        const base = projectile.ammo.emissiveIntensity ?? 1;
+        const pulse = base + Math.sin(projectile.age * speed) * amplitude;
+        material.emissiveIntensity = Math.max(0, pulse);
+        break;
+      }
+      case 'fade': {
+        const fadeStart = Number.isFinite(behavior.fadeStart) ? behavior.fadeStart : 0.5;
+        const fadeDuration = Number.isFinite(behavior.fadeDuration) ? behavior.fadeDuration : 2;
+        const startTime = projectile.lifespan * Math.max(0, Math.min(1, fadeStart));
+        const elapsed = Math.max(0, projectile.age - startTime);
+        if (elapsed > 0){
+          const t = Math.min(1, elapsed / Math.max(0.0001, fadeDuration));
+          material.transparent = true;
+          material.opacity = Math.max(0.05, 1 - t);
+        }
+        break;
+      }
+      case 'ember': {
+        const flicker = Number.isFinite(behavior.flicker) ? behavior.flicker : 0.35;
+        const speed = Number.isFinite(behavior.speed) ? behavior.speed : 8;
+        const scaleAmount = Number.isFinite(behavior.scaleAmount) ? behavior.scaleAmount : 0.08;
+        const emissive = projectile.ammo.emissiveIntensity ?? 1;
+        material.emissiveIntensity = Math.max(0, emissive * (1 + Math.sin(projectile.age * speed) * flicker));
+        const scaleJitter = 1 + Math.sin(projectile.age * (speed * 0.6)) * scaleAmount;
+        projectile.mesh.scale.set(
+          projectile.baseScale.x * scaleJitter,
+          projectile.baseScale.y,
+          projectile.baseScale.z * scaleJitter,
+        );
+        break;
+      }
+      default:
+        break;
     }
   }
 }

--- a/viewer/terra/TerraHUD.js
+++ b/viewer/terra/TerraHUD.js
@@ -1,0 +1,325 @@
+import { HUD as BaseHUD } from '../sandbox/HUD.js';
+
+const OVERLAY_STYLE = `
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+  color: #eef6ff;
+  text-shadow: 0 0 22px rgba(7, 24, 44, 0.7);
+  z-index: 2;
+`;
+
+const CENTER_GROUP_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 320px;
+  height: 320px;
+  transform: translate(-50%, -50%);
+`;
+
+const RETICLE_RING_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 240px;
+  height: 240px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2px solid rgba(160, 210, 255, 0.4);
+  box-shadow: 0 0 34px rgba(10, 40, 80, 0.35) inset, 0 0 32px rgba(125, 200, 255, 0.35);
+  backdrop-filter: blur(9px);
+`;
+
+const RETICLE_CORE_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 52px;
+  height: 52px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 0 26px rgba(140, 220, 255, 0.55);
+  background: radial-gradient(circle, rgba(140, 220, 255, 0.25) 0%, rgba(10, 40, 68, 0.6) 75%);
+`;
+
+const RETICLE_LINE_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 240px;
+  height: 2px;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(200, 240, 255, 0.9) 50%, rgba(255, 255, 255, 0) 100%);
+`;
+
+const RETICLE_LINE_VERTICAL_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 240px;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(200, 240, 255, 0.9) 50%, rgba(255, 255, 255, 0) 100%);
+`;
+
+const THROTTLE_RING_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 260px;
+  height: 260px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  filter: drop-shadow(0 0 22px rgba(12, 34, 58, 0.6));
+  mask: radial-gradient(circle at center, transparent 64%, rgba(0, 0, 0, 0.8) 68%, rgba(0, 0, 0, 0.8) 100%);
+  -webkit-mask: radial-gradient(circle at center, transparent 64%, rgba(0, 0, 0, 0.8) 68%, rgba(0, 0, 0, 0.8) 100%);
+`;
+
+const THROTTLE_TEXT_STYLE = `
+  position: absolute;
+  top: calc(50% + 82px);
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: #7ef9ff;
+`;
+
+const METRIC_STYLE = `
+  position: absolute;
+  padding: 14px 18px;
+  background: linear-gradient(180deg, rgba(16, 36, 68, 0.62) 0%, rgba(8, 18, 32, 0.88) 100%);
+  border-radius: 18px;
+  border: 1px solid rgba(122, 200, 255, 0.28);
+  box-shadow: 0 18px 48px rgba(4, 10, 24, 0.65);
+  backdrop-filter: blur(14px);
+  min-width: 148px;
+  text-align: center;
+`;
+
+const METRIC_TITLE_STYLE = `
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(190, 220, 255, 0.85);
+`;
+
+const METRIC_VALUE_STYLE = `
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-top: 6px;
+  color: #ffffff;
+`;
+
+const CONTROLS_PANEL_STYLE = `
+  position: absolute;
+  bottom: 36px;
+  left: 40px;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px 24px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(14, 32, 58, 0.78) 0%, rgba(8, 18, 32, 0.92) 100%);
+  box-shadow: 0 24px 52px rgba(6, 12, 26, 0.65);
+  backdrop-filter: blur(12px);
+  font-size: 14px;
+  pointer-events: none;
+`;
+
+const CONTROLS_TITLE_STYLE = `
+  font-size: 12px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(170, 210, 255, 0.86);
+`;
+
+const MESSAGE_STYLE = `
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 20px 34px;
+  font-size: 26px;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(90deg, rgba(220, 68, 88, 0.9) 0%, rgba(220, 118, 96, 0.85) 100%);
+  border-radius: 18px;
+  box-shadow: 0 28px 64px rgba(200, 60, 60, 0.55);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+`;
+
+const TOOLBAR_STYLE = `
+  position: absolute;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 12px;
+  padding: 16px 22px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(10, 24, 42, 0.82) 0%, rgba(6, 14, 26, 0.94) 100%);
+  border: 1px solid rgba(112, 188, 255, 0.35);
+  box-shadow: 0 26px 60px rgba(5, 12, 26, 0.72);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+  z-index: 4;
+`;
+
+const AMMO_BUTTON_STYLE = `
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px 16px;
+  min-width: 160px;
+  border-radius: 14px;
+  border: 1px solid rgba(120, 200, 255, 0.25);
+  background: rgba(18, 36, 62, 0.65);
+  color: #e9f6ff;
+  font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+`;
+
+const AMMO_BUTTON_ACTIVE_STYLE = `
+  background: rgba(40, 88, 140, 0.78);
+  border-color: rgba(140, 220, 255, 0.85);
+  box-shadow: 0 12px 28px rgba(26, 80, 140, 0.45);
+  transform: translateY(-3px);
+`;
+
+const AMMO_NAME_STYLE = `
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+`;
+
+const AMMO_EFFECT_STYLE = `
+  font-size: 13px;
+  color: rgba(210, 230, 255, 0.86);
+`;
+
+function applyStyle(element, style){
+  element.setAttribute('style', style);
+}
+
+function isElement(node){
+  return typeof HTMLElement !== 'undefined' && node instanceof HTMLElement;
+}
+
+export class TerraHUD extends BaseHUD {
+  constructor({ controls = {}, ammoOptions = [], onAmmoSelect = null } = {}){
+    super({ controls });
+    this.onAmmoSelect = onAmmoSelect;
+    this.selectedAmmoId = null;
+    this.ammoButtons = new Map();
+
+    this._applyTheme();
+    this._createToolbar();
+    this.setAmmoOptions(ammoOptions);
+  }
+
+  _applyTheme(){
+    applyStyle(this.overlay, OVERLAY_STYLE);
+    applyStyle(this.centerGroup, CENTER_GROUP_STYLE);
+    applyStyle(this.reticleRing, RETICLE_RING_STYLE);
+    applyStyle(this.reticleCore, RETICLE_CORE_STYLE);
+    applyStyle(this.throttleRing, THROTTLE_RING_STYLE);
+    applyStyle(this.throttleText, THROTTLE_TEXT_STYLE);
+
+    Array.from(this.centerGroup.children).forEach((node) => {
+      if (!isElement(node)) return;
+      if (node.style?.height === '2px'){
+        applyStyle(node, RETICLE_LINE_STYLE);
+      } else if (node.style?.width === '2px'){
+        applyStyle(node, RETICLE_LINE_VERTICAL_STYLE);
+      }
+    });
+
+    Object.values(this.metrics).forEach(({ wrapper, title, value }) => {
+      applyStyle(wrapper, METRIC_STYLE);
+      applyStyle(title, METRIC_TITLE_STYLE);
+      applyStyle(value, METRIC_VALUE_STYLE);
+    });
+
+    applyStyle(this.controlsPanel, CONTROLS_PANEL_STYLE);
+    applyStyle(this.controlsTitle, CONTROLS_TITLE_STYLE);
+    applyStyle(this.message, MESSAGE_STYLE);
+  }
+
+  _createToolbar(){
+    this.toolbar = document.createElement('div');
+    this.toolbar.id = 'terra-hud-toolbar';
+    applyStyle(this.toolbar, TOOLBAR_STYLE);
+    document.body.appendChild(this.toolbar);
+  }
+
+  setAmmoOptions(options = []){
+    this.ammoButtons.clear();
+    this.toolbar.innerHTML = '';
+    options.forEach((option, index) => {
+      if (!option || !option.id) return;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.ammoId = option.id;
+      applyStyle(button, AMMO_BUTTON_STYLE);
+
+      const name = document.createElement('div');
+      applyStyle(name, AMMO_NAME_STYLE);
+      name.textContent = option.name ?? option.id;
+
+      const effect = document.createElement('div');
+      applyStyle(effect, AMMO_EFFECT_STYLE);
+      effect.textContent = option.effect ?? '';
+
+      button.appendChild(name);
+      button.appendChild(effect);
+      button.addEventListener('click', () => {
+        this._selectAmmo(option.id, false);
+      });
+
+      this.toolbar.appendChild(button);
+      this.ammoButtons.set(option.id, button);
+
+      if (index === 0 && !this.selectedAmmoId){
+        this._selectAmmo(option.id, true);
+      }
+    });
+  }
+
+  setActiveAmmo(id){
+    this._selectAmmo(id, true);
+  }
+
+  _selectAmmo(id, silent){
+    if (!id || !this.ammoButtons.has(id)){
+      return;
+    }
+    if (this.selectedAmmoId === id){
+      if (!silent && typeof this.onAmmoSelect === 'function'){
+        this.onAmmoSelect(id);
+      }
+      return;
+    }
+    this.selectedAmmoId = id;
+    this.ammoButtons.forEach((button, ammoId) => {
+      const active = ammoId === id;
+      const style = `${AMMO_BUTTON_STYLE}${active ? AMMO_BUTTON_ACTIVE_STYLE : ''}`;
+      applyStyle(button, style);
+    });
+    if (!silent && typeof this.onAmmoSelect === 'function'){
+      this.onAmmoSelect(id);
+    }
+  }
+}

--- a/viewer/terra/main.js
+++ b/viewer/terra/main.js
@@ -3,7 +3,7 @@ import { TerraPlaneController, createPlaneMesh } from './PlaneController.js';
 import { CarController, createCarRig } from '../sandbox/CarController.js';
 import { ChaseCamera } from '../sandbox/ChaseCamera.js';
 import { CollisionSystem } from '../sandbox/CollisionSystem.js';
-import { HUD } from '../sandbox/HUD.js';
+import { TerraHUD } from './TerraHUD.js';
 import { TerraProjectileManager } from './Projectiles.js';
 import {
   createRenderer,
@@ -45,6 +45,7 @@ const collisionSystem = new CollisionSystem({ world, crashMargin: 2.4, obstacleP
 
 // 🔧 Standardize on TerraProjectileManager
 const projectileManager = new TerraProjectileManager({ scene });
+const ammoPresets = projectileManager.getAmmoTypes();
 
 const chaseCamera = new ChaseCamera(camera, {
   distance: 82,
@@ -88,7 +89,17 @@ const hudPresets = {
   },
 };
 
-const hud = new HUD({ controls: hudPresets.plane });
+const hud = new TerraHUD({
+  controls: hudPresets.plane,
+  ammoOptions: ammoPresets,
+  onAmmoSelect: (ammoId) => {
+    const accepted = projectileManager.setAmmoType(ammoId);
+    if (!accepted){
+      hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
+    }
+  },
+});
+hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
 
 const SKY_CEILING = 1800;
 const MAX_DEFAULT_VEHICLES = 5;
@@ -817,5 +828,15 @@ window.DriftPursuitTerra = {
   // fire() now uses the active vehicle’s muzzle via TerraProjectileManager
   fire(){
     return fireActiveVehicleProjectile();
+  },
+  setAmmo(ammoId){
+    const accepted = projectileManager.setAmmoType(ammoId);
+    if (accepted){
+      hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
+    }
+    return accepted;
+  },
+  getAmmoTypes(){
+    return projectileManager.getAmmoTypes().map(({ id, name, effect }) => ({ id, name, effect }));
   },
 };


### PR DESCRIPTION
## Summary
- introduce a Terra-specific HUD with refreshed styling and an ammo toolbar for projectile selection
- allow Terra projectiles to switch between configured ammo types with distinct visuals and behaviours
- connect the HUD selections to the projectile manager and expose ammo helpers on the Terra viewer API

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da2b4aa90083299acba0446f384a68