### PR TITLE
Enhance GLTF asset handling and obstacle bounds

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -3815,11 +3815,17 @@ function collectMeshObstacles({ root, chunkWorldOrigin, type, collision } = {}){
       : TMP_OBSTACLE_BOX.min.z;
     obstacles.push({
       mesh: node,
+      meshId: node.uuid,
       radius: Math.max(0, radius),
       worldPosition,
       topHeight,
       baseHeight,
       type: collision?.type || type || 'generic',
+      bounds: {
+        min: TMP_OBSTACLE_BOX.min.clone(),
+        max: TMP_OBSTACLE_BOX.max.clone(),
+        size: TMP_OBSTACLE_SIZE.clone(),
+      },
     });
   });
   return obstacles;

--- a/viewer/terra/glbLoader.js
+++ b/viewer/terra/glbLoader.js
@@ -18,6 +18,9 @@ function normalizeAssetRoot(root){
 function resolveAssetUrl(path, assetRoot){
   if (!path) return null;
   const normalizedPath = String(path).replace(/\\/g, '/').replace(/^\.\//, '');
+  if (/^data:/i.test(normalizedPath)){
+    return normalizedPath;
+  }
   if (/^https?:\/\//i.test(normalizedPath) || normalizedPath.startsWith('/')){
     return normalizedPath;
   }


### PR DESCRIPTION
## Summary
- ensure the shared GLTF loader leaves data URLs untouched while still resolving relative paths against a map asset root
- extend mesh obstacle registration to track mesh UUIDs and bounding box vectors for each loaded GLB/GLTF mesh

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da7a14a6448329b38cdc3342042c15