### PR TITLE
Refactor Terra viewer modules for maps, world, HUD, and vehicles

### DIFF
--- a/viewer/terra/hudConfig.js
+++ b/viewer/terra/hudConfig.js
@@ -1,0 +1,71 @@
+export function createHudPresets(){
+  return {
+    plane: {
+      title: 'Spectator (Flight)',
+      throttleLabel: 'THR',
+      metricLabels: {
+        speed: 'Airspeed',
+        crashes: 'Incidents',
+        time: 'Uptime',
+        distance: 'Distance',
+      },
+      items: [
+        { label: 'Cycle', detail: '[ / ] — change player' },
+        { label: 'Focus', detail: 'F — snap to focus' },
+        { label: 'Fire', detail: 'Click / Space — fire turret' },
+      ],
+    },
+    car: {
+      title: 'Spectator (Ground)',
+      throttleLabel: 'PWR',
+      metricLabels: {
+        speed: 'Speed',
+        crashes: 'Incidents',
+        time: 'Uptime',
+        distance: 'Distance',
+      },
+      items: [
+        { label: 'Cycle', detail: '[ / ] — change player' },
+        { label: 'Focus', detail: 'F — snap to focus' },
+        { label: 'Fire', detail: 'Click / Space — fire turret' },
+      ],
+    },
+  };
+}
+
+export function createMapSelectionHandler(onNavigate){
+  return (mapId) => {
+    if (!mapId) return;
+    if (typeof onNavigate === 'function'){
+      onNavigate(mapId);
+      return;
+    }
+    if (typeof window !== 'undefined' && window.location){
+      try {
+        const url = new URL(window.location.href);
+        url.searchParams.set('map', mapId);
+        window.location.href = url.toString();
+      } catch (error){
+        window.location.search = `?map=${encodeURIComponent(mapId)}`;
+      }
+    }
+  };
+}
+
+export function createHud({
+  TerraHUDClass,
+  ammoOptions = [],
+  mapOptions = [],
+  onAmmoSelect,
+  onMapSelect,
+  presets = createHudPresets(),
+} = {}){
+  const hud = new TerraHUDClass({
+    controls: presets.plane,
+    ammoOptions,
+    mapOptions,
+    onAmmoSelect,
+    onMapSelect,
+  });
+  return { hud, presets };
+}

--- a/viewer/terra/main.js
+++ b/viewer/terra/main.js
@@ -1,5 +1,3 @@
-import { TerraWorldStreamer } from './TerraWorldStreamer.js';
-import { TileMapWorld } from './TileMapWorld.js';
 import { TerraPlaneController, createPlaneMesh } from './PlaneController.js';
 import { CarController, createCarRig } from '../sandbox/CarController.js';
 import { ChaseCamera } from '../sandbox/ChaseCamera.js';
@@ -13,17 +11,25 @@ import {
   enableWindowResizeHandling,
   requireTHREE,
 } from '../shared/threeSetup.js';
+import {
+  loadMapDefinitions,
+  selectMapDefinition,
+} from './maps.js';
+import {
+  DEFAULT_WORLD_ENVIRONMENT,
+  initializeWorldForMap,
+} from './worldFactory.js';
+import {
+  createHud,
+  createHudPresets,
+  createMapSelectionHandler,
+} from './hudConfig.js';
+import { createVehicleSystem } from './vehicles.js';
 
 const THREE = requireTHREE();
 
 const MAPS_ENDPOINT = './maps.json';
