### PR TITLE
Add tile-map descriptor loading to Terra viewer

### DIFF
--- a/viewer/terra/TileMapWorld.js
+++ b/viewer/terra/TileMapWorld.js
@@ -258,13 +258,46 @@ function createMapObject({ descriptor, chunkSize }){
   const obstacle = type === 'plane'
     ? null
     : {
-      localPosition: center,
+      localPosition: center.clone(),
       radius: Math.max(1, radius),
       topHeight: bounds.max.z,
       baseHeight: bounds.min.z,
       mesh: primaryMesh,
       type,
     };
+
+  if (obstacle){
+    const collision = descriptor.collision && typeof descriptor.collision === 'object' ? descriptor.collision : null;
+    if (collision){
+      if (Array.isArray(collision.offset)){
+        const [offsetX = 0, offsetY = 0, offsetZ = 0] = collision.offset;
+        obstacle.localPosition.add(new THREE.Vector3(offsetX, offsetY, offsetZ));
+        obstacle.topHeight += offsetZ;
+        obstacle.baseHeight += offsetZ;
+      }
+      if (collision.radius != null){
+        const overrideRadius = Number(collision.radius);
+        if (Number.isFinite(overrideRadius)){
+          obstacle.radius = Math.max(0, overrideRadius);
+        }
+      }
+      if (collision.topHeight != null){
+        const overrideTop = Number(collision.topHeight);
+        if (Number.isFinite(overrideTop)){
+          obstacle.topHeight = overrideTop;
+        }
+      }
+      if (collision.baseHeight != null){
+        const overrideBase = Number(collision.baseHeight);
+        if (Number.isFinite(overrideBase)){
+          obstacle.baseHeight = overrideBase;
+        }
+      }
+      if (collision.type){
+        obstacle.type = collision.type;
+      }
+    }
+  }
 
   return { object: holder, disposables, obstacle };
 }


### PR DESCRIPTION
## Summary
- preserve tile-map metadata when loading maps, fetch remote tile-map descriptors, and clone definitions before presenting them in the selector
- initialize Terra tile-map worlds through the TileMapWorld helper while falling back to the streamer for procedural maps
- respect collision overrides on tile-map objects so collision and projectile systems stay in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7a10ebd883299d0cb3a29908ae54