### PR TITLE
Add map selection and explosive ammo to terra sandbox

### DIFF
--- a/viewer/sandbox/CarController.js
+++ b/viewer/sandbox/CarController.js
@@ -24,7 +24,7 @@ export class CarController {
     this.height = 2.1;
     this.armYaw = 0;
     this.armPitch = 0;
-    this.armYawLimit = THREE.MathUtils.degToRad(75);
+    this.armYawLimit = THREE.MathUtils.degToRad(175);
     this.armPitchLimit = THREE.MathUtils.degToRad(48);
     this.armResponse = 10;
     this.currentSteer = 0;

--- a/viewer/sandbox/CollisionSystem.js
+++ b/viewer/sandbox/CollisionSystem.js
@@ -10,6 +10,10 @@ export class CollisionSystem {
     this.obstaclePadding = obstaclePadding;
   }
 
+  setWorld(world){
+    this.world = world;
+  }
+
   evaluate(planeState){
     if (!planeState || !this.world) return { crashed: false };
     const { position } = planeState;

--- a/viewer/terra/PlaneController.js
+++ b/viewer/terra/PlaneController.js
@@ -9,7 +9,7 @@ export class TerraPlaneController extends BasePlaneController {
     this.turretYaw = 0;
     this.turretPitch = 0;
     this.turretAimTarget = { x: 0, y: 0 };
-    this.turretYawLimit = options.turretYawLimit ?? THREE.MathUtils.degToRad(110);
+    this.turretYawLimit = options.turretYawLimit ?? THREE.MathUtils.degToRad(178);
     this.turretPitchLimit = options.turretPitchLimit ?? THREE.MathUtils.degToRad(65);
     this.turretResponse = options.turretResponse ?? 9.5;
     this._turretDidUpdateThisFrame = false;

--- a/viewer/terra/maps.json
+++ b/viewer/terra/maps.json
@@ -1,0 +1,50 @@
+{
+  "default": "aurora-basin",
+  "maps": [
+    {
+      "id": "aurora-basin",
+      "name": "Aurora Basin",
+      "description": "Bright skies over rolling highlands with balanced cover.",
+      "seed": 982451653,
+      "chunkSize": 640,
+      "radius": 3,
+      "environment": {
+        "background": "#90b6ff",
+        "bodyBackground": "linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)",
+        "fog": { "color": "#a4c6ff", "near": 1500, "far": 4200 },
+        "sun": { "position": [-420, 580, 780], "intensity": 1.05, "color": "#ffffff" },
+        "hemisphere": { "skyColor": "#dce9ff", "groundColor": "#2b4a2e", "intensity": 0.85 }
+      }
+    },
+    {
+      "id": "ember-canyon",
+      "name": "Ember Canyon",
+      "description": "Dusty mesas, warm lighting, and tighter obstacle clusters.",
+      "seed": 147852369,
+      "chunkSize": 620,
+      "radius": 3,
+      "environment": {
+        "background": "#c97d4d",
+        "bodyBackground": "linear-gradient(180deg, #f3b074 0%, #fbe7b6 42%, #ffeeda 100%)",
+        "fog": { "color": "#f2c28a", "near": 1200, "far": 3600 },
+        "sun": { "position": [260, 520, 680], "intensity": 1.2, "color": "#ffd9a0" },
+        "hemisphere": { "skyColor": "#ffe3c2", "groundColor": "#4b2d1a", "intensity": 0.9 }
+      }
+    },
+    {
+      "id": "midnight-fjord",
+      "name": "Midnight Fjord",
+      "description": "Icy fjords at twilight with dramatic elevation changes.",
+      "seed": 369258147,
+      "chunkSize": 700,
+      "radius": 4,
+      "environment": {
+        "background": "#1d2742",
+        "bodyBackground": "linear-gradient(180deg, #1a2642 0%, #1a394f 45%, #1f4f63 100%)",
+        "fog": { "color": "#284666", "near": 900, "far": 3000 },
+        "sun": { "position": [-380, 420, 520], "intensity": 0.95, "color": "#cbe1ff" },
+        "hemisphere": { "skyColor": "#4f6b9a", "groundColor": "#0b1724", "intensity": 0.72 }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add maps.json and async bootstrap to choose maps for the terra sandbox and retheme the scene per map
- refresh the HUD toolbar with a map selector, relocated throttle indicator, and remove the old center reticle
- add an explosive ammo preset, visual impact effects, and broaden turret rotation limits for aircraft and ground rigs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da39fee17c83298f4cef389fe70b21