### PR TITLE
Update Terra map catalog docs and mark legacy manifest

### DIFF
--- a/viewer/assets/maps/manifest.json
+++ b/viewer/assets/maps/manifest.json
@@ -1,4 +1,5 @@
 {
+  "_legacyNote": "Legacy manifest retained for pre-Terra viewers. New content should use viewer/terra/maps.json.",
   "default": "procedural:endless",
   "maps": [
     {


### PR DESCRIPTION
## Summary
- rewrite the Terra map catalog documentation to cover viewer/terra/maps.json, selection flow, and procedural overrides
- mark the legacy viewer/assets/maps/manifest.json sample with an explicit note so creators follow the new pipeline

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68daed287f4c8329a6eced5e03ea36d7