### PR TITLE
Add planet registry and shared materials for cloud-of-orbs viewer

### DIFF
--- a/viewer/cloud-of-orbs/planets/earth.js
+++ b/viewer/cloud-of-orbs/planets/earth.js
@@ -1,0 +1,61 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'earth';
+
+/**
+ * Metadata describing Earth within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Earth',
+  radius: 1,
+  orbitDistance: 1,
+  loadThresholds: {
+    low: 0,
+    medium: 150,
+    high: 300,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Earth for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=32] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 32 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0x2a6bd4,
+    roughness: 0.75,
+    metalness: 0.05,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Earth's surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Earth.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/index.js
+++ b/viewer/cloud-of-orbs/planets/index.js
@@ -1,0 +1,69 @@
+import * as sun from './sun.js';
+import * as mercury from './mercury.js';
+import * as venus from './venus.js';
+import * as earth from './earth.js';
+import * as mars from './mars.js';
+import * as jupiter from './jupiter.js';
+import * as saturn from './saturn.js';
+import * as uranus from './uranus.js';
+import * as neptune from './neptune.js';
+
+const PLANET_MODULES_IN_RENDER_ORDER = [
+  sun,
+  mercury,
+  venus,
+  earth,
+  mars,
+  jupiter,
+  saturn,
+  uranus,
+  neptune,
+];
+
+const PLANET_REGISTRY = new Map(
+  PLANET_MODULES_IN_RENDER_ORDER.map((module) => [module.metadata.id, module]),
+);
+
+/**
+ * Immutable list of planet modules ordered for renderer placement (inner to outer).
+ */
+export const PLANETS_IN_RENDER_ORDER = Object.freeze([...PLANET_MODULES_IN_RENDER_ORDER]);
+
+/**
+ * Retrieve a planet module by its identifier.
+ *
+ * @param {string} id - Planet identifier (e.g. 'earth').
+ * @returns {object|null}
+ */
+export function getPlanetModule(id){
+  return PLANET_REGISTRY.get(id) ?? null;
+}
+
+/**
+ * Retrieve metadata for a planet by identifier.
+ *
+ * @param {string} id - Planet identifier (e.g. 'mars').
+ * @returns {object|null}
+ */
+export function getPlanetMetadata(id){
+  const module = PLANET_REGISTRY.get(id);
+  return module ? module.metadata : null;
+}
+
+/**
+ * Iterate over every registered planet module.
+ *
+ * @returns {IterableIterator<[string, object]>}
+ */
+export function entries(){
+  return PLANET_REGISTRY.entries();
+}
+
+/**
+ * Provide direct access to the registry map without exposing mutation helpers.
+ *
+ * @returns {Map<string, object>}
+ */
+export function getRegistrySnapshot(){
+  return new Map(PLANET_REGISTRY);
+}

--- a/viewer/cloud-of-orbs/planets/jupiter.js
+++ b/viewer/cloud-of-orbs/planets/jupiter.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'jupiter';
+
+/**
+ * Metadata describing Jupiter within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Jupiter',
+  radius: 11.21,
+  orbitDistance: 5.2,
+  loadThresholds: {
+    low: 0,
+    medium: 320,
+    high: 640,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Jupiter for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=48] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 48 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0xd8b694,
+    roughness: 0.8,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Jupiter's surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Jupiter.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/mars.js
+++ b/viewer/cloud-of-orbs/planets/mars.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'mars';
+
+/**
+ * Metadata describing Mars within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Mars',
+  radius: 0.532,
+  orbitDistance: 1.52,
+  loadThresholds: {
+    low: 0,
+    medium: 130,
+    high: 260,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Mars for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=28] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 28 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0xb6562d,
+    roughness: 0.85,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Mars' surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Mars.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/mercury.js
+++ b/viewer/cloud-of-orbs/planets/mercury.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'mercury';
+
+/**
+ * Metadata describing Mercury within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Mercury',
+  radius: 0.383,
+  orbitDistance: 0.39,
+  loadThresholds: {
+    low: 0,
+    medium: 80,
+    high: 160,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Mercury for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=24] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 24 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0x9f8f7f,
+    roughness: 0.9,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Mercury's surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Mercury.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/neptune.js
+++ b/viewer/cloud-of-orbs/planets/neptune.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'neptune';
+
+/**
+ * Metadata describing Neptune within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Neptune',
+  radius: 3.88,
+  orbitDistance: 30.05,
+  loadThresholds: {
+    low: 0,
+    medium: 300,
+    high: 600,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Neptune for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=36] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 36 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0x3553ff,
+    roughness: 0.72,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Neptune's surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Neptune.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/saturn.js
+++ b/viewer/cloud-of-orbs/planets/saturn.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'saturn';
+
+/**
+ * Metadata describing Saturn within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Saturn',
+  radius: 9.45,
+  orbitDistance: 9.58,
+  loadThresholds: {
+    low: 0,
+    medium: 340,
+    high: 680,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Saturn for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=44] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 44 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0xead6a5,
+    roughness: 0.82,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Saturn's surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Saturn.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/sharedMaterials.js
+++ b/viewer/cloud-of-orbs/planets/sharedMaterials.js
@@ -1,0 +1,49 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+
+const materialCache = new Map();
+
+/**
+ * Retrieve a shared material for a planet-like body.
+ * Materials are cached by identifier so that multiple meshes can reuse
+ * the same GPU resources.
+ *
+ * @param {string} id - Unique identifier for the body (e.g. 'earth').
+ * @param {object} [options]
+ * @param {number} [options.color=0xffffff] - Diffuse color of the surface.
+ * @param {number} [options.emissive=0x000000] - Emissive color for glowing bodies.
+ * @param {number} [options.metalness=0] - Metalness value passed to MeshStandardMaterial.
+ * @param {number} [options.roughness=1] - Roughness value passed to MeshStandardMaterial.
+ * @returns {THREE.MeshStandardMaterial}
+ */
+export function getPlanetMaterial(id, {
+  color = 0xffffff,
+  emissive = 0x000000,
+  metalness = 0,
+  roughness = 1,
+} = {}){
+  if (materialCache.has(id)){
+    return materialCache.get(id);
+  }
+
+  const THREE = requireTHREE();
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    emissive,
+    metalness,
+    roughness,
+    flatShading: false,
+  });
+
+  materialCache.set(id, material);
+  return material;
+}
+
+/**
+ * Dispose of every cached material. Useful when tearing down the viewer.
+ */
+export function disposeSharedMaterials(){
+  for (const material of materialCache.values()){
+    material.dispose();
+  }
+  materialCache.clear();
+}

