### PR TITLE
Add map label setter to TerraHUD

### DIFF
--- a/viewer/cloud-of-orbs/PlanetSurfaceManager.js
+++ b/viewer/cloud-of-orbs/PlanetSurfaceManager.js
@@ -127,6 +127,7 @@ export class PlanetSurfaceManager {
       : new Map(Object.entries(planetRegistry ?? {}));
     this.hud = hud;
     this.hudPresets = hudPresets ?? {};
+    this.defaultMapLabel = 'Orbital Overview';
     this.environment = {
       document: environment.document ?? (typeof document !== 'undefined' ? document : null),
       hemisphere: environment.hemisphere ?? null,
@@ -408,13 +409,17 @@ export class PlanetSurfaceManager {
   }
 
   _setHudMapLabel(text){
-    if (!this.hud || !text) return;
+    if (!this.hud) return;
+    const label = typeof text === 'string' && text.trim()
+      ? text
+      : this.defaultMapLabel;
+    if (!label) return;
     if (typeof this.hud.setMapLabel === 'function'){
-      this.hud.setMapLabel(text);
+      this.hud.setMapLabel(label);
       return;
     }
     if (this.hud.mapLabel && typeof this.hud.mapLabel.textContent === 'string'){
-      this.hud.mapLabel.textContent = text;
+      this.hud.mapLabel.textContent = label;
     }
   }
 

--- a/viewer/terra/TerraHUD.js
+++ b/viewer/terra/TerraHUD.js
@@ -307,6 +307,7 @@ export class TerraHUD extends BaseHUD {
     this.ammoButtons = new Map();
     this.selectedMapId = null;
     this.mapOptions = [];
+    this.mapLabelText = 'Active Map';
 
     this._applyTheme();
     this._createToolbar();
@@ -352,7 +353,7 @@ export class TerraHUD extends BaseHUD {
 
     this.mapLabel = document.createElement('div');
     applyStyle(this.mapLabel, MAP_LABEL_STYLE);
-    this.mapLabel.textContent = 'Active Map';
+    this.mapLabel.textContent = this.mapLabelText;
     this.mapSection.appendChild(this.mapLabel);
 
     this.mapSelect = document.createElement('select');
@@ -457,6 +458,14 @@ export class TerraHUD extends BaseHUD {
     });
     if (this.selectedMapId){
       this.mapSelect.value = this.selectedMapId;
+    }
+  }
+
+  setMapLabel(label){
+    const text = typeof label === 'string' && label.trim() ? label : 'Active Map';
+    this.mapLabelText = text;
+    if (this.mapLabel){
+      this.mapLabel.textContent = text;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a `setMapLabel` method to TerraHUD with a fallback label
- keep the toolbar map label in sync even if set before toolbar creation

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db339fbb8c8329a2e4ab0914c51480