### PR TITLE
Add Cloud of Orbs sandbox bootstrap

### DIFF
--- a/viewer/cloud-of-orbs/InputManager.js
+++ b/viewer/cloud-of-orbs/InputManager.js
@@ -1,0 +1,101 @@
+import { TerraInputManager } from '../terra/InputManager.js';
+
+const DEFAULT_SYSTEM_BINDINGS = Object.freeze({
+  systemNextPlanet: ['BracketRight', 'Period'],
+  systemPreviousPlanet: ['BracketLeft', 'Comma'],
+});
+
+function mergeBindings(base, override){
+  const result = { ...base };
+  if (!override) return result;
+  for (const [key, value] of Object.entries(override)){
+    if (Array.isArray(value)){
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export class CloudOfOrbsInputManager extends TerraInputManager {
+  constructor({ keyBindings = {}, ...rest } = {}){
+    const mergedBindings = mergeBindings(DEFAULT_SYSTEM_BINDINGS, keyBindings);
+    super({ keyBindings: { ...mergedBindings, ...keyBindings }, ...rest });
+    this.systemBindings = mergedBindings;
+    this.pendingSystemCycle = 0;
+    this.orbitalControlsEnabled = true;
+    this.primaryPointerActive = false;
+  }
+
+  setOrbitalControlsEnabled(enabled){
+    this.orbitalControlsEnabled = Boolean(enabled);
+    if (!this.orbitalControlsEnabled){
+      this.primaryPointerActive = false;
+    }
+  }
+
+  handleKeyDown(event){
+    super.handleKeyDown(event);
+    if (this._matchesBinding(this.systemBindings.systemNextPlanet, event.code)){
+      this.pendingSystemCycle += 1;
+      event.preventDefault();
+    } else if (this._matchesBinding(this.systemBindings.systemPreviousPlanet, event.code)){
+      this.pendingSystemCycle -= 1;
+      event.preventDefault();
+    }
+  }
+
+  handlePointerMove(event){
+    if (this.orbitalControlsEnabled && (event.buttons & 1) === 1){
+      this.cameraOrbitDelta.x += event.movementX ?? 0;
+      this.cameraOrbitDelta.y += event.movementY ?? 0;
+    }
+    super.handlePointerMove(event);
+  }
+
+  handlePointerDown(event){
+    if (this.orbitalControlsEnabled && event.button === 0){
+      this.orbitActive = true;
+      this.primaryPointerActive = true;
+      event.preventDefault();
+      return;
+    }
+    super.handlePointerDown(event);
+  }
+
+  handlePointerUp(event){
+    if (this.orbitalControlsEnabled && event.button === 0){
+      this.orbitActive = false;
+      this.primaryPointerActive = false;
+      event.preventDefault();
+      return;
+    }
+    super.handlePointerUp(event);
+  }
+
+  handlePointerLeave(event){
+    super.handlePointerLeave(event);
+    if (this.orbitalControlsEnabled){
+      this.primaryPointerActive = false;
+    }
+  }
+
+  readState(dt){
+    const zoomImpulse = this.throttleImpulse;
+    const sample = super.readState(dt);
+    const cycle = this.pendingSystemCycle;
+    this.pendingSystemCycle = 0;
+    sample.system = {
+      zoomDelta: zoomImpulse,
+      cycle,
+      orbitActive: this.orbitActive,
+    };
+    return sample;
+  }
+
+  _matchesBinding(binding, code){
+    if (!Array.isArray(binding)) return false;
+    return binding.includes(code);
+  }
+}
+
+export default CloudOfOrbsInputManager;

--- a/viewer/cloud-of-orbs/SolarSystemWorld.js
+++ b/viewer/cloud-of-orbs/SolarSystemWorld.js
@@ -1,0 +1,331 @@
+import { requireTHREE } from '../shared/threeSetup.js';
+
+const THREE = requireTHREE();
+
+const TMP_SPHERICAL = new THREE.Spherical();
+
+const DEFAULT_RADIUS_SCALE = 120;
+const DEFAULT_ORBIT_SCALE = 3200;
+const DEFAULT_AUTO_ORBIT_SPEED = 0.045;
+const CAMERA_BLEND_RATE = 6.4;
+const DISTANCE_BLEND_RATE = 5.1;
+
+function createFallbackMesh(label = 'Body'){
+  const geometry = new THREE.SphereGeometry(1, 24, 24);
+  const material = new THREE.MeshStandardMaterial({ color: 0x9cb3ff, roughness: 0.68 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = label;
+  return mesh;
+}
+
+function cloneThresholds(thresholds){
+  if (!thresholds) return null;
+  return {
+    approachEnter: thresholds.approachEnter,
+    surfaceEnter: thresholds.surfaceEnter,
+    departLeave: thresholds.departLeave,
+    systemLeave: thresholds.systemLeave,
+  };
+}
+
+export class SolarSystemWorld {
+  constructor({
+    scene = null,
+    camera = null,
+    planetRegistry = new Map(),
+    radiusScale = DEFAULT_RADIUS_SCALE,
+    orbitScale = DEFAULT_ORBIT_SCALE,
+    autoOrbitSpeed = DEFAULT_AUTO_ORBIT_SPEED,
+    initialPlanetId = null,
+  } = {}){
+    this.scene = scene;
+    this.camera = camera;
+    this.radiusScale = radiusScale;
+    this.orbitScale = orbitScale;
+    this.autoOrbitSpeed = autoOrbitSpeed;
+
+    this.root = new THREE.Group();
+    this.root.name = 'SolarSystemWorld';
+    if (this.scene){
+      this.scene.add(this.root);
+    }
+
+    this.planets = new Map();
+    this.planetList = [];
+
+    this.cameraTarget = new THREE.Vector3();
+    this.cameraPosition = new THREE.Vector3();
+    this.orbitAngles = { yaw: 0, pitch: 0 };
+    this.autoOrbitEnabled = true;
+
+    this.cameraDistance = 6400;
+    this.targetCameraDistance = this.cameraDistance;
+    this.minDistance = 1800;
+    this.maxDistance = 38000;
+    this.zoomSpeed = 620;
+    this.zoomNormalized = 0.25;
+
+    this.metrics = {
+      planetId: null,
+      distanceToSurface: Number.POSITIVE_INFINITY,
+      altitude: Number.POSITIVE_INFINITY,
+      thresholds: null,
+    };
+
+    this._initializePlanets(planetRegistry);
+
+    this.focusPlanetId = initialPlanetId ?? this._getDefaultPlanetId();
+    this.setFocusPlanet(this.focusPlanetId);
+
+    this.cameraRig = {
+      camera: this.camera,
+      update: (dt, _metrics, orbitInput) => {
+        this._updateCamera(dt, orbitInput);
+      },
+    };
+  }
+
+  dispose(){
+    if (this.scene && this.root){
+      this.scene.remove(this.root);
+    }
+    this.planets.clear();
+    this.planetList.length = 0;
+  }
+
+  getCameraRig(){
+    return this.cameraRig;
+  }
+
+  getFocusPlanetId(){
+    return this.focusPlanetId;
+  }
+
+  getPlanetOptions(){
+    return this.planetList.map(({ id, metadata }) => ({
+      id,
+      name: metadata.label ?? id,
+      description: metadata.description ?? '',
+    }));
+  }
+
+  getProximityMetrics(){
+    const { planetId, distanceToSurface, altitude, thresholds } = this.metrics;
+    return {
+      planetId,
+      distanceToSurface,
+      altitude,
+      thresholds: cloneThresholds(thresholds),
+    };
+  }
+
+  getZoomLevel(){
+    return this.zoomNormalized;
+  }
+
+  cycleFocus(delta = 1){
+    if (!Number.isFinite(delta) || this.planetList.length === 0) return this.focusPlanetId;
+    const index = this.planetList.findIndex((entry) => entry.id === this.focusPlanetId);
+    if (index < 0){
+      this.setFocusPlanet(this.planetList[0].id);
+      return this.focusPlanetId;
+    }
+    const nextIndex = (index + delta + this.planetList.length) % this.planetList.length;
+    this.setFocusPlanet(this.planetList[nextIndex].id);
+    return this.focusPlanetId;
+  }
+
+  setFocusPlanet(planetId){
+    if (!planetId || !this.planets.has(planetId)){
+      return false;
+    }
+    const entry = this.planets.get(planetId);
+    this.focusPlanetId = planetId;
+    this.metrics.planetId = planetId;
+    this._updateDistanceBounds(entry);
+    this._updateMetrics(entry);
+    return true;
+  }
+
+  update(dt = 0, { inputSample = null } = {}){
+    const planet = this.planets.get(this.focusPlanetId);
+    if (!planet){
+      this.metrics.distanceToSurface = Number.POSITIVE_INFINITY;
+      this.metrics.altitude = Number.POSITIVE_INFINITY;
+      this.metrics.thresholds = null;
+      return this.metrics;
+    }
+
+    const zoomDelta = inputSample?.system?.zoomDelta ?? 0;
+    this._updateZoom(dt, zoomDelta, planet);
+
+    const orbitDelta = dt * planet.orbitAngularSpeed;
+    planet.pivot.rotation.y += orbitDelta;
+    planet.mesh.rotation.y += dt * planet.spinSpeed;
+
+    this._updateMetrics(planet);
+    this.lastInputOrbitActive = inputSample?.system?.orbitActive ?? false;
+    this.lastOrbitInput = inputSample?.cameraOrbit ?? null;
+    return this.metrics;
+  }
+
+  _initializePlanets(planetRegistry){
+    const registry = planetRegistry instanceof Map
+      ? planetRegistry
+      : new Map(Object.entries(planetRegistry ?? {}));
+
+    registry.forEach((module, id) => {
+      const metadata = module?.metadata ?? { id };
+      const planetId = metadata.id ?? id;
+      const radius = Math.abs(metadata.radius ?? 1) * this.radiusScale;
+      const orbitDistance = Math.abs(metadata.orbitDistance ?? 0) * this.orbitScale;
+
+      const pivot = new THREE.Group();
+      pivot.name = `${planetId}-pivot`;
+
+      let mesh = null;
+      if (module && typeof module.createOrbitalMesh === 'function'){
+        try {
+          mesh = module.createOrbitalMesh({ segments: Math.max(16, Math.round(32 + radius * 0.08)) });
+        } catch (error){
+          console.warn(`[SolarSystemWorld] Failed to create mesh for ${planetId}`, error);
+        }
+      }
+      if (!mesh){
+        mesh = createFallbackMesh(metadata.label ?? planetId);
+      }
+
+      mesh.scale.setScalar(this.radiusScale);
+      mesh.position.set(orbitDistance, 0, 0);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      pivot.add(mesh);
+      this.root.add(pivot);
+
+      const orbitAngularSpeed = THREE.MathUtils.degToRad(Math.max(2, 48 / Math.max(0.2, metadata.orbitDistance ?? 1))) * 0.0016;
+      const spinSpeed = THREE.MathUtils.degToRad(18 / Math.sqrt(Math.max(0.25, metadata.radius ?? 1))) * 0.45;
+
+      const entry = {
+        id: planetId,
+        metadata,
+        module,
+        mesh,
+        pivot,
+        radius,
+        orbitDistance,
+        orbitAngularSpeed,
+        spinSpeed,
+      };
+      this.planets.set(planetId, entry);
+      this.planetList.push(entry);
+    });
+
+    this.planetList.sort((a, b) => a.orbitDistance - b.orbitDistance);
+  }
+
+  _getDefaultPlanetId(){
+    if (this.planetList.length === 0) return null;
+    const earthIndex = this.planetList.findIndex((entry) => entry.id === 'earth');
+    if (earthIndex >= 0) return this.planetList[earthIndex].id;
+    return this.planetList[Math.min(2, this.planetList.length - 1)].id;
+  }
+
+  _updateZoom(dt, zoomDelta, planet){
+    if (Number.isFinite(zoomDelta) && zoomDelta !== 0){
+      const step = zoomDelta * this.zoomSpeed;
+      this.targetCameraDistance = THREE.MathUtils.clamp(
+        this.targetCameraDistance - step,
+        this.minDistance,
+        this.maxDistance,
+      );
+    }
+    const blend = dt > 0 ? 1 - Math.exp(-DISTANCE_BLEND_RATE * dt) : 1;
+    this.cameraDistance += (this.targetCameraDistance - this.cameraDistance) * blend;
+    this.zoomNormalized = this._computeZoomNormalized();
+  }
+
+  _computeZoomNormalized(){
+    if (!Number.isFinite(this.minDistance) || !Number.isFinite(this.maxDistance)) return 0;
+    if (this.maxDistance <= this.minDistance) return 0;
+    const ratio = (this.cameraDistance - this.minDistance) / (this.maxDistance - this.minDistance);
+    return THREE.MathUtils.clamp(ratio, 0, 1);
+  }
+
+  _updateCamera(dt, orbitInput){
+    const planet = this.planets.get(this.focusPlanetId);
+    if (!planet || !this.camera) return;
+
+    const input = orbitInput ?? this.lastOrbitInput ?? {};
+    const yawDelta = input?.yawDelta ?? 0;
+    const pitchDelta = input?.pitchDelta ?? 0;
+    const active = input?.active ?? this.lastInputOrbitActive ?? false;
+
+    if (active){
+      this.orbitAngles.yaw += yawDelta;
+      this.orbitAngles.pitch += pitchDelta;
+    } else {
+      this.orbitAngles.yaw += yawDelta * 0.5;
+      this.orbitAngles.pitch += pitchDelta * 0.5;
+      if (this.autoOrbitEnabled){
+        this.orbitAngles.yaw += this.autoOrbitSpeed * (dt || 0);
+      }
+    }
+
+    this.orbitAngles.pitch = THREE.MathUtils.clamp(this.orbitAngles.pitch, -Math.PI / 2 + 0.14, Math.PI / 2 - 0.14);
+
+    const worldTarget = planet.mesh.getWorldPosition(this.cameraTarget);
+    const distance = Math.max(this.cameraDistance, planet.radius * 1.2);
+    const phi = Math.PI / 2 - this.orbitAngles.pitch;
+    const theta = this.orbitAngles.yaw;
+    TMP_SPHERICAL.set(distance, phi, theta);
+    this.cameraPosition.setFromSpherical(TMP_SPHERICAL).add(worldTarget);
+
+    if (dt > 0){
+      const blend = 1 - Math.exp(-CAMERA_BLEND_RATE * dt);
+      this.camera.position.lerp(this.cameraPosition, blend);
+    } else {
+      this.camera.position.copy(this.cameraPosition);
+    }
+    this.camera.lookAt(worldTarget);
+    this.camera.up.set(0, 1, 0);
+  }
+
+  _updateDistanceBounds(planet){
+    const base = Math.max(planet.radius * 2.6, 1200);
+    const orbitInfluence = Math.max(planet.orbitDistance * 0.12, 0);
+    this.minDistance = base + orbitInfluence * 0.18;
+    this.maxDistance = Math.max(this.minDistance * 4.5, base * 6.8, planet.orbitDistance * 1.4 + base * 1.8);
+
+    const preferred = planet.radius * 4.4 + orbitInfluence * 0.4;
+    const clampedTarget = THREE.MathUtils.clamp(preferred, this.minDistance * 1.05, this.maxDistance * 0.9);
+
+    this.targetCameraDistance = clampedTarget;
+    this.cameraDistance = clampedTarget;
+    this.zoomNormalized = this._computeZoomNormalized();
+  }
+
+  _updateMetrics(planet){
+    const thresholds = this._computeThresholds(planet);
+    const altitude = Math.max(0, this.cameraDistance - planet.radius);
+    this.metrics.planetId = planet.id;
+    this.metrics.distanceToSurface = altitude;
+    this.metrics.altitude = altitude;
+    this.metrics.thresholds = thresholds;
+  }
+
+  _computeThresholds(planet){
+    const base = Math.max(this.minDistance, planet.radius * 2.8);
+    const surface = Math.max(planet.radius * 1.4, base * 0.55);
+    const depart = Math.max(surface * 1.6, base * 0.9);
+    const approach = Math.max(depart * 1.32, base * 1.25);
+    const system = Math.max(approach * 1.45, depart * 1.75);
+    return {
+      approachEnter: approach,
+      surfaceEnter: surface,
+      departLeave: depart,
+      systemLeave: system,
+    };
+  }
+}
+
+export default SolarSystemWorld;

--- a/viewer/cloud-of-orbs/hudConfig.js
+++ b/viewer/cloud-of-orbs/hudConfig.js
@@ -1,0 +1,84 @@
+export function createHudPresets(){
+  return {
+    system: {
+      title: 'Orbital Control',
+      throttleLabel: 'ZOOM',
+      metricLabels: {
+        speed: 'Velocity',
+        crashes: 'Participants',
+        time: 'Session',
+        distance: 'Altitude',
+      },
+      items: [
+        { label: 'Orbit', detail: 'Hold Mouse — pan around focus' },
+        { label: 'Zoom', detail: 'Scroll — adjust altitude' },
+        { label: 'Select', detail: 'HUD picker — choose planet' },
+      ],
+    },
+    approach: {
+      title: 'Atmospheric Entry',
+      throttleLabel: 'THR',
+      metricLabels: {
+        speed: 'Airspeed',
+        crashes: 'Incidents',
+        time: 'Flight Time',
+        distance: 'Altitude',
+      },
+      items: [
+        { label: 'Cycle', detail: '[ / ] — change pilot' },
+        { label: 'Focus', detail: 'F — snap to target' },
+        { label: 'Fire', detail: 'Click / Space — fire turret' },
+      ],
+    },
+    surface: {
+      title: 'Surface Operations',
+      throttleLabel: 'PWR',
+      metricLabels: {
+        speed: 'Speed',
+        crashes: 'Incidents',
+        time: 'Uptime',
+        distance: 'Distance',
+      },
+      items: [
+        { label: 'Cycle', detail: '[ / ] — change pilot' },
+        { label: 'Focus', detail: 'F — snap to target' },
+        { label: 'Mode', detail: '1 / 2 — toggle air / ground' },
+      ],
+    },
+    departing: {
+      title: 'Departure Burn',
+      throttleLabel: 'THR',
+      metricLabels: {
+        speed: 'Velocity',
+        crashes: 'Incidents',
+        time: 'Uptime',
+        distance: 'Altitude',
+      },
+      items: [
+        { label: 'Cycle', detail: '[ / ] — change pilot' },
+        { label: 'Focus', detail: 'F — snap to target' },
+        { label: 'Fire', detail: 'Click / Space — fire turret' },
+      ],
+    },
+  };
+}
+
+export function createHud({
+  TerraHUDClass,
+  ammoOptions = [],
+  mapOptions = [],
+  onAmmoSelect,
+  onMapSelect,
+  presets = createHudPresets(),
+} = {}){
+  const hud = new TerraHUDClass({
+    controls: presets.system,
+    ammoOptions,
+    mapOptions,
+    onAmmoSelect,
+    onMapSelect,
+  });
+  return { hud, presets };
+}
+
+export default { createHudPresets, createHud };

--- a/viewer/cloud-of-orbs/index.html
+++ b/viewer/cloud-of-orbs/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>DriftPursuit – Cloud of Orbs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: radial-gradient(circle at 20% 20%, #1c2a46 0%, #0d1528 55%, #05060b 100%);
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/viewer/cloud-of-orbs/main.js
+++ b/viewer/cloud-of-orbs/main.js
@@ -1,0 +1,375 @@
+/**
+ * Cloud of Orbs bootstrap sequence.
+ *
+ * To run alongside the Terra sandbox:
+ * 1. Start the local viewer dev server (e.g. `npm run viewer` or `python -m http.server` from the repo root).
+ * 2. Open `viewer/cloud-of-orbs/index.html` in a modern browser.
+ * 3. Ensure `three.min.js` is served globally (handled via the CDN script tag in `index.html`).
+ *
+ * This file mirrors Terra's initialization flow while orchestrating the orbital view and
+ * the surface transition manager.
+ */
+
+import { createRenderer, createPerspectiveCamera, enableWindowResizeHandling, requireTHREE } from '../shared/threeSetup.js';
+import { TerraHUD } from '../terra/TerraHUD.js';
+import { TerraProjectileManager } from '../terra/Projectiles.js';
+import { DEFAULT_WORLD_ENVIRONMENT } from '../terra/worldFactory.js';
+import { PLANETS_IN_RENDER_ORDER, getRegistrySnapshot } from './planets/index.js';
+import { createHud, createHudPresets } from './hudConfig.js';
+import { SolarSystemWorld } from './SolarSystemWorld.js';
+import { PlanetSurfaceManager, PlanetSurfaceState } from './PlanetSurfaceManager.js';
+import { CloudOfOrbsInputManager } from './InputManager.js';
+
+const THREE = requireTHREE();
+
+const DEFAULT_SURFACE_DESCRIPTOR = {
+  id: 'aurora-basin',
+  name: 'Aurora Basin',
+  description: 'Rolling terrain under bright aurora skies.',
+  type: 'procedural',
+  seed: 982451653,
+  chunkSize: 640,
+  radius: 3,
+  environment: {
+    background: '#90b6ff',
+    bodyBackground: DEFAULT_WORLD_ENVIRONMENT.bodyBackground,
+    fog: {
+      color: '#a4c6ff',
+      near: DEFAULT_WORLD_ENVIRONMENT.fog.near,
+      far: DEFAULT_WORLD_ENVIRONMENT.fog.far,
+    },
+    sun: {
+      position: DEFAULT_WORLD_ENVIRONMENT.sun.position,
+      intensity: DEFAULT_WORLD_ENVIRONMENT.sun.intensity,
+      color: '#ffffff',
+    },
+    hemisphere: {
+      skyColor: '#dce9ff',
+      groundColor: '#2b4a2e',
+      intensity: DEFAULT_WORLD_ENVIRONMENT.hemisphere.intensity,
+    },
+  },
+};
+
+const FIRE_COOLDOWN = 0.35;
+const MIN_FAILED_FIRE_DELAY = 0.12;
+
+const planetRegistry = getRegistrySnapshot();
+const initialPlanetId = planetRegistry.has('earth')
+  ? 'earth'
+  : PLANETS_IN_RENDER_ORDER[0]?.metadata?.id
+  ?? Array.from(planetRegistry.keys())[0]
+  ?? null;
+
+const planetOptions = PLANETS_IN_RENDER_ORDER.map((module) => ({
+  id: module.metadata.id,
+  name: module.metadata.label,
+  description: module.metadata.description ?? '',
+}));
+
+const ammoManager = new TerraProjectileManager({ scene: null, world: null });
+const ammoOptions = ammoManager.getAmmoTypes();
+
+const input = new CloudOfOrbsInputManager();
+input.setOrbitalControlsEnabled(true);
+
+const hudPresets = createHudPresets();
+const { hud } = createHud({
+  TerraHUDClass: TerraHUD,
+  ammoOptions,
+  mapOptions: planetOptions,
+  onAmmoSelect: handleAmmoSelection,
+  onMapSelect: handlePlanetSelection,
+  presets: hudPresets,
+});
+
+hud.setActiveAmmo(ammoManager.getCurrentAmmoId());
+hud.setControls(hudPresets.system);
+
+const renderer = createRenderer({ enableShadows: true });
+document.body.style.margin = '0';
+document.body.style.overflow = 'hidden';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x050b16);
+scene.fog = new THREE.Fog(0x050b16, 12000, 36000);
+
+const camera = createPerspectiveCamera({ fov: 60, near: 0.1, far: 260000 });
+
+const hemisphere = new THREE.HemisphereLight(0x3a4c72, 0x040608, 0.45);
+scene.add(hemisphere);
+
+const sunLight = new THREE.DirectionalLight(0xfff0d2, 2.15);
+sunLight.position.set(-5200, 4200, 2600);
+sunLight.castShadow = true;
+sunLight.shadow.mapSize.set(4096, 4096);
+sunLight.shadow.camera.near = 100;
+sunLight.shadow.camera.far = 32000;
+sunLight.shadow.camera.left = -16000;
+sunLight.shadow.camera.right = 16000;
+sunLight.shadow.camera.top = 16000;
+sunLight.shadow.camera.bottom = -16000;
+scene.add(sunLight);
+
+const ambient = new THREE.AmbientLight(0x0f1c34, 0.32);
+scene.add(ambient);
+
+const solarSystem = new SolarSystemWorld({
+  scene,
+  camera,
+  planetRegistry,
+  initialPlanetId,
+});
+
+const surfaceManager = new PlanetSurfaceManager({
+  scene,
+  camera,
+  planetRegistry,
+  orbitalCameraRig: solarSystem.getCameraRig(),
+  hud,
+  hudPresets,
+  projectileManager: ammoManager,
+  environment: { document, hemisphere, sun: sunLight, defaults: DEFAULT_WORLD_ENVIRONMENT },
+  onStateChange: handleSurfaceStateChange,
+  onSurfaceReady: handleSurfaceReady,
+  onSurfaceDisposed: handleSurfaceDisposed,
+  defaultSurfaceDescriptor: DEFAULT_SURFACE_DESCRIPTOR,
+});
+
+const vehicleOpsQueue = [];
+const activeFireSources = new Set();
+let fireInputHeld = false;
+let fireCooldownTimer = 0;
+let elapsedTime = 0;
+let lastFrameTime = typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+handlePlanetSelection(initialPlanetId);
+hud.setActiveMap(initialPlanetId ?? '');
+hud.setMapLabel('Orbital Overview');
+
+ammoManager.setScene?.(scene);
+ammoManager.setWorld?.(null);
+
+enableWindowResizeHandling({ renderer, camera });
+requestAnimationFrame(animate);
+
+window.addEventListener('keydown', (event) => {
+  if (event.defaultPrevented) return;
+  const state = surfaceManager.getState();
+  if (event.code === 'BracketRight'){
+    enqueueVehicleOp((system) => system.cycleActiveVehicle?.(1));
+    if (state === PlanetSurfaceState.SYSTEM_VIEW){
+      solarSystem.cycleFocus(1);
+      handlePlanetSelection(solarSystem.getFocusPlanetId());
+    }
+    event.preventDefault();
+  } else if (event.code === 'BracketLeft'){
+    enqueueVehicleOp((system) => system.cycleActiveVehicle?.(-1));
+    if (state === PlanetSurfaceState.SYSTEM_VIEW){
+      solarSystem.cycleFocus(-1);
+      handlePlanetSelection(solarSystem.getFocusPlanetId());
+    }
+    event.preventDefault();
+  } else if (event.code === 'KeyF'){
+    enqueueVehicleOp((system) => system.handleFocusShortcut?.());
+    event.preventDefault();
+  } else if ((event.code === 'Space' || event.code === 'KeyX' || event.code === 'Enter') && !event.repeat){
+    setFireSourceActive(event.code, true);
+    event.preventDefault();
+  }
+});
+
+window.addEventListener('keyup', (event) => {
+  if (event.code === 'Space' || event.code === 'KeyX' || event.code === 'Enter'){
+    setFireSourceActive(event.code, false);
+    event.preventDefault();
+  }
+});
+
+window.addEventListener('mousedown', (event) => {
+  if (event.button === 0 && surfaceManager.getState() !== PlanetSurfaceState.SYSTEM_VIEW){
+    setFireSourceActive(`mouse-${event.button}`, true);
+    event.preventDefault();
+  }
+});
+
+window.addEventListener('mouseup', (event) => {
+  if (event.button === 0){
+    setFireSourceActive(`mouse-${event.button}`, false);
+    event.preventDefault();
+  }
+});
+
+window.addEventListener('mouseleave', () => {
+  setFireSourceActive('mouse-0', false);
+});
+
+window.addEventListener('blur', () => {
+  resetFireInput();
+});
+
+window.DriftPursuitCloud = {
+  join: (id, options) => enqueueVehicleOp((system) => system.handlePlayerJoin?.(id, options)),
+  leave: (id) => enqueueVehicleOp((system) => system.handlePlayerLeave?.(id)),
+  cycle: (delta = 1) => enqueueVehicleOp((system) => system.cycleActiveVehicle?.(delta)),
+  focus: () => enqueueVehicleOp((system) => system.handleFocusShortcut?.()),
+  setActive: (id) => enqueueVehicleOp((system) => system.setActiveVehicle?.(id)),
+  update: (id, snapshot) => enqueueVehicleOp((system) => system.applyVehicleSnapshot?.(id, snapshot)),
+  fire: () => surfaceManager.vehicleSystem?.fireActiveVehicleProjectile?.() ?? false,
+  setAmmo: (ammoId) => {
+    const accepted = ammoManager.setAmmoType(ammoId);
+    if (accepted){
+      hud.setActiveAmmo(ammoManager.getCurrentAmmoId());
+    }
+    return accepted;
+  },
+  getTrackedVehicles(){
+    return surfaceManager.vehicleSystem?.getTrackedVehicles?.() ?? [];
+  },
+  selectPlanet: (planetId) => handlePlanetSelection(planetId),
+  getState: () => surfaceManager.getState(),
+};
+
+function animate(now){
+  requestAnimationFrame(animate);
+  const dt = Math.min(0.08, ((now ?? performance.now()) - lastFrameTime) / 1000 || 0);
+  lastFrameTime = now;
+  elapsedTime += dt;
+
+  const inputSample = input.readState(dt);
+
+  if (inputSample.system?.cycle && surfaceManager.getState() === PlanetSurfaceState.SYSTEM_VIEW){
+    solarSystem.cycleFocus(inputSample.system.cycle);
+    handlePlanetSelection(solarSystem.getFocusPlanetId());
+  }
+
+  const proximityMetrics = solarSystem.update(dt, { inputSample });
+
+  surfaceManager.update({
+    dt,
+    elapsedTime,
+    inputSample,
+    orbitInput: inputSample.cameraOrbit,
+    proximityMetrics,
+  });
+
+  flushVehicleQueue();
+
+  fireCooldownTimer = Math.max(0, fireCooldownTimer - dt);
+  if (fireInputHeld && fireCooldownTimer <= 0){
+    const fired = surfaceManager.vehicleSystem?.fireActiveVehicleProjectile?.() ?? false;
+    fireCooldownTimer = fired ? FIRE_COOLDOWN : MIN_FAILED_FIRE_DELAY;
+  }
+
+  if (surfaceManager.getState() === PlanetSurfaceState.SYSTEM_VIEW){
+    const altitude = proximityMetrics?.altitude ?? 0;
+    const vehicleMap = surfaceManager.vehicleSystem?.getVehicles?.() ?? null;
+    const participantCount = vehicleMap ? vehicleMap.size ?? 0 : 0;
+    hud.update({
+      throttle: 1 - solarSystem.getZoomLevel(),
+      speed: 0,
+      crashCount: participantCount,
+      elapsedTime,
+      distance: altitude,
+    });
+    const focused = solarSystem.getFocusPlanetId();
+    const module = focused ? planetRegistry.get(focused) : null;
+    hud.setMapLabel(module?.metadata?.label ?? 'Orbital Overview');
+  }
+
+  const activeCamera = surfaceManager.getActiveCamera() ?? camera;
+  renderer.render(scene, activeCamera);
+}
+
+function enqueueVehicleOp(operation){
+  if (!operation) return;
+  if (surfaceManager.vehicleSystem){
+    try {
+      operation(surfaceManager.vehicleSystem);
+    } catch (error){
+      console.warn('[CloudOfOrbs] Vehicle operation failed', error);
+    }
+    return;
+  }
+  vehicleOpsQueue.push(operation);
+}
+
+function flushVehicleQueue(){
+  if (!surfaceManager.vehicleSystem || vehicleOpsQueue.length === 0){
+    return;
+  }
+  while (vehicleOpsQueue.length){
+    const operation = vehicleOpsQueue.shift();
+    try {
+      operation(surfaceManager.vehicleSystem);
+    } catch (error){
+      console.warn('[CloudOfOrbs] Deferred vehicle op failed', error);
+    }
+  }
+}
+
+function handleAmmoSelection(ammoId){
+  if (!ammoId) return;
+  const accepted = ammoManager.setAmmoType(ammoId);
+  if (!accepted){
+    hud.setActiveAmmo(ammoManager.getCurrentAmmoId());
+  }
+}
+
+function handlePlanetSelection(planetId){
+  if (!planetId) return;
+  solarSystem.setFocusPlanet(planetId);
+  surfaceManager.selectPlanet(planetId);
+  hud.setActiveMap(planetId);
+  if (surfaceManager.getState() === PlanetSurfaceState.SYSTEM_VIEW){
+    const module = planetRegistry.get(planetId);
+    hud.setMapLabel(module?.metadata?.label ?? 'Orbital Overview');
+  }
+}
+
+function handleSurfaceStateChange({ next, planetId }){
+  input.setOrbitalControlsEnabled(next === PlanetSurfaceState.SYSTEM_VIEW);
+  switch (next){
+    case PlanetSurfaceState.SYSTEM_VIEW:
+      hud.setControls(hudPresets.system);
+      hud.setMapLabel('Orbital Overview');
+      break;
+    case PlanetSurfaceState.APPROACH:
+      hud.setControls(hudPresets.approach);
+      hud.setMapLabel(planetRegistry.get(planetId)?.metadata?.label ?? 'Approach Vector');
+      break;
+    case PlanetSurfaceState.SURFACE:
+      hud.setControls(hudPresets.surface);
+      hud.setMapLabel(planetRegistry.get(planetId)?.metadata?.label ?? 'Surface');
+      break;
+    case PlanetSurfaceState.DEPARTING:
+      hud.setControls(hudPresets.departing);
+      hud.setMapLabel(planetRegistry.get(planetId)?.metadata?.label ?? 'Departure Burn');
+      break;
+    default:
+      break;
+  }
+}
+
+function handleSurfaceReady(){
+  flushVehicleQueue();
+}
+
+function handleSurfaceDisposed(){
+  resetFireInput();
+}
+
+function setFireSourceActive(source, active){
+  if (!source) return;
+  if (active){
+    activeFireSources.add(source);
+  } else {
+    activeFireSources.delete(source);
+  }
+  fireInputHeld = activeFireSources.size > 0;
+}
+
+function resetFireInput(){
+  activeFireSources.clear();
+  fireInputHeld = false;
+}


### PR DESCRIPTION
## Summary
- add a dedicated Cloud of Orbs entry page that loads the new viewer bundle
- implement orbital world, HUD presets, and input extensions to bridge orbital and surface play
- bootstrap the sandbox to share vehicles, projectiles, and HUD updates across states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db2e80e1f8832993fbcb2003c280e2