--- a/viewer/cloud-of-orbs/planets/sun.js
+++ b/viewer/cloud-of-orbs/planets/sun.js
@@ -1,0 +1,62 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'sun';
+
+/**
+ * Metadata describing the Sun within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Sun',
+  radius: 109,
+  orbitDistance: 0,
+  loadThresholds: {
+    low: 0,
+    medium: 200,
+    high: 450,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing the Sun for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=48] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 48 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0xffc857,
+    emissive: 0xffa000,
+    roughness: 0.6,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook to describe the Sun's surface scene when entering detail mode.
+ * Currently returns null until higher fidelity assets are implemented.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for the Sun.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/uranus.js
+++ b/viewer/cloud-of-orbs/planets/uranus.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'uranus';
+
+/**
+ * Metadata describing Uranus within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Uranus',
+  radius: 4.01,
+  orbitDistance: 19.2,
+  loadThresholds: {
+    low: 0,
+    medium: 280,
+    high: 560,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Uranus for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=36] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 36 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0x76d6ff,
+    roughness: 0.7,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Uranus' surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Uranus.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}

--- a/viewer/cloud-of-orbs/planets/venus.js
+++ b/viewer/cloud-of-orbs/planets/venus.js
@@ -1,0 +1,60 @@
+import { requireTHREE } from '../../shared/threeSetup.js';
+import { getPlanetMaterial } from './sharedMaterials.js';
+
+const PLANET_ID = 'venus';
+
+/**
+ * Metadata describing Venus within the orbital view.
+ * - id: Unique identifier for registry lookups.
+ * - label: Human readable name displayed in UI.
+ * - radius: Relative radius in Earth units (Earth = 1).
+ * - orbitDistance: Average orbital distance in astronomical units (AU).
+ * - loadThresholds: Distance thresholds (in scene units) for LOD transitions.
+ */
+export const metadata = Object.freeze({
+  id: PLANET_ID,
+  label: 'Venus',
+  radius: 0.949,
+  orbitDistance: 0.72,
+  loadThresholds: {
+    low: 0,
+    medium: 120,
+    high: 240,
+  },
+});
+
+/**
+ * Create a lightweight mesh representing Venus for the solar-system view.
+ *
+ * @param {object} [options]
+ * @param {number} [options.segments=28] - Segments used for the sphere geometry.
+ * @returns {THREE.Mesh}
+ */
+export function createOrbitalMesh({ segments = 28 } = {}){
+  const THREE = requireTHREE();
+  const geometry = new THREE.SphereGeometry(metadata.radius, segments, segments);
+  const material = getPlanetMaterial(PLANET_ID, {
+    color: 0xd4b36b,
+    roughness: 0.85,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = metadata.label;
+  mesh.userData = { planetId: PLANET_ID };
+  return mesh;
+}
+
+/**
+ * Optional hook describing Venus' surface scene for future high-detail loads.
+ * @returns {null}
+ */
+export function createSurfaceDescriptor(){
+  return null;
+}
+
+/**
+ * Optional async hook to load detailed assets for Venus.
+ * @returns {Promise<null>}
+ */
+export async function loadDetailAssets(){
+  return null;
+}


### PR DESCRIPTION
## Summary
- add modular planet definitions for the Sun through Neptune with metadata, mesh factories, and documented hooks
- introduce shared planet material helper for caching and disposal
- register the planets with a central index to manage render order and lookups

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db224bb4c48329b3aae0cae24518e2