-const DEFAULT_BODY_BACKGROUND = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)';
-const DEFAULT_BACKGROUND_COLOR = 0x90b6ff;
-const DEFAULT_FOG_COLOR = 0xa4c6ff;
-const DEFAULT_FOG_NEAR = 1500;
-const DEFAULT_FOG_FAR = 4200;
-const DEFAULT_SUN = { color: 0xffffff, intensity: 1.05, position: [-420, 580, 780] };
-const DEFAULT_HEMISPHERE = { skyColor: 0xdce9ff, groundColor: 0x2b4a2e, intensity: 0.85 };
+const DEFAULT_BODY_BACKGROUND = DEFAULT_WORLD_ENVIRONMENT.bodyBackground;
 
 const FALLBACK_MAPS = [
   {
@@ -37,135 +43,20 @@ const FALLBACK_MAPS = [
     environment: {
       background: '#90b6ff',
       bodyBackground: DEFAULT_BODY_BACKGROUND,
-      fog: { color: '#a4c6ff', near: DEFAULT_FOG_NEAR, far: DEFAULT_FOG_FAR },
-      sun: { position: DEFAULT_SUN.position, intensity: DEFAULT_SUN.intensity, color: '#ffffff' },
-      hemisphere: { skyColor: '#dce9ff', groundColor: '#2b4a2e', intensity: DEFAULT_HEMISPHERE.intensity },
+      fog: { color: '#a4c6ff', near: DEFAULT_WORLD_ENVIRONMENT.fog.near, far: DEFAULT_WORLD_ENVIRONMENT.fog.far },
+      sun: {
+        position: DEFAULT_WORLD_ENVIRONMENT.sun.position,
+        intensity: DEFAULT_WORLD_ENVIRONMENT.sun.intensity,
+        color: '#ffffff',
+      },
+      hemisphere: {
+        skyColor: '#dce9ff',
+        groundColor: '#2b4a2e',
+        intensity: DEFAULT_WORLD_ENVIRONMENT.hemisphere.intensity,
+      },
     },
   },
 ];
-
-function cloneEnvironment(environment){
-  if (!environment || typeof environment !== 'object') return null;
-  const clone = { ...environment };
-  if (environment.fog && typeof environment.fog === 'object'){ clone.fog = { ...environment.fog }; }
-  if (environment.sun && typeof environment.sun === 'object'){ clone.sun = { ...environment.sun }; }
-  if (environment.hemisphere && typeof environment.hemisphere === 'object'){
-    clone.hemisphere = { ...environment.hemisphere };
-  }
-  return clone;
-}
-
-function cloneHeightfieldDescriptor(descriptor){
-  if (!descriptor || typeof descriptor !== 'object') return null;
-  const clone = { ...descriptor };
-  if (Array.isArray(descriptor.data)){
-    clone.data = [...descriptor.data];
-  }
-  return clone;
-}
-
-function cloneTileObjects(objects){
-  if (!Array.isArray(objects)) return [];
-  return objects.map((entry) => {
-    if (!entry || typeof entry !== 'object') return entry;
-    return { ...entry };
-  });
-}
-
-function cloneTileDescriptor(tile){
-  if (!tile || typeof tile !== 'object') return tile;
-  const clone = { ...tile };
-  if (Array.isArray(tile.coords)) clone.coords = [...tile.coords];
-  if (Array.isArray(tile.coordinates)) clone.coordinates = [...tile.coordinates];
-  if (tile.heightfield && typeof tile.heightfield === 'object'){
-    clone.heightfield = cloneHeightfieldDescriptor(tile.heightfield);
-  }
-  if (Array.isArray(tile.objects)){
-    clone.objects = cloneTileObjects(tile.objects);
-  }
-  return clone;
-}
-
-function cloneProceduralConfig(config){
-  if (!config || typeof config !== 'object') return null;
-  try {
-    return JSON.parse(JSON.stringify(config));
-  } catch (error){
-    console.warn('Failed to clone procedural configuration', error);
-    return null;
-  }
-}
-
-function cloneMapDescriptor(descriptor){
-  if (!descriptor || typeof descriptor !== 'object') return null;
-  const clone = { ...descriptor };
-  if (descriptor.environment) clone.environment = cloneEnvironment(descriptor.environment);
-  if (descriptor.procedural && typeof descriptor.procedural === 'object'){
-    const proceduralClone = cloneProceduralConfig(descriptor.procedural);
-    if (proceduralClone) clone.procedural = proceduralClone;
-  }
-  if (descriptor.generator && typeof descriptor.generator === 'object'){
-    const generatorClone = cloneProceduralConfig(descriptor.generator);
-    if (generatorClone) clone.generator = generatorClone;
-  }
-  if (Array.isArray(descriptor.tiles)){
-    clone.tiles = descriptor.tiles.map((tile) => cloneTileDescriptor(tile));
-  }
-  if (descriptor.fallback && typeof descriptor.fallback === 'object'){
-    clone.fallback = { ...descriptor.fallback };
-  }
-  return clone;
-}
-
-function cloneMapDefinition(entry){
-  if (!entry || typeof entry !== 'object') return null;
-  const clone = { ...entry };
-  if (clone.environment) clone.environment = cloneEnvironment(clone.environment);
-  if (clone.procedural && typeof clone.procedural === 'object'){
-    const proceduralClone = cloneProceduralConfig(clone.procedural);
-    if (proceduralClone) clone.procedural = proceduralClone;
-    else delete clone.procedural;
-  }
-  if (clone.generator && typeof clone.generator === 'object'){
-    const generatorClone = cloneProceduralConfig(clone.generator);
-    if (generatorClone) clone.generator = generatorClone;
-    else delete clone.generator;
-  }
-  if (Array.isArray(clone.tiles)) clone.tiles = clone.tiles.map((tile) => cloneTileDescriptor(tile));
-  if (clone.descriptor) clone.descriptor = cloneMapDescriptor(clone.descriptor);
-  if (clone.fallback && typeof clone.fallback === 'object') clone.fallback = { ...clone.fallback };
-  return clone;
-}
-
-function mergeTileDescriptor({ mapEntry, descriptor, descriptorUrl }){
-  const merged = cloneMapDescriptor(descriptor) ?? {};
-  if (mapEntry){
-    if (!merged.id && mapEntry.id) merged.id = mapEntry.id;
-    const typeValue = typeof mapEntry.type === 'string' ? mapEntry.type.toLowerCase() : mapEntry.type;
-    if (!merged.type && typeValue) merged.type = typeValue;
-    if (!merged.tileSize && Number.isFinite(mapEntry.tileSize)) merged.tileSize = mapEntry.tileSize;
-    if (!merged.visibleRadius && Number.isFinite(mapEntry.visibleRadius)) merged.visibleRadius = mapEntry.visibleRadius;
-    if (!merged.assetRoot && typeof mapEntry.assetRoot === 'string') merged.assetRoot = mapEntry.assetRoot;
-    if (!Array.isArray(merged.tiles) && Array.isArray(mapEntry.tiles)){
-      merged.tiles = mapEntry.tiles.map((tile) => cloneTileDescriptor(tile));
-    }
-  }
-  if (descriptorUrl){
-    merged.descriptorSource = descriptorUrl.toString();
-    if (typeof merged.assetRoot === 'string' && merged.assetRoot.length > 0){
-      try {
-        const assetUrl = new URL(merged.assetRoot, descriptorUrl);
-        merged.assetRoot = assetUrl.toString();
-      } catch (error){
-        // If URL resolution fails, keep the provided assetRoot as-is.
-      }
-    }
-  }
-  if (!Array.isArray(merged.tiles)){
-    merged.tiles = [];
-  }
-  return merged;
-}
 
 document.body.style.margin = '0';
 document.body.style.overflow = 'hidden';
@@ -174,23 +65,30 @@ document.body.style.background = DEFAULT_BODY_BACKGROUND;
 const renderer = createRenderer();
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(DEFAULT_BACKGROUND_COLOR);
-scene.fog = new THREE.Fog(DEFAULT_FOG_COLOR, DEFAULT_FOG_NEAR, DEFAULT_FOG_FAR);
+scene.background = new THREE.Color(DEFAULT_WORLD_ENVIRONMENT.backgroundColor);
+scene.fog = new THREE.Fog(
+  DEFAULT_WORLD_ENVIRONMENT.fog.color,
+  DEFAULT_WORLD_ENVIRONMENT.fog.near,
+  DEFAULT_WORLD_ENVIRONMENT.fog.far,
+);
 
 const camera = createPerspectiveCamera({ fov: 60, near: 0.1, far: 24000 });
 
 const hemisphere = new THREE.HemisphereLight(
-  DEFAULT_HEMISPHERE.skyColor,
-  DEFAULT_HEMISPHERE.groundColor,
-  DEFAULT_HEMISPHERE.intensity,
+  DEFAULT_WORLD_ENVIRONMENT.hemisphere.skyColor,
+  DEFAULT_WORLD_ENVIRONMENT.hemisphere.groundColor,
+  DEFAULT_WORLD_ENVIRONMENT.hemisphere.intensity,
 );
 scene.add(hemisphere);
 
-const sun = new THREE.DirectionalLight(DEFAULT_SUN.color, DEFAULT_SUN.intensity);
+const sun = new THREE.DirectionalLight(
+  DEFAULT_WORLD_ENVIRONMENT.sun.color,
+  DEFAULT_WORLD_ENVIRONMENT.sun.intensity,
+);
 sun.position.set(
-  DEFAULT_SUN.position[0],
-  DEFAULT_SUN.position[1],
-  DEFAULT_SUN.position[2],
+  DEFAULT_WORLD_ENVIRONMENT.sun.position[0],
+  DEFAULT_WORLD_ENVIRONMENT.sun.position[1],
+  DEFAULT_WORLD_ENVIRONMENT.sun.position[2],
 );
 sun.castShadow = true;
 sun.shadow.mapSize.set(2048, 2048);
@@ -201,10 +99,7 @@ sun.shadow.camera.bottom = -800;
 sun.shadow.camera.far = 2400;
 scene.add(sun);
 
-let world = null;
 const collisionSystem = new CollisionSystem({ world: null, crashMargin: 2.4, obstaclePadding: 3.2 });
-
-// 🔧 Standardize on TerraProjectileManager
 const projectileManager = new TerraProjectileManager({ scene, world: null });
 const ammoPresets = projectileManager.getAmmoTypes();
 
@@ -212,223 +107,7 @@ let availableMaps = [...FALLBACK_MAPS];
 let defaultMapId = FALLBACK_MAPS[0]?.id ?? null;
 let currentMapDefinition = FALLBACK_MAPS[0] ?? null;
 
-function getRequestedMapId(){
-  try {
-    const url = new URL(window.location.href);
-    return url.searchParams.get('map');
-  } catch (error){
-    return null;
-  }
-}
-
-async function loadMapDefinitions(requestedId){
-  try {
-    const options = requestedId ? { headers: { 'X-Active-Map': requestedId } } : {};
-    const response = await fetch(MAPS_ENDPOINT, options);
-    if (!response.ok){
-      throw new Error(`Failed to fetch maps.json: ${response.status}`);
-    }
-    const data = await response.json();
-    const rawMaps = Array.isArray(data?.maps) ? data.maps : Array.isArray(data) ? data : [];
-    const baseUrl = new URL(MAPS_ENDPOINT, window.location.href);
-    const maps = await Promise.all(
-      rawMaps.map(async (entry) => {
-        const mapEntry = cloneMapDefinition(entry);
-        if (!mapEntry) return null;
-
-        const typeValue = typeof mapEntry.type === 'string' ? mapEntry.type.toLowerCase() : mapEntry.type;
-        if (typeValue){
-          mapEntry.type = typeValue;
-        }
-
-        if (mapEntry.type === 'tilemap'){
-          let descriptorUrl = null;
-          if (typeof mapEntry.path === 'string' && mapEntry.path.length > 0){
-            try {
-              descriptorUrl = new URL(mapEntry.path, baseUrl);
-            } catch (urlError){
-              console.warn(`Invalid descriptor path for tile map ${mapEntry.id}`, urlError);
-            }
-          }
-
-          let descriptorSource = mapEntry.descriptor ? cloneMapDescriptor(mapEntry.descriptor) : null;
-
-          if (!descriptorSource && descriptorUrl && typeof fetch === 'function'){
-            try {
-              const descriptorResponse = await fetch(descriptorUrl.toString(), { cache: 'no-cache' });
-              if (!descriptorResponse.ok){
-                console.warn(`Failed to load tile-map descriptor for ${mapEntry.id}: HTTP ${descriptorResponse.status}`);
-              } else {
-                const descriptorData = await descriptorResponse.json();
-                descriptorSource = cloneMapDescriptor(descriptorData);
-              }
-            } catch (descriptorError){
-              console.warn(`Failed to load tile-map descriptor for ${mapEntry.id}`, descriptorError);
-            }
-          }
-
-          if (descriptorSource){
-            const merged = mergeTileDescriptor({ mapEntry, descriptor: descriptorSource, descriptorUrl });
-            mapEntry.descriptor = merged;
-            if (!Array.isArray(mapEntry.tiles) && Array.isArray(merged.tiles)){
-              mapEntry.tiles = merged.tiles.map((tile) => cloneTileDescriptor(tile));
-            }
-            if (!Number.isFinite(mapEntry.tileSize) && Number.isFinite(merged.tileSize)){
-              mapEntry.tileSize = merged.tileSize;
-            }
-            if (!Number.isFinite(mapEntry.visibleRadius) && Number.isFinite(merged.visibleRadius)){
-              mapEntry.visibleRadius = merged.visibleRadius;
-            }
-          } else {
-            mapEntry.descriptor = mergeTileDescriptor({
-              mapEntry,
-              descriptor: { id: mapEntry.id, type: 'tilemap', tiles: Array.isArray(mapEntry.tiles) ? mapEntry.tiles : [] },
-              descriptorUrl,
-            });
-          }
-        }
-
-        return mapEntry;
-      }),
-    );
-    const sanitizedMaps = maps.filter(Boolean);
-    const defaultId = typeof data?.default === 'string' ? data.default : sanitizedMaps[0]?.id ?? null;
-    return { maps: sanitizedMaps, defaultId };
-  } catch (error){
-    console.warn('Falling back to bundled map definitions.', error);
-    return { maps: FALLBACK_MAPS.map((entry) => cloneMapDefinition(entry)), defaultId: defaultMapId };
-  }
-}
-
-function selectMapDefinition(maps, requestedId, fallbackId){
-  const mapList = Array.isArray(maps) && maps.length > 0
-    ? maps.map((entry) => cloneMapDefinition(entry))
-    : FALLBACK_MAPS.map((entry) => cloneMapDefinition(entry));
-  const registry = new Map();
-  mapList.forEach((entry) => {
-    if (entry?.id){
-      registry.set(entry.id, entry);
-    }
-  });
-  let targetId = requestedId && registry.has(requestedId) ? requestedId : null;
-  if (!targetId && fallbackId && registry.has(fallbackId)){
-    targetId = fallbackId;
-  }
-  if (!targetId){
-    targetId = mapList.find((entry) => entry?.id)?.id ?? FALLBACK_MAPS[0]?.id ?? null;
-  }
-  const selected = targetId ? registry.get(targetId) ?? mapList[0] : mapList[0];
-  return { selected, id: selected?.id ?? targetId ?? null, registry, maps: mapList };
-}
-
-function applyMapEnvironment(map){
-  const environment = map?.descriptor?.environment ?? map?.environment ?? {};
-  document.body.style.background = environment.bodyBackground ?? DEFAULT_BODY_BACKGROUND;
-  const background = environment.background ?? DEFAULT_BACKGROUND_COLOR;
-  scene.background = new THREE.Color(background);
-
-  const fogConfig = environment.fog ?? {};
-  scene.fog.color.set(fogConfig.color ?? DEFAULT_FOG_COLOR);
-  scene.fog.near = Number.isFinite(fogConfig.near) ? fogConfig.near : DEFAULT_FOG_NEAR;
-  scene.fog.far = Number.isFinite(fogConfig.far) ? fogConfig.far : DEFAULT_FOG_FAR;
-
-  const hemisphereConfig = environment.hemisphere ?? {};
-  hemisphere.color.set(hemisphereConfig.skyColor ?? DEFAULT_HEMISPHERE.skyColor);
-  hemisphere.groundColor.set(hemisphereConfig.groundColor ?? DEFAULT_HEMISPHERE.groundColor);
-  hemisphere.intensity = Number.isFinite(hemisphereConfig.intensity)
-    ? hemisphereConfig.intensity
-    : DEFAULT_HEMISPHERE.intensity;
-
-  const sunConfig = environment.sun ?? {};
-  sun.color.set(sunConfig.color ?? DEFAULT_SUN.color);
-  sun.intensity = Number.isFinite(sunConfig.intensity) ? sunConfig.intensity : DEFAULT_SUN.intensity;
-  if (sunConfig.position){
-    assignVector3(sun.position, sunConfig.position);
-  } else {
-    sun.position.set(DEFAULT_SUN.position[0], DEFAULT_SUN.position[1], DEFAULT_SUN.position[2]);
-  }
-}
-
-function initializeWorldForMap(map){
-  const mapDefinition = map ? cloneMapDefinition(map) : cloneMapDefinition(FALLBACK_MAPS[0]);
-  if (world){
-    collisionSystem.setWorld(null);
-    projectileManager.setWorld(null);
-    world.dispose();
-  }
-  let descriptor = null;
-  if (mapDefinition?.descriptor && typeof mapDefinition.descriptor === 'object'){
-    descriptor = cloneMapDescriptor(mapDefinition.descriptor);
-    descriptor.id = descriptor.id ?? mapDefinition.id;
-    descriptor.type = descriptor.type ?? mapDefinition.type;
-    if (!descriptor.tileSize && Number.isFinite(mapDefinition.tileSize)){
-      descriptor.tileSize = mapDefinition.tileSize;
-    }
-    if (!descriptor.visibleRadius){
-      const fallbackRadius = Number.isFinite(mapDefinition.visibleRadius)
-        ? mapDefinition.visibleRadius
-        : Number.isFinite(mapDefinition.radius)
-          ? mapDefinition.radius
-          : null;
-      if (Number.isFinite(fallbackRadius)){
-        descriptor.visibleRadius = fallbackRadius;
-      }
-    }
-  } else if (mapDefinition?.type === 'tilemap'){
-    descriptor = { ...mapDefinition };
-  }
-
-  const descriptorType = typeof descriptor?.type === 'string' ? descriptor.type.toLowerCase() : descriptor?.type;
-  if (descriptorType === 'tilemap'){
-    descriptor.type = 'tilemap';
-    descriptor.tiles = Array.isArray(descriptor.tiles)
-      ? descriptor.tiles.map((tile) => cloneTileDescriptor(tile))
-      : Array.isArray(mapDefinition?.tiles)
-        ? mapDefinition.tiles.map((tile) => cloneTileDescriptor(tile))
-        : [];
-    if (!descriptor.tileSize){
-      descriptor.tileSize = Number.isFinite(mapDefinition?.tileSize)
-        ? mapDefinition.tileSize
-        : Number.isFinite(mapDefinition?.chunkSize)
-          ? mapDefinition.chunkSize
-          : 640;
-    }
-    if (Number.isFinite(descriptor.visibleRadius)){
-      mapDefinition.visibleRadius = descriptor.visibleRadius;
-    }
-    mapDefinition.tiles = descriptor.tiles.map((tile) => cloneTileDescriptor(tile));
-    mapDefinition.tileSize = descriptor.tileSize;
-    world = new TileMapWorld({ scene, descriptor });
-  } else {
-    if (!mapDefinition.procedural && descriptor?.procedural){
-      const descriptorProcedural = cloneProceduralConfig(descriptor.procedural);
-      if (descriptorProcedural) mapDefinition.procedural = descriptorProcedural;
-    }
-    const chunkSize = Number.isFinite(mapDefinition?.chunkSize)
-      ? mapDefinition.chunkSize
-      : Number.isFinite(descriptor?.chunkSize)
-        ? descriptor.chunkSize
-        : 640;
-    const radius = Number.isFinite(mapDefinition?.radius)
-      ? mapDefinition.radius
-      : Number.isFinite(descriptor?.radius)
-        ? descriptor.radius
-        : 3;
-    const seed = Number.isFinite(mapDefinition?.seed) ? mapDefinition.seed : 982451653;
-    const generatorConfig = mapDefinition?.procedural
-      ?? mapDefinition?.generator
-      ?? descriptor?.procedural
-      ?? descriptor?.generator
-      ?? null;
-    world = new TerraWorldStreamer({ scene, chunkSize, radius, seed, generator: generatorConfig });
-  }
-  collisionSystem.setWorld(world);
-  projectileManager.setWorld(world);
-  applyMapEnvironment(mapDefinition);
-  currentMapDefinition = mapDefinition;
-}
-
-function handleMapSelect(mapId){
+const mapSelectionHandler = createMapSelectionHandler((mapId) => {
   if (!mapId) return;
   if (currentMapDefinition?.id === mapId) return;
   try {
@@ -438,7 +117,23 @@ function handleMapSelect(mapId){
   } catch (error){
     window.location.search = `?map=${encodeURIComponent(mapId)}`;
   }
-}
+});
+
+const hudPresets = createHudPresets();
+const { hud } = createHud({
+  TerraHUDClass: TerraHUD,
+  ammoOptions: ammoPresets,
+  mapOptions: availableMaps,
+  onAmmoSelect: (ammoId) => {
+    const accepted = projectileManager.setAmmoType(ammoId);
+    if (!accepted){
+      hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
+    }
+  },
+  onMapSelect: mapSelectionHandler,
+  presets: hudPresets,
+});
+hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
 
 const chaseCamera = new ChaseCamera(camera, {
   distance: 82,
@@ -448,53 +143,6 @@ const chaseCamera = new ChaseCamera(camera, {
   forwardResponsiveness: 5.1,
   pitchInfluence: 0.36,
 });
-
-const hudPresets = {
-  plane: {
-    title: 'Spectator (Flight)',
-    throttleLabel: 'THR',
-    metricLabels: {
-      speed: 'Airspeed',
-      crashes: 'Incidents',
-      time: 'Uptime',
-      distance: 'Distance',
-    },
-    items: [
-      { label: 'Cycle', detail: '[ / ] — change player' },
-      { label: 'Focus', detail: 'F — snap to focus' },
-      { label: 'Fire', detail: 'Click / Space — fire turret' },
-    ],
-  },
-  car: {
-    title: 'Spectator (Ground)',
-    throttleLabel: 'PWR',
-    metricLabels: {
-      speed: 'Speed',
-      crashes: 'Incidents',
-      time: 'Uptime',
-      distance: 'Distance',
-    },
-    items: [
-      { label: 'Cycle', detail: '[ / ] — change player' },
-      { label: 'Focus', detail: 'F — snap to focus' },
-      { label: 'Fire', detail: 'Click / Space — fire turret' },
-    ],
-  },
-};
-
-const hud = new TerraHUD({
-  controls: hudPresets.plane,
-  ammoOptions: ammoPresets,
-  mapOptions: availableMaps,
-  onAmmoSelect: (ammoId) => {
-    const accepted = projectileManager.setAmmoType(ammoId);
-    if (!accepted){
-      hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
-    }
-  },
-  onMapSelect: handleMapSelect,
-});
-hud.setActiveAmmo(projectileManager.getCurrentAmmoId());
 
 const SKY_CEILING = 1800;
 const MAX_DEFAULT_VEHICLES = 5;
@@ -521,25 +169,33 @@ const input = new TerraInputManager();
 const LOCAL_PLAYER_ID = 'pilot-local';
 const ORIGIN_FALLBACK = new THREE.Vector3(0, 0, 0);
 
-const vehicles = new Map();
-let activeVehicleId = null;
+const worldRef = { current: null };
 
-const trackedVehicles = [];
+const vehicleSystem = createVehicleSystem({
+  THREE,
+  scene,
+  chaseCamera,
+  hud,
+  hudPresets,
+  projectileManager,
+  collisionSystem,
+  getWorld: () => worldRef.current,
+  localPlayerId: LOCAL_PLAYER_ID,
+  planeCameraConfig,
+  carCameraConfig,
+  maxDefaultVehicles: MAX_DEFAULT_VEHICLES,
+  skyCeiling: SKY_CEILING,
+  createPlaneMesh,
+  createPlaneController: () => new TerraPlaneController(),
+  createCarRig,
+  createCarController: () => new CarController(),
+});
 
 const FIRE_COOLDOWN = 0.35;
 const MIN_FAILED_FIRE_DELAY = 0.12;
 const activeFireSources = new Set();
 let fireInputHeld = false;
 let fireCooldownTimer = 0;
-
-function updateTrackedVehicles(){
-  trackedVehicles.length = 0;
-  for (const [id, vehicle] of vehicles.entries()){
-    const state = getVehicleState(vehicle);
-    if (!state) continue;
-    trackedVehicles.push({ id, mode: vehicle.mode, state });
-  }
-}
 
 function setFireSourceActive(source, active){
   if (!source) return;
@@ -556,585 +212,139 @@ function resetFireInput(){
   fireInputHeld = false;
 }
 
-function getVehicleState(vehicle){
-  if (!vehicle) return null;
-  const modeState = vehicle.modes[vehicle.mode];
-  if (!modeState) return null;
-  if (typeof modeState.controller?.getState !== 'function') return null;
-  return modeState.controller.getState();
-}
-
-function ensureVehicleVisibility(vehicle){
-  if (!vehicle) return;
-  const { plane, car } = vehicle.modes;
-  if (plane?.mesh) plane.mesh.visible = vehicle.mode === 'plane';
-  if (car?.rig?.carMesh) car.rig.carMesh.visible = vehicle.mode === 'car';
-}
-
-function switchVehicleMode(vehicle, mode){
-  if (!vehicle || !mode) return;
-  if (vehicle.mode === mode) return;
-  if (!vehicle.modes?.[mode]) return;
-  vehicle.mode = mode;
-  ensureVehicleVisibility(vehicle);
-  if (vehicle.id === activeVehicleId){
-    applyHudControls(vehicle);
-    focusCameraOnVehicle(vehicle);
+function getRequestedMapId(){
+  try {
+    const url = new URL(window.location.href);
+    return url.searchParams.get('map');
+  } catch (error){
+    return null;
   }
 }
 
-function applyHudControls(vehicle){
-  if (!vehicle) return;
-  const preset = hudPresets[vehicle.mode] ?? hudPresets.plane;
-  hud.setControls(preset);
-}
+enableWindowResizeHandling({ renderer, camera });
 
-function assignVector3(target, source){
-  if (!target || source == null) return;
-  if (Array.isArray(source) && source.length >= 3){
-    target.set(source[0], source[1], source[2]);
-    return;
-  }
-  const { x, y, z } = source;
-  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number'){
-    target.set(x, y, z);
-    return;
-  }
-  if (typeof x === 'number') target.x = x;
-  if (typeof y === 'number') target.y = y;
-  if (typeof z === 'number') target.z = z;
-}
+function animate(now){
+  requestAnimationFrame(animate);
+  const dt = Math.min(0.08, (now - animate.lastTime) / 1000 || 0);
+  animate.lastTime = now;
+  animate.elapsedTime = (animate.elapsedTime ?? 0) + dt;
 
-function assignQuaternion(target, source){
-  if (!target || source == null) return;
-  if (Array.isArray(source) && source.length >= 4){
-    target.set(source[0], source[1], source[2], source[3]);
-    return;
-  }
-  const { x, y, z, w } = source;
-  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number' && typeof w === 'number'){
-    target.set(x, y, z, w);
-    return;
-  }
-  if (typeof x === 'number') target.x = x;
-  if (typeof y === 'number') target.y = y;
-  if (typeof z === 'number') target.z = z;
-  if (typeof w === 'number') target.w = w;
-}
-
-function syncControllerVisual(controller){
-  if (!controller) return;
-  if (controller.mesh){
-    controller.mesh.position.copy(controller.position);
-    controller.mesh.quaternion.copy(controller.orientation);
-  }
-}
-
-function clampPlaneAltitude(controller, ground){
-  if (!controller) return;
-  const minAltitude = ground + 16;
-  if (controller.position.z < minAltitude){
-    controller.position.z = minAltitude;
-    if (controller.velocity.z < 0) controller.velocity.z = 0;
-  }
-  if (controller.position.z > SKY_CEILING){
-    controller.position.z = SKY_CEILING;
-    if (controller.velocity.z > 0) controller.velocity.z = 0;
-  }
-}
-
-function computeSpawnTransform(index){
-  const angle = index * (Math.PI * 2 / Math.max(1, MAX_DEFAULT_VEHICLES));
-  const radius = 420 + (index % 3) * 60;
-  const x = Math.cos(angle) * radius;
-  const y = Math.sin(angle) * radius;
-  const ground = world.getHeightAt(x, y);
-  const planePos = new THREE.Vector3(x, y, ground + 60 + (index % 2) * 12);
-  const carPos = new THREE.Vector3(x + 28, y - 28, ground + 2.6);
-  const yaw = angle + Math.PI / 2;
-  return {
-    plane: { position: planePos, yaw },
-    car: { position: carPos, yaw },
-  };
-}
-
-function createVehicleEntry(id, { isBot = false, initialMode = 'plane', spawnIndex = vehicles.size } = {}){
-  const transform = computeSpawnTransform(spawnIndex);
-
-  const planeMesh = createPlaneMesh();
-  scene.add(planeMesh);
-
-  const planeController = new TerraPlaneController();
-  planeController.attachMesh(planeMesh, {
-    turretYawGroup: planeMesh.userData?.turretYawGroup,
-    turretPitchGroup: planeMesh.userData?.turretPitchGroup,
-    stickYaw: planeMesh.userData?.turretStickYaw,
-    stickPitch: planeMesh.userData?.turretStickPitch,
-  });
-  planeController.reset({
-    position: transform.plane.position,
-    yaw: transform.plane.yaw,
-    pitch: THREE.MathUtils.degToRad(4),
-    throttle: 0.46,
+  const inputSample = input.readState(dt);
+  const { activeVehicle, activeState, hudData } = vehicleSystem.update({
+    dt,
+    elapsedTime: animate.elapsedTime,
+    inputSample,
   });
 
-  const carRig = createCarRig();
-  scene.add(carRig.carMesh);
+  fireCooldownTimer = Math.max(0, fireCooldownTimer - dt);
+  if (fireInputHeld && fireCooldownTimer <= 0){
+    const fired = vehicleSystem.fireActiveVehicleProjectile();
+    fireCooldownTimer = fired ? FIRE_COOLDOWN : MIN_FAILED_FIRE_DELAY;
+  }
 
-  const carController = new CarController();
-  carController.attachMesh(carRig.carMesh, {
-    stickYaw: carRig.stickYaw,
-    stickPitch: carRig.stickPitch,
-    towerGroup: carRig.towerGroup,
-    towerHead: carRig.towerHead,
-    wheels: carRig.wheels,
-  });
-  carController.reset({
-    position: transform.car.position,
-    yaw: transform.car.yaw,
-  });
-
-  const entry = {
-    id,
-    isBot,
-    mode: initialMode,
-    modes: {
-      plane: {
-        controller: planeController,
-        mesh: planeMesh,
-        cameraConfig: planeCameraConfig,
-        muzzle: planeMesh.userData?.turretMuzzle ?? null,
-      },
-      car: {
-        controller: carController,
-        rig: carRig,
-        cameraConfig: carCameraConfig,
-        muzzle: carRig.carMesh.userData?.turretMuzzle ?? null,
-      },
+  projectileManager.update(dt, {
+    vehicles: vehicleSystem.getVehicles(),
+    onVehicleHit: (vehicle, projectile) => {
+      vehicleSystem.handleProjectileHit(vehicle, projectile);
     },
-    stats: {
-      crashCount: 0,
-      elapsed: 0,
-      distance: 0,
-      throttle: 0,
-      speed: 0,
-      lastPosition: transform.plane.position.clone(),
-    },
-    behaviorSeed: Math.random() * Math.PI * 2,
-    spawnTransform: {
-      plane: {
-        position: transform.plane.position.clone(),
-        yaw: transform.plane.yaw,
-      },
-      car: {
-        position: transform.car.position.clone(),
-        yaw: transform.car.yaw,
-      },
-    },
-  };
-
-  vehicles.set(id, entry);
-  ensureVehicleVisibility(entry);
-  const initialState = getVehicleState(entry);
-  if (initialState?.position){
-    entry.stats.lastPosition.copy(initialState.position);
-    if (Number.isFinite(initialState.throttle)){
-      entry.stats.throttle = initialState.throttle;
-    }
-    if (Number.isFinite(initialState.speed)){
-      entry.stats.speed = initialState.speed;
-    }
-  }
-  return entry;
-}
-
-function removeVehicle(id){
-  const entry = vehicles.get(id);
-  if (!entry) return;
-  projectileManager.clearByOwner(id);
-  if (entry.modes.plane?.mesh){
-    scene.remove(entry.modes.plane.mesh);
-  }
-  if (entry.modes.car?.rig?.carMesh){
-    scene.remove(entry.modes.car.rig.carMesh);
-  }
-  vehicles.delete(id);
-  if (activeVehicleId === id){
-    activeVehicleId = null;
-  }
-}
-
-function countRealPlayers(){
-  let count = 0;
-  for (const vehicle of vehicles.values()){
-    if (!vehicle.isBot) count += 1;
-  }
-  return count;
-}
-
-function selectActiveVehicle(preferredId = null){
-  const previous = activeVehicleId;
-  if (preferredId && vehicles.has(preferredId)){
-    activeVehicleId = preferredId;
-  } else if (activeVehicleId && vehicles.has(activeVehicleId)){
-    // keep current selection
-  } else {
-    let fallback = null;
-    for (const [id, vehicle] of vehicles.entries()){
-      if (!vehicle.isBot){
-        activeVehicleId = id;
-        fallback = null;
-        break;
+    onImpact: (impact) => {
+      if (worldRef.current && typeof worldRef.current.applyProjectileImpact === 'function'){
+        worldRef.current.applyProjectileImpact(impact);
       }
-      if (!fallback) fallback = id;
-    }
-    if (!vehicles.has(activeVehicleId) && fallback){
-      activeVehicleId = fallback;
-    }
-  }
-
-  if (activeVehicleId && !vehicles.has(activeVehicleId)){
-    activeVehicleId = null;
-  }
-  if (previous !== activeVehicleId){
-    const nextVehicle = activeVehicleId ? vehicles.get(activeVehicleId) : null;
-    if (nextVehicle){
-      focusCameraOnVehicle(nextVehicle);
-    }
-  }
-}
-
-function setActiveVehicle(id){
-  if (!id || !vehicles.has(id)) return;
-  if (activeVehicleId === id) return;
-  activeVehicleId = id;
-  focusCameraOnVehicle(vehicles.get(activeVehicleId));
-}
-
-function removeOneBot(){
-  for (const [id, vehicle] of vehicles.entries()){
-    if (vehicle.isBot){
-      removeVehicle(id);
-      return true;
-    }
-  }
-  return false;
-}
-
-function spawnDefaultVehicles(){
-  for (let i = 0; i < MAX_DEFAULT_VEHICLES; i += 1){
-    const id = `bot-${i + 1}`;
-    if (vehicles.has(id)) continue;
-    const vehicle = createVehicleEntry(id, { isBot: true, spawnIndex: i });
-    vehicle.mode = 'plane';
-    ensureVehicleVisibility(vehicle);
-  }
-  selectActiveVehicle();
-}
-
-function handlePlayerJoin(id, options = {}){
-  if (!id) return;
-  if (vehicles.has(id)) return;
-  const vehicle = createVehicleEntry(id, { isBot: !!options.isBot, initialMode: options.initialMode ?? 'plane' });
-  if (!vehicle.isBot){
-    removeOneBot();
-    setActiveVehicle(id);
-  } else {
-    selectActiveVehicle();
-  }
-  ensureVehicleVisibility(vehicle);
-}
-
-function handlePlayerLeave(id){
-  if (!id) return;
-  const existed = vehicles.has(id);
-  removeVehicle(id);
-  if (vehicles.size === 0){
-    spawnDefaultVehicles();
-  } else if (existed){
-    selectActiveVehicle();
-  }
-}
-
-function resetVehicleStats(vehicle){
-  const state = getVehicleState(vehicle);
-  if (!state) return;
-  vehicle.stats.elapsed = 0;
-  vehicle.stats.distance = 0;
-  vehicle.stats.lastPosition.copy(state.position);
-  vehicle.stats.crashCount = 0;
-}
-
-function registerVehicleCrash(vehicle, { message = 'Impact detected' } = {}){
-  if (!vehicle) return;
-  if (vehicle.stats){
-    vehicle.stats.crashCount = (vehicle.stats.crashCount ?? 0) + 1;
-  }
-  if (message){
-    hud.showMessage(message);
-  }
-  if (vehicle.id === activeVehicleId){
-    focusCameraOnVehicle(vehicle);
-  }
-}
-
-function resetCarAfterCrash(vehicle){
-  if (!vehicle) return;
-  const spawn = vehicle.spawnTransform?.car;
-  const carMode = vehicle.modes?.car;
-  if (!spawn || !carMode?.controller) return;
-  carMode.controller.reset({ position: spawn.position, yaw: spawn.yaw });
-  syncControllerVisual(carMode.controller);
-  if (vehicle.stats){
-    if (vehicle.stats.lastPosition){
-      vehicle.stats.lastPosition.copy(carMode.controller.position);
-    } else {
-      vehicle.stats.lastPosition = carMode.controller.position.clone();
-    }
-    vehicle.stats.speed = 0;
-    vehicle.stats.throttle = 0;
-  }
-}
-
-function handleProjectileHit(vehicle, projectile){
-  if (!vehicle) return;
-  if (projectile?.mesh?.position){
-    projectileManager.triggerExplosion({
-      position: projectile.mesh.position.clone(),
-      ammoId: projectile.ammo?.id ?? null,
-    });
-  }
-  registerVehicleCrash(vehicle, { message: 'Direct hit!' });
-  if (vehicle.mode === 'car'){
-    resetCarAfterCrash(vehicle);
-  }
-}
-
-// 🔧 Unified firing uses projectileManager
-function fireActiveVehicleProjectile(){
-  if (!activeVehicleId) return false;
-  const vehicle = vehicles.get(activeVehicleId);
-  if (!vehicle) return false;
-  const modeName = vehicle.mode;
-  const mode = vehicle.modes?.[modeName];
-  if (!mode) return false;
-
-  let muzzle = null;
-  let controller = mode.controller ?? null;
-
-  if (modeName === 'plane'){
-    muzzle = mode.mesh?.userData?.turretMuzzle ?? mode.muzzle ?? null;
-  } else if (modeName === 'car'){
-    const carMesh = mode.rig?.carMesh ?? null;
-    muzzle = carMesh?.userData?.turretMuzzle ?? mode.muzzle ?? null;
-  }
-
-  if (!muzzle) return false;
-
-  const inheritVelocity = controller?.velocity ?? null;
-  const projectile = projectileManager.spawnFromMuzzle(muzzle, {
-    ownerId: vehicle.id,
-    inheritVelocity,
-  });
-  return !!projectile;
-}
-
-function updateVehicleStats(vehicle, dt){
-  const state = getVehicleState(vehicle);
-  if (!state) return;
-  const stats = vehicle.stats;
-  if (!stats) return;
-  stats.elapsed += dt;
-  stats.throttle = state.throttle ?? stats.throttle;
-  stats.speed = state.speed ?? stats.speed;
-  if (stats.lastPosition){
-    stats.distance += state.position.distanceTo(stats.lastPosition);
-    stats.lastPosition.copy(state.position);
-  } else {
-    stats.lastPosition = state.position.clone();
-  }
-}
-
-function updatePlaneBot(vehicle, dt, elapsedTime){
-  const controller = vehicle.modes.plane.controller;
-  if (!controller) return;
-  const oscillation = elapsedTime * 0.35 + vehicle.behaviorSeed;
-  const input = {
-    pitch: Math.sin(oscillation * 0.9) * 0.24,
-    yaw: 0.14 + Math.sin(oscillation * 0.35) * 0.06,
-    roll: Math.sin(oscillation * 0.65) * 0.42,
-    throttleAdjust: Math.sin(oscillation * 0.18) * 0.05,
-    brake: false,
-    aim: {
-      x: Math.sin(oscillation * 0.52) * 0.65,
-      y: Math.cos(oscillation * 0.41) * 0.5,
     },
-  };
-  controller.update(dt, input, {
-    clampAltitude: clampPlaneAltitude,
-    sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
   });
-}
 
-function updateCarBot(vehicle, dt, elapsedTime){
-  const controller = vehicle.modes.car.controller;
-  if (!controller) return;
-  const oscillation = elapsedTime * 0.6 + vehicle.behaviorSeed;
-  const input = {
-    throttle: 0.4 + Math.sin(oscillation) * 0.35,
-    steer: Math.sin(oscillation * 0.7) * 0.65,
-    brake: false,
-    aim: {
-      x: Math.sin(oscillation * 1.1) * 0.5,
-      y: Math.cos(oscillation * 0.9) * 0.35,
-    },
-  };
-  controller.update(dt, input, {
-    sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
+  if (activeVehicle && activeState){
+    const mode = activeVehicle.modes[activeVehicle.mode];
+    const cameraConfig = mode?.cameraConfig ?? planeCameraConfig;
+    chaseCamera.setConfig(cameraConfig);
+    chaseCamera.update(activeState, dt, inputSample?.cameraOrbit ?? null);
+    worldRef.current?.update?.(activeState.position);
+  } else if (worldRef.current){
+    worldRef.current.update(ORIGIN_FALLBACK);
+  }
+
+  hud.update(hudData);
+
+  renderer.render(scene, camera);
+}
+animate.lastTime = performance.now();
+animate.elapsedTime = 0;
+
+async function bootstrap(){
+  const requestedId = getRequestedMapId();
+  const origin = typeof window !== 'undefined' ? window.location.href : undefined;
+  const fetchFn = typeof fetch === 'function' ? fetch : null;
+  const definition = await loadMapDefinitions({
+    endpoint: MAPS_ENDPOINT,
+    requestedId,
+    fetchFn,
+    fallbackMaps: FALLBACK_MAPS,
+    fallbackDefaultId: defaultMapId,
+    origin,
   });
-}
 
-function updateLocalVehicle(vehicle, dt, inputSample){
-  if (!vehicle) return;
-  const modeRequest = inputSample?.modeRequest;
-  if (modeRequest && vehicle.modes?.[modeRequest]){
-    switchVehicleMode(vehicle, modeRequest);
-    if (vehicle.id === LOCAL_PLAYER_ID && activeVehicleId !== LOCAL_PLAYER_ID){
-      setActiveVehicle(LOCAL_PLAYER_ID);
-    }
-  }
+  availableMaps = Array.isArray(definition.maps) && definition.maps.length
+    ? definition.maps
+    : [...FALLBACK_MAPS];
+  defaultMapId = definition.defaultId ?? availableMaps[0]?.id ?? defaultMapId;
 
-  const currentMode = vehicle.mode;
-  if (currentMode === 'plane'){
-    const controller = vehicle.modes.plane.controller;
-    if (!controller) return;
-    const planeInput = inputSample?.plane ?? {};
-    controller.update(dt, {
-      pitch: planeInput.pitch ?? 0,
-      roll: planeInput.roll ?? 0,
-      yaw: planeInput.yaw ?? 0,
-      throttleAdjust: planeInput.throttleAdjust ?? 0,
-      brake: planeInput.brake ?? false,
-      aim: planeInput.aim ?? { x: 0, y: 0 },
-    }, {
-      clampAltitude: clampPlaneAltitude,
-      sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
-    });
-  } else if (currentMode === 'car'){
-    const controller = vehicle.modes.car.controller;
-    if (!controller) return;
-    const carInput = inputSample?.car ?? {};
-    controller.update(dt, {
-      throttle: carInput.throttle ?? 0,
-      steer: carInput.steer ?? 0,
-      brake: carInput.brake ?? false,
-      aim: carInput.aim ?? { x: 0, y: 0 },
-    }, {
-      sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
-    });
-  }
-}
+  const selection = selectMapDefinition({
+    maps: availableMaps,
+    requestedId,
+    fallbackId: defaultMapId,
+    fallbackMaps: FALLBACK_MAPS,
+  });
 
-function updateVehicleController(vehicle, dt, elapsedTime, inputSample){
-  if (!vehicle) return;
-  if (vehicle.isBot){
-    if (vehicle.mode === 'plane'){
-      updatePlaneBot(vehicle, dt, elapsedTime);
-    } else {
-      updateCarBot(vehicle, dt, elapsedTime);
-    }
-  } else if (vehicle.id === LOCAL_PLAYER_ID){
-    updateLocalVehicle(vehicle, dt, inputSample);
-  }
-}
+  availableMaps = selection.maps;
+  defaultMapId = selection.id ?? defaultMapId;
+  currentMapDefinition = selection.selected ?? availableMaps[0] ?? FALLBACK_MAPS[0];
 
-function stepVehicleAttachments(vehicle, dt){
-  if (!vehicle) return;
-  const plane = vehicle.modes?.plane;
-  if (plane?.controller?.stepTurretAim){
-    plane.controller.stepTurretAim(dt);
-  }
-}
+  hud.setMapOptions(availableMaps);
+  hud.setActiveMap(currentMapDefinition?.id ?? '');
 
-function applyVehicleSnapshot(id, snapshot = {}){
-  const vehicle = vehicles.get(id);
-  if (!vehicle) return;
-  if (snapshot.mode && vehicle.modes[snapshot.mode]){
-    vehicle.mode = snapshot.mode;
-    ensureVehicleVisibility(vehicle);
-    if (activeVehicleId === id){
-      applyHudControls(vehicle);
-    }
-  }
+  const worldResult = initializeWorldForMap({
+    scene,
+    mapDefinition: currentMapDefinition,
+    currentWorld: worldRef.current,
+    collisionSystem,
+    projectileManager,
+    environment: { document, hemisphere, sun },
+  });
+  worldRef.current = worldResult.world;
+  currentMapDefinition = worldResult.mapDefinition ?? currentMapDefinition;
 
-  const mode = vehicle.modes[vehicle.mode];
-  if (!mode) return;
-  const controller = mode.controller;
-  if (!controller) return;
+  vehicleSystem.spawnDefaultVehicles();
+  vehicleSystem.handlePlayerJoin(LOCAL_PLAYER_ID, { initialMode: 'plane' });
 
-  if (snapshot.position) assignVector3(controller.position, snapshot.position);
-  if (snapshot.velocity) assignVector3(controller.velocity, snapshot.velocity);
-  if (snapshot.orientation) assignQuaternion(controller.orientation, snapshot.orientation);
-  if (typeof snapshot.speed === 'number') controller.speed = snapshot.speed;
-  if (typeof snapshot.throttle === 'number') controller.throttle = snapshot.throttle;
-  if (typeof snapshot.targetThrottle === 'number') controller.targetThrottle = snapshot.targetThrottle;
+  const initialVehicle = vehicleSystem.getActiveVehicle()
+    ?? vehicleSystem.getVehicles().get(LOCAL_PLAYER_ID)
+    ?? vehicleSystem.getVehicles().values().next().value
+    ?? null;
 
-  const planeMode = vehicle.modes?.plane;
-  if (planeMode?.controller?.setTurretAimTarget){
-    const turretAim = snapshot.planeAim ?? snapshot.aircraftAim ?? snapshot.airAim ?? snapshot.turretAim ?? null;
-    if (turretAim){
-      planeMode.controller.setTurretAimTarget(turretAim, { immediate: !!snapshot.instantAim });
-    }
-  }
-  if (planeMode?.controller?.setTurretOrientation){
-    const turretOrientation = snapshot.turretOrientation ?? snapshot.turretAngles ?? snapshot.turret ?? null;
-    if (turretOrientation){
-      planeMode.controller.setTurretOrientation(turretOrientation);
-    }
-  }
-
-  syncControllerVisual(controller);
-
-  if (snapshot.resetStats){
-    resetVehicleStats(vehicle);
-  } else {
-    const state = controller.getState ? controller.getState() : null;
+  if (initialVehicle){
+    const state = vehicleSystem.getVehicleState(initialVehicle);
     if (state){
-      vehicle.stats.throttle = state.throttle ?? vehicle.stats.throttle;
-      vehicle.stats.speed = state.speed ?? vehicle.stats.speed;
-      if (!vehicle.stats.lastPosition){
-        vehicle.stats.lastPosition = state.position.clone();
-      } else {
-        vehicle.stats.lastPosition.copy(state.position);
-      }
+      chaseCamera.snapTo(state);
+      worldRef.current?.update?.(state.position);
+    } else {
+      worldRef.current?.update?.(ORIGIN_FALLBACK);
     }
+  } else {
+    worldRef.current?.update?.(ORIGIN_FALLBACK);
   }
-}
 
-function focusCameraOnVehicle(vehicle){
-  if (!vehicle) return;
-  const mode = vehicle.modes[vehicle.mode];
-  if (!mode) return;
-  chaseCamera.setConfig(mode.cameraConfig);
-  chaseCamera.resetOrbit();
-  chaseCamera.snapTo(mode.controller.getState());
-  applyHudControls(vehicle);
-}
-
-function handleFocusShortcut(){
-  if (!activeVehicleId) return;
-  const vehicle = vehicles.get(activeVehicleId);
-  focusCameraOnVehicle(vehicle);
+  requestAnimationFrame(animate);
 }
 
 window.addEventListener('keydown', (event) => {
   if (event.defaultPrevented) return;
   if (event.code === 'BracketRight'){
-    cycleActiveVehicle(1);
+    vehicleSystem.cycleActiveVehicle(1);
   } else if (event.code === 'BracketLeft'){
-    cycleActiveVehicle(-1);
+    vehicleSystem.cycleActiveVehicle(-1);
   } else if (event.code === 'KeyF'){
-    handleFocusShortcut();
+    vehicleSystem.handleFocusShortcut();
   } else if ((event.code === 'Space' || event.code === 'KeyX' || event.code === 'Enter') && !event.repeat){
     setFireSourceActive(event.code, true);
     event.preventDefault();
@@ -1170,166 +380,22 @@ window.addEventListener('blur', () => {
   resetFireInput();
 });
 
-function cycleActiveVehicle(delta){
-  if (vehicles.size === 0) return;
-  const ids = Array.from(vehicles.keys());
-  if (ids.length === 0) return;
-  if (!activeVehicleId || !vehicles.has(activeVehicleId)){
-    selectActiveVehicle();
-  }
-  const currentIndex = ids.indexOf(activeVehicleId);
-  const index = currentIndex === -1 ? 0 : currentIndex;
-  let next = (index + delta) % ids.length;
-  if (next < 0) next += ids.length;
-  const nextId = ids[next];
-  if (nextId !== activeVehicleId){
-    setActiveVehicle(nextId);
-  }
-}
-
-enableWindowResizeHandling({ renderer, camera });
-
-function updateHud(vehicle){
-  if (!vehicle){
-    hud.update({ throttle: 0, speed: 0, crashCount: 0, elapsedTime: 0, distance: 0 });
-    return;
-  }
-  hud.update({
-    throttle: vehicle.stats.throttle,
-    speed: vehicle.stats.speed,
-    crashCount: vehicle.stats.crashCount,
-    elapsedTime: vehicle.stats.elapsed,
-    distance: vehicle.stats.distance,
-  });
-}
-
-function evaluateCollisions(vehicle){
-  if (!vehicle || vehicle.mode !== 'plane') return;
-  const state = getVehicleState(vehicle);
-  if (!state) return;
-  const result = collisionSystem.evaluate(state);
-  if (result.crashed){
-    registerVehicleCrash(vehicle, { message: 'Impact detected' });
-  }
-}
-
-// ⏱️ Main loop
-
-let lastTime = performance.now();
-let elapsedTime = 0;
-
-function animate(now){
-  requestAnimationFrame(animate);
-  const dt = Math.min(0.08, (now - lastTime) / 1000 || 0);
-  lastTime = now;
-  elapsedTime += dt;
-
-  const inputSample = input.readState(dt);
-
-  for (const vehicle of vehicles.values()){
-    updateVehicleController(vehicle, dt, elapsedTime, inputSample);
-    stepVehicleAttachments(vehicle, dt);
-    updateVehicleStats(vehicle, dt);
-  }
-
-  selectActiveVehicle();
-
-  fireCooldownTimer = Math.max(0, fireCooldownTimer - dt);
-  if (fireInputHeld && fireCooldownTimer <= 0){
-    const fired = fireActiveVehicleProjectile();
-    fireCooldownTimer = fired ? FIRE_COOLDOWN : MIN_FAILED_FIRE_DELAY;
-  }
-
-  // Projectiles: integrate hits back into your game logic
-  projectileManager.update(dt, {
-    vehicles,
-    onVehicleHit: handleProjectileHit,
-    onImpact: (impact) => {
-      if (world && typeof world.applyProjectileImpact === 'function'){
-        world.applyProjectileImpact(impact);
-      }
-    },
-  });
-
-  const activeVehicle = activeVehicleId ? vehicles.get(activeVehicleId) : null;
-  if (activeVehicle && world){
-    const state = getVehicleState(activeVehicle);
-    if (state){
-      chaseCamera.setConfig(activeVehicle.modes[activeVehicle.mode]?.cameraConfig ?? planeCameraConfig);
-      chaseCamera.update(state, dt, inputSample?.cameraOrbit ?? null);
-      world.update(state.position);
-    }
-  } else if (world){
-    world.update(ORIGIN_FALLBACK);
-  }
-
-  evaluateCollisions(activeVehicle);
-  updateHud(activeVehicle);
-  updateTrackedVehicles();
-
-  renderer.render(scene, camera);
-}
-
-async function bootstrap(){
-  const requestedId = getRequestedMapId();
-  const definition = await loadMapDefinitions(requestedId);
-  availableMaps = Array.isArray(definition.maps) && definition.maps.length
-    ? definition.maps
-    : [...FALLBACK_MAPS];
-  defaultMapId = definition.defaultId ?? availableMaps[0]?.id ?? defaultMapId;
-  const selection = selectMapDefinition(availableMaps, requestedId, defaultMapId);
-  availableMaps = selection.maps;
-  defaultMapId = selection.id ?? defaultMapId;
-  currentMapDefinition = selection.selected ?? availableMaps[0] ?? FALLBACK_MAPS[0];
-
-  hud.setMapOptions(availableMaps);
-  hud.setActiveMap(currentMapDefinition?.id ?? '');
-
-  initializeWorldForMap(currentMapDefinition);
-
-  spawnDefaultVehicles();
-  handlePlayerJoin(LOCAL_PLAYER_ID, { initialMode: 'plane' });
-  const initialVehicle = activeVehicleId
-    ? vehicles.get(activeVehicleId)
-    : vehicles.get(LOCAL_PLAYER_ID) ?? vehicles.values().next().value ?? null;
-  if (initialVehicle){
-    focusCameraOnVehicle(initialVehicle);
-    const state = getVehicleState(initialVehicle);
-    if (state && world){
-      world.update(state.position);
-    } else if (world){
-      world.update(ORIGIN_FALLBACK);
-    }
-  } else if (world){
-    world.update(ORIGIN_FALLBACK);
-  }
-
-  requestAnimationFrame(animate);
-}
-
 bootstrap().catch((error) => {
   console.error('Failed to initialize Terra sandbox', error);
 });
 
-// 🔧 Public API: rewire to current systems
 window.DriftPursuitTerra = {
-  join: handlePlayerJoin,
-  leave: handlePlayerLeave,
-  cycle: cycleActiveVehicle,
-  focus: handleFocusShortcut,
-  setActive: setActiveVehicle,
-  update: applyVehicleSnapshot,
+  join: (id, options) => vehicleSystem.handlePlayerJoin(id, options),
+  leave: (id) => vehicleSystem.handlePlayerLeave(id),
+  cycle: (delta) => vehicleSystem.cycleActiveVehicle(delta ?? 1),
+  focus: () => vehicleSystem.handleFocusShortcut(),
+  setActive: (id) => vehicleSystem.setActiveVehicle(id),
+  update: (id, snapshot) => vehicleSystem.applyVehicleSnapshot(id, snapshot),
   getTrackedVehicles(){
-    return trackedVehicles.map((entry) => ({
-      id: entry.id,
-      mode: entry.mode,
-      position: entry.state.position.clone(),
-      velocity: entry.state.velocity.clone(),
-    }));
+    return vehicleSystem.getTrackedVehicles();
   },
-  // fire() now uses the active vehicle’s muzzle via TerraProjectileManager
   fire(){
-    return fireActiveVehicleProjectile();
+    return vehicleSystem.fireActiveVehicleProjectile();
   },
   setAmmo(ammoId){
     const accepted = projectileManager.setAmmoType(ammoId);

--- a/viewer/terra/maps.js
+++ b/viewer/terra/maps.js
@@ -1,0 +1,270 @@
+export function cloneEnvironment(environment){
+  if (!environment || typeof environment !== 'object') return null;
+  const clone = { ...environment };
+  if (environment.fog && typeof environment.fog === 'object'){
+    clone.fog = { ...environment.fog };
+  }
+  if (environment.sun && typeof environment.sun === 'object'){
+    clone.sun = { ...environment.sun };
+  }
+  if (environment.hemisphere && typeof environment.hemisphere === 'object'){
+    clone.hemisphere = { ...environment.hemisphere };
+  }
+  return clone;
+}
+
+export function cloneHeightfieldDescriptor(descriptor){
+  if (!descriptor || typeof descriptor !== 'object') return null;
+  const clone = { ...descriptor };
+  if (Array.isArray(descriptor.data)){
+    clone.data = [...descriptor.data];
+  }
+  return clone;
+}
+
+export function cloneTileObjects(objects){
+  if (!Array.isArray(objects)) return [];
+  return objects.map((entry) => {
+    if (!entry || typeof entry !== 'object') return entry;
+    return { ...entry };
+  });
+}
+
+export function cloneTileDescriptor(tile){
+  if (!tile || typeof tile !== 'object') return tile;
+  const clone = { ...tile };
+  if (Array.isArray(tile.coords)) clone.coords = [...tile.coords];
+  if (Array.isArray(tile.coordinates)) clone.coordinates = [...tile.coordinates];
+  if (tile.heightfield && typeof tile.heightfield === 'object'){
+    clone.heightfield = cloneHeightfieldDescriptor(tile.heightfield);
+  }
+  if (Array.isArray(tile.objects)){
+    clone.objects = cloneTileObjects(tile.objects);
+  }
+  return clone;
+}
+
+export function cloneProceduralConfig(config){
+  if (!config || typeof config !== 'object') return null;
+  try {
+    return JSON.parse(JSON.stringify(config));
+  } catch (error){
+    console.warn('Failed to clone procedural configuration', error);
+    return null;
+  }
+}
+
+export function cloneMapDescriptor(descriptor){
+  if (!descriptor || typeof descriptor !== 'object') return null;
+  const clone = { ...descriptor };
+  if (descriptor.environment) clone.environment = cloneEnvironment(descriptor.environment);
+  if (descriptor.procedural && typeof descriptor.procedural === 'object'){
+    const proceduralClone = cloneProceduralConfig(descriptor.procedural);
+    if (proceduralClone) clone.procedural = proceduralClone;
+  }
+  if (descriptor.generator && typeof descriptor.generator === 'object'){
+    const generatorClone = cloneProceduralConfig(descriptor.generator);
+    if (generatorClone) clone.generator = generatorClone;
+  }
+  if (Array.isArray(descriptor.tiles)){
+    clone.tiles = descriptor.tiles.map((tile) => cloneTileDescriptor(tile));
+  }
+  if (descriptor.fallback && typeof descriptor.fallback === 'object'){
+    clone.fallback = { ...descriptor.fallback };
+  }
+  return clone;
+}
+
+export function cloneMapDefinition(entry){
+  if (!entry || typeof entry !== 'object') return null;
+  const clone = { ...entry };
+  if (clone.environment) clone.environment = cloneEnvironment(clone.environment);
+  if (clone.procedural && typeof clone.procedural === 'object'){
+    const proceduralClone = cloneProceduralConfig(clone.procedural);
+    if (proceduralClone) clone.procedural = proceduralClone;
+    else delete clone.procedural;
+  }
+  if (clone.generator && typeof clone.generator === 'object'){
+    const generatorClone = cloneProceduralConfig(clone.generator);
+    if (generatorClone) clone.generator = generatorClone;
+    else delete clone.generator;
+  }
+  if (Array.isArray(clone.tiles)) clone.tiles = clone.tiles.map((tile) => cloneTileDescriptor(tile));
+  if (clone.descriptor) clone.descriptor = cloneMapDescriptor(clone.descriptor);
+  if (clone.fallback && typeof clone.fallback === 'object') clone.fallback = { ...clone.fallback };
+  return clone;
+}
+
+export function mergeTileDescriptor({ mapEntry, descriptor, descriptorUrl }){
+  const merged = cloneMapDescriptor(descriptor) ?? {};
+  if (mapEntry){
+    if (!merged.id && mapEntry.id) merged.id = mapEntry.id;
+    const typeValue = typeof mapEntry.type === 'string' ? mapEntry.type.toLowerCase() : mapEntry.type;
+    if (!merged.type && typeValue) merged.type = typeValue;
+    if (!merged.tileSize && Number.isFinite(mapEntry.tileSize)) merged.tileSize = mapEntry.tileSize;
+    if (!merged.visibleRadius && Number.isFinite(mapEntry.visibleRadius)) merged.visibleRadius = mapEntry.visibleRadius;
+    if (!merged.assetRoot && typeof mapEntry.assetRoot === 'string') merged.assetRoot = mapEntry.assetRoot;
+    if (!Array.isArray(merged.tiles) && Array.isArray(mapEntry.tiles)){
+      merged.tiles = mapEntry.tiles.map((tile) => cloneTileDescriptor(tile));
+    }
+  }
+  if (descriptorUrl){
+    const source = descriptorUrl.toString();
+    merged.descriptorSource = source;
+    if (typeof merged.assetRoot === 'string' && merged.assetRoot.length > 0){
+      try {
+        const assetUrl = new URL(merged.assetRoot, descriptorUrl);
+        merged.assetRoot = assetUrl.toString();
+      } catch (error){
+        // Keep provided assetRoot if URL resolution fails.
+      }
+    }
+  }
+  if (!Array.isArray(merged.tiles)){
+    merged.tiles = [];
+  }
+  return merged;
+}
+
+function cloneFallbackMaps(fallbackMaps){
+  if (!Array.isArray(fallbackMaps)) return [];
+  return fallbackMaps.map((entry) => cloneMapDefinition(entry)).filter(Boolean);
+}
+
+export async function loadMapDefinitions({
+  endpoint,
+  requestedId,
+  fetchFn,
+  fallbackMaps = [],
+  fallbackDefaultId = null,
+  origin,
+} = {}){
+  const fallbackResult = {
+    maps: cloneFallbackMaps(fallbackMaps),
+    defaultId: fallbackDefaultId ?? fallbackMaps[0]?.id ?? null,
+  };
+
+  if (typeof fetchFn !== 'function' || !endpoint){
+    return fallbackResult;
+  }
+
+  try {
+    const options = requestedId ? { headers: { 'X-Active-Map': requestedId } } : undefined;
+    const response = await fetchFn(endpoint, options);
+    if (!response || !response.ok){
+      throw new Error(`Failed to fetch maps: ${response?.status ?? 'unknown status'}`);
+    }
+    const data = await response.json();
+    const rawMaps = Array.isArray(data?.maps)
+      ? data.maps
+      : Array.isArray(data)
+        ? data
+        : [];
+
+    const originValue = origin ?? (typeof window !== 'undefined' ? window.location.href : 'http://localhost/');
+    const baseUrl = new URL(endpoint, originValue);
+
+    const maps = await Promise.all(
+      rawMaps.map(async (entry) => {
+        const mapEntry = cloneMapDefinition(entry);
+        if (!mapEntry) return null;
+
+        if (typeof mapEntry.type === 'string'){
+          mapEntry.type = mapEntry.type.toLowerCase();
+        }
+
+        if (mapEntry.type === 'tilemap'){
+          let descriptorUrl = null;
+          if (typeof mapEntry.path === 'string' && mapEntry.path.length > 0){
+            try {
+              descriptorUrl = new URL(mapEntry.path, baseUrl);
+            } catch (error){
+              console.warn(`Invalid descriptor path for tile map ${mapEntry.id}`, error);
+            }
+          }
+
+          let descriptorSource = mapEntry.descriptor ? cloneMapDescriptor(mapEntry.descriptor) : null;
+
+          if (!descriptorSource && descriptorUrl){
+            try {
+              const descriptorResponse = await fetchFn(descriptorUrl.toString(), { cache: 'no-cache' });
+              if (!descriptorResponse.ok){
+                console.warn(`Failed to load tile-map descriptor for ${mapEntry.id}: HTTP ${descriptorResponse.status}`);
+              } else {
+                const descriptorData = await descriptorResponse.json();
+                descriptorSource = cloneMapDescriptor(descriptorData);
+              }
+            } catch (error){
+              console.warn(`Failed to load tile-map descriptor for ${mapEntry.id}`, error);
+            }
+          }
+
+          if (descriptorSource){
+            const merged = mergeTileDescriptor({ mapEntry, descriptor: descriptorSource, descriptorUrl });
+            mapEntry.descriptor = merged;
+            if (!Array.isArray(mapEntry.tiles) && Array.isArray(merged.tiles)){
+              mapEntry.tiles = merged.tiles.map((tile) => cloneTileDescriptor(tile));
+            }
+            if (!Number.isFinite(mapEntry.tileSize) && Number.isFinite(merged.tileSize)){
+              mapEntry.tileSize = merged.tileSize;
+            }
+            if (!Number.isFinite(mapEntry.visibleRadius) && Number.isFinite(merged.visibleRadius)){
+              mapEntry.visibleRadius = merged.visibleRadius;
+            }
+          } else {
+            mapEntry.descriptor = mergeTileDescriptor({
+              mapEntry,
+              descriptor: {
+                id: mapEntry.id,
+                type: 'tilemap',
+                tiles: Array.isArray(mapEntry.tiles) ? mapEntry.tiles : [],
+              },
+              descriptorUrl,
+            });
+          }
+        }
+
+        return mapEntry;
+      }),
+    );
+
+    const sanitizedMaps = maps.filter(Boolean);
+    const defaultId = typeof data?.default === 'string'
+      ? data.default
+      : sanitizedMaps[0]?.id ?? fallbackResult.defaultId;
+
+    return { maps: sanitizedMaps, defaultId };
+  } catch (error){
+    console.warn('Falling back to bundled map definitions.', error);
+    return fallbackResult;
+  }
+}
+
+export function selectMapDefinition({ maps, requestedId, fallbackId, fallbackMaps = [] } = {}){
+  const mapList = Array.isArray(maps) && maps.length > 0
+    ? maps.map((entry) => cloneMapDefinition(entry)).filter(Boolean)
+    : cloneFallbackMaps(fallbackMaps);
+
+  const registry = new Map();
+  mapList.forEach((entry) => {
+    if (entry?.id){
+      registry.set(entry.id, entry);
+    }
+  });
+
+  let targetId = requestedId && registry.has(requestedId) ? requestedId : null;
+  if (!targetId && fallbackId && registry.has(fallbackId)){
+    targetId = fallbackId;
+  }
+  if (!targetId){
+    targetId = mapList.find((entry) => entry?.id)?.id ?? fallbackMaps[0]?.id ?? null;
+  }
+
+  const selected = targetId ? registry.get(targetId) ?? mapList[0] : mapList[0];
+  return {
+    selected,
+    id: selected?.id ?? targetId ?? null,
+    registry,
+    maps: mapList,
+  };
+}

--- a/viewer/terra/vehicles.js
+++ b/viewer/terra/vehicles.js
@@ -1,0 +1,710 @@
+function assignVector3(target, source){
+  if (!target || source == null) return;
+  if (Array.isArray(source) && source.length >= 3){
+    target.set(source[0], source[1], source[2]);
+    return;
+  }
+  const { x, y, z } = source ?? {};
+  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number'){
+    target.set(x, y, z);
+    return;
+  }
+  if (typeof x === 'number') target.x = x;
+  if (typeof y === 'number') target.y = y;
+  if (typeof z === 'number') target.z = z;
+}
+
+function assignQuaternion(target, source){
+  if (!target || source == null) return;
+  if (Array.isArray(source) && source.length >= 4){
+    target.set(source[0], source[1], source[2], source[3]);
+    return;
+  }
+  const { x, y, z, w } = source ?? {};
+  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number' && typeof w === 'number'){
+    target.set(x, y, z, w);
+    return;
+  }
+  if (typeof x === 'number') target.x = x;
+  if (typeof y === 'number') target.y = y;
+  if (typeof z === 'number') target.z = z;
+  if (typeof w === 'number') target.w = w;
+}
+
+function syncControllerVisual(controller){
+  if (!controller) return;
+  if (controller.mesh){
+    controller.mesh.position.copy(controller.position);
+    controller.mesh.quaternion.copy(controller.orientation);
+  }
+}
+
+export function createVehicleSystem({
+  THREE,
+  scene,
+  chaseCamera,
+  hud,
+  hudPresets,
+  projectileManager,
+  collisionSystem,
+  getWorld,
+  localPlayerId,
+  planeCameraConfig,
+  carCameraConfig,
+  maxDefaultVehicles = 5,
+  skyCeiling = 1800,
+  createPlaneMesh,
+  createPlaneController,
+  createCarRig,
+  createCarController,
+} = {}){
+  const vehicles = new Map();
+  const trackedVehicles = [];
+  let activeVehicleId = null;
+
+  function getWorldInstance(){
+    return typeof getWorld === 'function' ? getWorld() : null;
+  }
+
+  function getGroundHeight(x, y){
+    const world = getWorldInstance();
+    if (world && typeof world.getHeightAt === 'function'){
+      return world.getHeightAt(x, y);
+    }
+    return 0;
+  }
+
+  function getVehicleState(vehicle){
+    if (!vehicle) return null;
+    const modeState = vehicle.modes[vehicle.mode];
+    if (!modeState) return null;
+    if (typeof modeState.controller?.getState !== 'function') return null;
+    return modeState.controller.getState();
+  }
+
+  function ensureVehicleVisibility(vehicle){
+    if (!vehicle) return;
+    const { plane, car } = vehicle.modes;
+    if (plane?.mesh) plane.mesh.visible = vehicle.mode === 'plane';
+    if (car?.rig?.carMesh) car.rig.carMesh.visible = vehicle.mode === 'car';
+  }
+
+  function applyHudControls(vehicle){
+    if (!vehicle) return;
+    const preset = hudPresets?.[vehicle.mode] ?? hudPresets?.plane;
+    if (preset && hud?.setControls){
+      hud.setControls(preset);
+    }
+  }
+
+  function focusCameraOnVehicle(vehicle){
+    if (!vehicle) return;
+    const mode = vehicle.modes[vehicle.mode];
+    if (!mode) return;
+    chaseCamera?.setConfig?.(mode.cameraConfig);
+    chaseCamera?.resetOrbit?.();
+    const state = mode.controller?.getState ? mode.controller.getState() : null;
+    if (state){
+      chaseCamera?.snapTo?.(state);
+    }
+    applyHudControls(vehicle);
+  }
+
+  function switchVehicleMode(vehicle, mode){
+    if (!vehicle || !mode) return;
+    if (vehicle.mode === mode) return;
+    if (!vehicle.modes?.[mode]) return;
+    vehicle.mode = mode;
+    ensureVehicleVisibility(vehicle);
+    if (vehicle.id === activeVehicleId){
+      applyHudControls(vehicle);
+      focusCameraOnVehicle(vehicle);
+    }
+  }
+
+  function clampPlaneAltitude(controller, ground){
+    if (!controller) return;
+    const minAltitude = ground + 16;
+    if (controller.position.z < minAltitude){
+      controller.position.z = minAltitude;
+      if (controller.velocity.z < 0) controller.velocity.z = 0;
+    }
+    if (controller.position.z > skyCeiling){
+      controller.position.z = skyCeiling;
+      if (controller.velocity.z > 0) controller.velocity.z = 0;
+    }
+  }
+
+  function computeSpawnTransform(index){
+    const angle = index * (Math.PI * 2 / Math.max(1, maxDefaultVehicles));
+    const radius = 420 + (index % 3) * 60;
+    const x = Math.cos(angle) * radius;
+    const y = Math.sin(angle) * radius;
+    const ground = getGroundHeight(x, y);
+    const planePos = new THREE.Vector3(x, y, ground + 60 + (index % 2) * 12);
+    const carPos = new THREE.Vector3(x + 28, y - 28, ground + 2.6);
+    const yaw = angle + Math.PI / 2;
+    return {
+      plane: { position: planePos, yaw },
+      car: { position: carPos, yaw },
+    };
+  }
+
+  function createVehicleEntry(id, { isBot = false, initialMode = 'plane', spawnIndex = vehicles.size } = {}){
+    if (!id) return null;
+    const transform = computeSpawnTransform(spawnIndex);
+
+    const planeMesh = createPlaneMesh?.();
+    if (planeMesh) scene?.add?.(planeMesh);
+
+    const planeController = createPlaneController?.();
+    planeController?.attachMesh?.(planeMesh, {
+      turretYawGroup: planeMesh?.userData?.turretYawGroup,
+      turretPitchGroup: planeMesh?.userData?.turretPitchGroup,
+      stickYaw: planeMesh?.userData?.turretStickYaw,
+      stickPitch: planeMesh?.userData?.turretStickPitch,
+    });
+    planeController?.reset?.({
+      position: transform.plane.position,
+      yaw: transform.plane.yaw,
+      pitch: THREE.MathUtils.degToRad(4),
+      throttle: 0.46,
+    });
+
+    const carRig = createCarRig?.();
+    if (carRig?.carMesh) scene?.add?.(carRig.carMesh);
+
+    const carController = createCarController?.();
+    carController?.attachMesh?.(carRig?.carMesh, {
+      stickYaw: carRig?.stickYaw,
+      stickPitch: carRig?.stickPitch,
+      towerGroup: carRig?.towerGroup,
+      towerHead: carRig?.towerHead,
+      wheels: carRig?.wheels,
+    });
+    carController?.reset?.({
+      position: transform.car.position,
+      yaw: transform.car.yaw,
+    });
+
+    const entry = {
+      id,
+      isBot,
+      mode: initialMode,
+      modes: {
+        plane: {
+          controller: planeController,
+          mesh: planeMesh,
+          cameraConfig: planeCameraConfig,
+          muzzle: planeMesh?.userData?.turretMuzzle ?? null,
+        },
+        car: {
+          controller: carController,
+          rig: carRig,
+          cameraConfig: carCameraConfig,
+          muzzle: carRig?.carMesh?.userData?.turretMuzzle ?? null,
+        },
+      },
+      stats: {
+        crashCount: 0,
+        elapsed: 0,
+        distance: 0,
+        throttle: 0,
+        speed: 0,
+        lastPosition: transform.plane.position.clone(),
+      },
+      behaviorSeed: Math.random() * Math.PI * 2,
+      spawnTransform: {
+        plane: {
+          position: transform.plane.position.clone(),
+          yaw: transform.plane.yaw,
+        },
+        car: {
+          position: transform.car.position.clone(),
+          yaw: transform.car.yaw,
+        },
+      },
+    };
+
+    vehicles.set(id, entry);
+    ensureVehicleVisibility(entry);
+    const initialState = getVehicleState(entry);
+    if (initialState?.position){
+      entry.stats.lastPosition.copy(initialState.position);
+      if (Number.isFinite(initialState.throttle)){
+        entry.stats.throttle = initialState.throttle;
+      }
+      if (Number.isFinite(initialState.speed)){
+        entry.stats.speed = initialState.speed;
+      }
+    }
+
+    return entry;
+  }
+
+  function removeVehicle(id){
+    const entry = vehicles.get(id);
+    if (!entry) return;
+    projectileManager?.clearByOwner?.(id);
+    if (entry.modes.plane?.mesh){
+      scene?.remove?.(entry.modes.plane.mesh);
+    }
+    if (entry.modes.car?.rig?.carMesh){
+      scene?.remove?.(entry.modes.car.rig.carMesh);
+    }
+    vehicles.delete(id);
+    if (activeVehicleId === id){
+      activeVehicleId = null;
+    }
+  }
+
+  function selectActiveVehicle(preferredId = null){
+    const previous = activeVehicleId;
+    if (preferredId && vehicles.has(preferredId)){
+      activeVehicleId = preferredId;
+    } else if (activeVehicleId && vehicles.has(activeVehicleId)){
+      // keep current selection
+    } else {
+      let fallback = null;
+      for (const [id, vehicle] of vehicles.entries()){
+        if (!vehicle.isBot){
+          activeVehicleId = id;
+          fallback = null;
+          break;
+        }
+        if (!fallback) fallback = id;
+      }
+      if (!vehicles.has(activeVehicleId) && fallback){
+        activeVehicleId = fallback;
+      }
+    }
+
+    if (activeVehicleId && !vehicles.has(activeVehicleId)){
+      activeVehicleId = null;
+    }
+    if (previous !== activeVehicleId){
+      const nextVehicle = activeVehicleId ? vehicles.get(activeVehicleId) : null;
+      if (nextVehicle){
+        focusCameraOnVehicle(nextVehicle);
+      }
+    }
+  }
+
+  function setActiveVehicle(id){
+    if (!id || !vehicles.has(id)) return;
+    if (activeVehicleId === id) return;
+    activeVehicleId = id;
+    const vehicle = vehicles.get(activeVehicleId);
+    focusCameraOnVehicle(vehicle);
+  }
+
+  function cycleActiveVehicle(delta){
+    if (vehicles.size === 0) return;
+    const ids = Array.from(vehicles.keys());
+    if (ids.length === 0) return;
+    if (!activeVehicleId || !vehicles.has(activeVehicleId)){
+      selectActiveVehicle();
+    }
+    const currentIndex = ids.indexOf(activeVehicleId);
+    const index = currentIndex === -1 ? 0 : currentIndex;
+    let next = (index + delta) % ids.length;
+    if (next < 0) next += ids.length;
+    const nextId = ids[next];
+    if (nextId !== activeVehicleId){
+      setActiveVehicle(nextId);
+    }
+  }
+
+  function resetVehicleStats(vehicle){
+    const state = getVehicleState(vehicle);
+    if (!state) return;
+    vehicle.stats.elapsed = 0;
+    vehicle.stats.distance = 0;
+    vehicle.stats.lastPosition.copy(state.position);
+    vehicle.stats.crashCount = 0;
+  }
+
+  function registerVehicleCrash(vehicle, { message = 'Impact detected' } = {}){
+    if (!vehicle) return;
+    if (vehicle.stats){
+      vehicle.stats.crashCount = (vehicle.stats.crashCount ?? 0) + 1;
+    }
+    if (message){
+      hud?.showMessage?.(message);
+    }
+    if (vehicle.id === activeVehicleId){
+      focusCameraOnVehicle(vehicle);
+    }
+  }
+
+  function resetCarAfterCrash(vehicle){
+    if (!vehicle) return;
+    const spawn = vehicle.spawnTransform?.car;
+    const carMode = vehicle.modes?.car;
+    if (!spawn || !carMode?.controller) return;
+    carMode.controller.reset({ position: spawn.position, yaw: spawn.yaw });
+    syncControllerVisual(carMode.controller);
+    if (vehicle.stats){
+      if (vehicle.stats.lastPosition){
+        vehicle.stats.lastPosition.copy(carMode.controller.position);
+      } else {
+        vehicle.stats.lastPosition = carMode.controller.position.clone();
+      }
+      vehicle.stats.speed = 0;
+      vehicle.stats.throttle = 0;
+    }
+  }
+
+  function handleProjectileHit(vehicle, projectile){
+    if (!vehicle) return;
+    if (projectile?.mesh?.position){
+      projectileManager?.triggerExplosion?.({
+        position: projectile.mesh.position.clone(),
+        ammoId: projectile.ammo?.id ?? null,
+      });
+    }
+    registerVehicleCrash(vehicle, { message: 'Direct hit!' });
+    if (vehicle.mode === 'car'){
+      resetCarAfterCrash(vehicle);
+    }
+  }
+
+  function fireActiveVehicleProjectile(){
+    if (!activeVehicleId) return false;
+    const vehicle = vehicles.get(activeVehicleId);
+    if (!vehicle) return false;
+    const modeName = vehicle.mode;
+    const mode = vehicle.modes?.[modeName];
+    if (!mode) return false;
+
+    let muzzle = null;
+    const controller = mode.controller ?? null;
+
+    if (modeName === 'plane'){
+      muzzle = mode.mesh?.userData?.turretMuzzle ?? mode.muzzle ?? null;
+    } else if (modeName === 'car'){
+      const carMesh = mode.rig?.carMesh ?? null;
+      muzzle = carMesh?.userData?.turretMuzzle ?? mode.muzzle ?? null;
+    }
+
+    if (!muzzle) return false;
+
+    const inheritVelocity = controller?.velocity ?? null;
+    const projectile = projectileManager?.spawnFromMuzzle?.(muzzle, {
+      ownerId: vehicle.id,
+      inheritVelocity,
+    });
+    return !!projectile;
+  }
+
+  function updateVehicleStats(vehicle, dt){
+    const state = getVehicleState(vehicle);
+    if (!state) return;
+    const stats = vehicle.stats;
+    if (!stats) return;
+    stats.elapsed += dt;
+    stats.throttle = state.throttle ?? stats.throttle;
+    stats.speed = state.speed ?? stats.speed;
+    if (stats.lastPosition){
+      stats.distance += state.position.distanceTo(stats.lastPosition);
+      stats.lastPosition.copy(state.position);
+    } else {
+      stats.lastPosition = state.position.clone();
+    }
+  }
+
+  function updatePlaneBot(vehicle, dt, elapsedTime){
+    const controller = vehicle.modes.plane.controller;
+    if (!controller) return;
+    const oscillation = elapsedTime * 0.35 + vehicle.behaviorSeed;
+    const input = {
+      pitch: Math.sin(oscillation * 0.9) * 0.24,
+      yaw: 0.14 + Math.sin(oscillation * 0.35) * 0.06,
+      roll: Math.sin(oscillation * 0.65) * 0.42,
+      throttleAdjust: Math.sin(oscillation * 0.18) * 0.05,
+      brake: false,
+      aim: {
+        x: Math.sin(oscillation * 0.52) * 0.65,
+        y: Math.cos(oscillation * 0.41) * 0.5,
+      },
+    };
+    controller.update(dt, input, {
+      clampAltitude: clampPlaneAltitude,
+      sampleGroundHeight: (x, y) => getGroundHeight(x, y),
+    });
+  }
+
+  function updateCarBot(vehicle, dt, elapsedTime){
+    const controller = vehicle.modes.car.controller;
+    if (!controller) return;
+    const oscillation = elapsedTime * 0.6 + vehicle.behaviorSeed;
+    const input = {
+      throttle: 0.4 + Math.sin(oscillation) * 0.35,
+      steer: Math.sin(oscillation * 0.7) * 0.65,
+      brake: false,
+      aim: {
+        x: Math.sin(oscillation * 1.1) * 0.5,
+        y: Math.cos(oscillation * 0.9) * 0.35,
+      },
+    };
+    controller.update(dt, input, {
+      sampleGroundHeight: (x, y) => getGroundHeight(x, y),
+    });
+  }
+
+  function updateLocalVehicle(vehicle, dt, inputSample){
+    if (!vehicle) return;
+    const modeRequest = inputSample?.modeRequest;
+    if (modeRequest && vehicle.modes?.[modeRequest]){
+      switchVehicleMode(vehicle, modeRequest);
+      if (vehicle.id === localPlayerId && activeVehicleId !== localPlayerId){
+        setActiveVehicle(localPlayerId);
+      }
+    }
+
+    const currentMode = vehicle.mode;
+    if (currentMode === 'plane'){
+      const controller = vehicle.modes.plane.controller;
+      if (!controller) return;
+      const planeInput = inputSample?.plane ?? {};
+      controller.update(dt, {
+        pitch: planeInput.pitch ?? 0,
+        roll: planeInput.roll ?? 0,
+        yaw: planeInput.yaw ?? 0,
+        throttleAdjust: planeInput.throttleAdjust ?? 0,
+        brake: planeInput.brake ?? false,
+        aim: planeInput.aim ?? { x: 0, y: 0 },
+      }, {
+        clampAltitude: clampPlaneAltitude,
+        sampleGroundHeight: (x, y) => getGroundHeight(x, y),
+      });
+    } else if (currentMode === 'car'){
+      const controller = vehicle.modes.car.controller;
+      if (!controller) return;
+      const carInput = inputSample?.car ?? {};
+      controller.update(dt, {
+        throttle: carInput.throttle ?? 0,
+        steer: carInput.steer ?? 0,
+        brake: carInput.brake ?? false,
+        aim: carInput.aim ?? { x: 0, y: 0 },
+      }, {
+        sampleGroundHeight: (x, y) => getGroundHeight(x, y),
+      });
+    }
+  }
+
+  function updateVehicleController(vehicle, dt, elapsedTime, inputSample){
+    if (!vehicle) return;
+    if (vehicle.isBot){
+      if (vehicle.mode === 'plane'){
+        updatePlaneBot(vehicle, dt, elapsedTime);
+      } else {
+        updateCarBot(vehicle, dt, elapsedTime);
+      }
+    } else if (vehicle.id === localPlayerId){
+      updateLocalVehicle(vehicle, dt, inputSample);
+    }
+  }
+
+  function stepVehicleAttachments(vehicle, dt){
+    if (!vehicle) return;
+    const plane = vehicle.modes?.plane;
+    if (plane?.controller?.stepTurretAim){
+      plane.controller.stepTurretAim(dt);
+    }
+  }
+
+  function updateTrackedVehicles(){
+    trackedVehicles.length = 0;
+    for (const [id, vehicle] of vehicles.entries()){
+      const state = getVehicleState(vehicle);
+      if (!state) continue;
+      trackedVehicles.push({ id, mode: vehicle.mode, state });
+    }
+  }
+
+  function evaluateCollisions(vehicle){
+    if (!vehicle || vehicle.mode !== 'plane') return;
+    const state = getVehicleState(vehicle);
+    if (!state) return;
+    const result = collisionSystem?.evaluate?.(state);
+    if (result?.crashed){
+      registerVehicleCrash(vehicle, { message: 'Impact detected' });
+    }
+  }
+
+  function getHudData(vehicle){
+    if (!vehicle){
+      return { throttle: 0, speed: 0, crashCount: 0, elapsedTime: 0, distance: 0 };
+    }
+    return {
+      throttle: vehicle.stats.throttle,
+      speed: vehicle.stats.speed,
+      crashCount: vehicle.stats.crashCount,
+      elapsedTime: vehicle.stats.elapsed,
+      distance: vehicle.stats.distance,
+    };
+  }
+
+  function spawnDefaultVehicles(){
+    for (let i = 0; i < maxDefaultVehicles; i += 1){
+      const id = `bot-${i + 1}`;
+      if (vehicles.has(id)) continue;
+      const vehicle = createVehicleEntry(id, { isBot: true, spawnIndex: i });
+      if (vehicle){
+        vehicle.mode = 'plane';
+        ensureVehicleVisibility(vehicle);
+      }
+    }
+    selectActiveVehicle();
+  }
+
+  function removeOneBot(){
+    for (const [id, vehicle] of vehicles.entries()){
+      if (vehicle.isBot){
+        removeVehicle(id);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function handlePlayerJoin(id, options = {}){
+    if (!id) return;
+    if (vehicles.has(id)) return;
+    const vehicle = createVehicleEntry(id, { isBot: !!options.isBot, initialMode: options.initialMode ?? 'plane' });
+    if (!vehicle) return;
+    if (!vehicle.isBot){
+      removeOneBot();
+      setActiveVehicle(id);
+    } else {
+      selectActiveVehicle();
+    }
+    ensureVehicleVisibility(vehicle);
+  }
+
+  function handlePlayerLeave(id){
+    if (!id) return;
+    const existed = vehicles.has(id);
+    removeVehicle(id);
+    if (vehicles.size === 0){
+      spawnDefaultVehicles();
+    } else if (existed){
+      selectActiveVehicle();
+    }
+  }
+
+  function applyVehicleSnapshot(id, snapshot = {}){
+    const vehicle = vehicles.get(id);
+    if (!vehicle) return;
+    if (snapshot.mode && vehicle.modes[snapshot.mode]){
+      vehicle.mode = snapshot.mode;
+      ensureVehicleVisibility(vehicle);
+      if (activeVehicleId === id){
+        applyHudControls(vehicle);
+      }
+    }
+
+    const mode = vehicle.modes[vehicle.mode];
+    if (!mode) return;
+    const controller = mode.controller;
+    if (!controller) return;
+
+    if (snapshot.position) assignVector3(controller.position, snapshot.position);
+    if (snapshot.velocity) assignVector3(controller.velocity, snapshot.velocity);
+    if (snapshot.orientation) assignQuaternion(controller.orientation, snapshot.orientation);
+    if (typeof snapshot.speed === 'number') controller.speed = snapshot.speed;
+    if (typeof snapshot.throttle === 'number') controller.throttle = snapshot.throttle;
+    if (typeof snapshot.targetThrottle === 'number') controller.targetThrottle = snapshot.targetThrottle;
+
+    const planeMode = vehicle.modes?.plane;
+    if (planeMode?.controller?.setTurretAimTarget){
+      const turretAim = snapshot.planeAim ?? snapshot.aircraftAim ?? snapshot.airAim ?? snapshot.turretAim ?? null;
+      if (turretAim){
+        planeMode.controller.setTurretAimTarget(turretAim, { immediate: !!snapshot.instantAim });
+      }
+    }
+    if (planeMode?.controller?.setTurretOrientation){
+      const turretOrientation = snapshot.turretOrientation ?? snapshot.turretAngles ?? snapshot.turret ?? null;
+      if (turretOrientation){
+        planeMode.controller.setTurretOrientation(turretOrientation);
+      }
+    }
+
+    syncControllerVisual(controller);
+
+    if (snapshot.resetStats){
+      resetVehicleStats(vehicle);
+    } else {
+      const state = controller.getState ? controller.getState() : null;
+      if (state){
+        vehicle.stats.throttle = state.throttle ?? vehicle.stats.throttle;
+        vehicle.stats.speed = state.speed ?? vehicle.stats.speed;
+        if (!vehicle.stats.lastPosition){
+          vehicle.stats.lastPosition = state.position.clone();
+        } else {
+          vehicle.stats.lastPosition.copy(state.position);
+        }
+      }
+    }
+  }
+
+  function handleFocusShortcut(){
+    if (!activeVehicleId) return;
+    const vehicle = vehicles.get(activeVehicleId);
+    focusCameraOnVehicle(vehicle);
+  }
+
+  function update({ dt, elapsedTime, inputSample }){
+    for (const vehicle of vehicles.values()){
+      updateVehicleController(vehicle, dt, elapsedTime, inputSample);
+      stepVehicleAttachments(vehicle, dt);
+      updateVehicleStats(vehicle, dt);
+    }
+
+    selectActiveVehicle();
+
+    const activeVehicle = activeVehicleId ? vehicles.get(activeVehicleId) : null;
+    const activeState = activeVehicle ? getVehicleState(activeVehicle) : null;
+
+    updateTrackedVehicles();
+    evaluateCollisions(activeVehicle);
+
+    const hudData = getHudData(activeVehicle);
+
+    return { activeVehicle, activeState, hudData };
+  }
+
+  function getTrackedVehiclesSnapshot(){
+    return trackedVehicles.map((entry) => ({
+      id: entry.id,
+      mode: entry.mode,
+      position: entry.state.position.clone(),
+      velocity: entry.state.velocity.clone(),
+    }));
+  }
+
+  function getVehicles(){
+    return vehicles;
+  }
+
+  return {
+    createVehicleEntry,
+    handlePlayerJoin,
+    handlePlayerLeave,
+    cycleActiveVehicle,
+    setActiveVehicle,
+    handleFocusShortcut,
+    fireActiveVehicleProjectile,
+    spawnDefaultVehicles,
+    applyVehicleSnapshot,
+    update,
+    getActiveVehicle: () => (activeVehicleId ? vehicles.get(activeVehicleId) : null),
+    getActiveVehicleId: () => activeVehicleId,
+    getTrackedVehicles: getTrackedVehiclesSnapshot,
+    getVehicles,
+    getVehicleState,
+    registerVehicleCrash,
+    handleProjectileHit,
+  };
+}

--- a/viewer/terra/worldFactory.js
+++ b/viewer/terra/worldFactory.js
@@ -1,0 +1,200 @@
+import { TerraWorldStreamer } from './TerraWorldStreamer.js';
+import { TileMapWorld } from './TileMapWorld.js';
+import {
+  cloneMapDefinition,
+  cloneMapDescriptor,
+  cloneTileDescriptor,
+  cloneProceduralConfig,
+} from './maps.js';
+
+export const DEFAULT_WORLD_ENVIRONMENT = {
+  bodyBackground: 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)',
+  backgroundColor: 0x90b6ff,
+  fog: { color: 0xa4c6ff, near: 1500, far: 4200 },
+  sun: { color: 0xffffff, intensity: 1.05, position: [-420, 580, 780] },
+  hemisphere: { skyColor: 0xdce9ff, groundColor: 0x2b4a2e, intensity: 0.85 },
+};
+
+function assignVector3(target, source){
+  if (!target || source == null) return;
+  if (Array.isArray(source) && source.length >= 3){
+    target.set(source[0], source[1], source[2]);
+    return;
+  }
+  const { x, y, z } = source;
+  if (typeof x === 'number' && typeof y === 'number' && typeof z === 'number'){
+    target.set(x, y, z);
+    return;
+  }
+  if (typeof x === 'number') target.x = x;
+  if (typeof y === 'number') target.y = y;
+  if (typeof z === 'number') target.z = z;
+}
+
+export function applyMapEnvironment({
+  mapDefinition,
+  scene,
+  documentRef,
+  hemisphere,
+  sun,
+  defaults = DEFAULT_WORLD_ENVIRONMENT,
+} = {}){
+  const environment = mapDefinition?.descriptor?.environment ?? mapDefinition?.environment ?? {};
+  if (documentRef?.body){
+    documentRef.body.style.background = environment.bodyBackground ?? defaults.bodyBackground;
+  }
+  if (scene){
+    const background = environment.background ?? defaults.backgroundColor;
+    if (scene.background){
+      scene.background.set ? scene.background.set(background) : scene.background = background;
+    } else {
+      scene.background = scene.background ?? background;
+      if (scene.background?.set){
+        scene.background.set(background);
+      }
+    }
+    if (scene.fog){
+      const fogConfig = environment.fog ?? {};
+      scene.fog.color.set(fogConfig.color ?? defaults.fog.color);
+      scene.fog.near = Number.isFinite(fogConfig.near) ? fogConfig.near : defaults.fog.near;
+      scene.fog.far = Number.isFinite(fogConfig.far) ? fogConfig.far : defaults.fog.far;
+    }
+  }
+
+  if (hemisphere){
+    const hemisphereConfig = environment.hemisphere ?? {};
+    hemisphere.color.set(hemisphereConfig.skyColor ?? defaults.hemisphere.skyColor);
+    hemisphere.groundColor.set(hemisphereConfig.groundColor ?? defaults.hemisphere.groundColor);
+    hemisphere.intensity = Number.isFinite(hemisphereConfig.intensity)
+      ? hemisphereConfig.intensity
+      : defaults.hemisphere.intensity;
+  }
+
+  if (sun){
+    const sunConfig = environment.sun ?? {};
+    sun.color.set(sunConfig.color ?? defaults.sun.color);
+    sun.intensity = Number.isFinite(sunConfig.intensity) ? sunConfig.intensity : defaults.sun.intensity;
+    if (sunConfig.position){
+      assignVector3(sun.position, sunConfig.position);
+    } else {
+      assignVector3(sun.position, defaults.sun.position);
+    }
+  }
+}
+
+function buildDescriptorFromDefinition(mapDefinition){
+  if (!mapDefinition) return null;
+  let descriptor = null;
+  if (mapDefinition.descriptor && typeof mapDefinition.descriptor === 'object'){
+    descriptor = cloneMapDescriptor(mapDefinition.descriptor);
+    descriptor.id = descriptor.id ?? mapDefinition.id;
+    descriptor.type = descriptor.type ?? mapDefinition.type;
+    if (!descriptor.tileSize && Number.isFinite(mapDefinition.tileSize)){
+      descriptor.tileSize = mapDefinition.tileSize;
+    }
+    if (!descriptor.visibleRadius){
+      const fallbackRadius = Number.isFinite(mapDefinition.visibleRadius)
+        ? mapDefinition.visibleRadius
+        : Number.isFinite(mapDefinition.radius)
+          ? mapDefinition.radius
+          : null;
+      if (Number.isFinite(fallbackRadius)){
+        descriptor.visibleRadius = fallbackRadius;
+      }
+    }
+  } else if (mapDefinition.type === 'tilemap'){
+    descriptor = { ...mapDefinition };
+  }
+  return descriptor;
+}
+
+function createWorldFromDescriptor({ scene, mapDefinition }){
+  const descriptor = buildDescriptorFromDefinition(mapDefinition);
+  const descriptorType = typeof descriptor?.type === 'string'
+    ? descriptor.type.toLowerCase()
+    : descriptor?.type;
+
+  if (descriptorType === 'tilemap'){
+    descriptor.type = 'tilemap';
+    descriptor.tiles = Array.isArray(descriptor.tiles)
+      ? descriptor.tiles.map((tile) => cloneTileDescriptor(tile))
+      : Array.isArray(mapDefinition?.tiles)
+        ? mapDefinition.tiles.map((tile) => cloneTileDescriptor(tile))
+        : [];
+    if (!descriptor.tileSize){
+      descriptor.tileSize = Number.isFinite(mapDefinition?.tileSize)
+        ? mapDefinition.tileSize
+        : Number.isFinite(mapDefinition?.chunkSize)
+          ? mapDefinition.chunkSize
+          : 640;
+    }
+    if (Number.isFinite(descriptor.visibleRadius)){
+      mapDefinition.visibleRadius = descriptor.visibleRadius;
+    }
+    mapDefinition.tiles = descriptor.tiles.map((tile) => cloneTileDescriptor(tile));
+    mapDefinition.tileSize = descriptor.tileSize;
+    return new TileMapWorld({ scene, descriptor });
+  }
+
+  if (!mapDefinition.procedural && descriptor?.procedural){
+    const proceduralClone = cloneProceduralConfig(descriptor.procedural);
+    if (proceduralClone) mapDefinition.procedural = proceduralClone;
+  }
+  const chunkSize = Number.isFinite(mapDefinition?.chunkSize)
+    ? mapDefinition.chunkSize
+    : Number.isFinite(descriptor?.chunkSize)
+      ? descriptor.chunkSize
+      : 640;
+  const radius = Number.isFinite(mapDefinition?.radius)
+    ? mapDefinition.radius
+    : Number.isFinite(descriptor?.radius)
+      ? descriptor.radius
+      : 3;
+  const seed = Number.isFinite(mapDefinition?.seed) ? mapDefinition.seed : 982451653;
+  const generatorConfig = mapDefinition?.procedural
+    ?? mapDefinition?.generator
+    ?? descriptor?.procedural
+    ?? descriptor?.generator
+    ?? null;
+  return new TerraWorldStreamer({ scene, chunkSize, radius, seed, generator: generatorConfig });
+}
+
+export function initializeWorldForMap({
+  scene,
+  mapDefinition,
+  currentWorld = null,
+  collisionSystem,
+  projectileManager,
+  environment = {},
+  defaults = DEFAULT_WORLD_ENVIRONMENT,
+} = {}){
+  const normalizedDefinition = mapDefinition
+    ? cloneMapDefinition(mapDefinition)
+    : null;
+
+  if (currentWorld?.dispose){
+    collisionSystem?.setWorld?.(null);
+    projectileManager?.setWorld?.(null);
+    currentWorld.dispose();
+  }
+
+  const world = createWorldFromDescriptor({ scene, mapDefinition: normalizedDefinition ?? cloneMapDefinition(mapDefinition) ?? {} });
+
+  if (collisionSystem){
+    collisionSystem.setWorld(world);
+  }
+  if (projectileManager){
+    projectileManager.setWorld(world);
+  }
+
+  applyMapEnvironment({
+    mapDefinition: normalizedDefinition,
+    scene,
+    documentRef: environment.document,
+    hemisphere: environment.hemisphere,
+    sun: environment.sun,
+    defaults,
+  });
+
+  return { world, collisionSystem, projectileManager, mapDefinition: normalizedDefinition };
+}


### PR DESCRIPTION
## Summary
- extract map cloning, loading, and selection helpers into reusable `viewer/terra/maps.js`
- add `viewer/terra/worldFactory.js` to configure environments and initialize TileMap or Terra worlds
- move HUD presets/configuration and map navigation callbacks into `viewer/terra/hudConfig.js`
- consolidate vehicle lifecycle, stats, and collision handling in `viewer/terra/vehicles.js` and slim `viewer/terra/main.js`

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db1d347874832984ab1a41278106ff