### PR TITLE
Toggle SolarSystemWorld visibility in system view transitions

### DIFF
--- a/node_modules/three/index.js
+++ b/node_modules/three/index.js
@@ -1,0 +1,430 @@
+class Vector3 {
+  constructor(x = 0, y = 0, z = 0){
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  set(x = 0, y = 0, z = 0){
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    return this;
+  }
+
+  setScalar(s = 0){
+    this.x = s;
+    this.y = s;
+    this.z = s;
+    return this;
+  }
+
+  copy(v){
+    this.x = v.x;
+    this.y = v.y;
+    this.z = v.z;
+    return this;
+  }
+
+  clone(){
+    return new Vector3(this.x, this.y, this.z);
+  }
+
+  add(v){
+    this.x += v.x;
+    this.y += v.y;
+    this.z += v.z;
+    return this;
+  }
+
+  addScaledVector(v, s){
+    this.x += v.x * s;
+    this.y += v.y * s;
+    this.z += v.z * s;
+    return this;
+  }
+
+  sub(v){
+    this.x -= v.x;
+    this.y -= v.y;
+    this.z -= v.z;
+    return this;
+  }
+
+  multiplyScalar(s){
+    this.x *= s;
+    this.y *= s;
+    this.z *= s;
+    return this;
+  }
+
+  lengthSq(){
+    return this.x * this.x + this.y * this.y + this.z * this.z;
+  }
+
+  length(){
+    return Math.sqrt(this.lengthSq());
+  }
+
+  normalize(){
+    const len = this.length();
+    if (len > 0){
+      this.multiplyScalar(1 / len);
+    }
+    return this;
+  }
+
+  distanceTo(v){
+    return Math.sqrt(this.distanceToSquared(v));
+  }
+
+  distanceToSquared(v){
+    const dx = this.x - v.x;
+    const dy = this.y - v.y;
+    const dz = this.z - v.z;
+    return dx * dx + dy * dy + dz * dz;
+  }
+
+  crossVectors(a, b){
+    const ax = a.x, ay = a.y, az = a.z;
+    const bx = b.x, by = b.y, bz = b.z;
+    this.x = ay * bz - az * by;
+    this.y = az * bx - ax * bz;
+    this.z = ax * by - ay * bx;
+    return this;
+  }
+
+  applyQuaternion(q){
+    const x = this.x, y = this.y, z = this.z;
+    const qx = q.x, qy = q.y, qz = q.z, qw = q.w;
+
+    const ix = qw * x + qy * z - qz * y;
+    const iy = qw * y + qz * x - qx * z;
+    const iz = qw * z + qx * y - qy * x;
+    const iw = -qx * x - qy * y - qz * z;
+
+    this.x = ix * qw + iw * -qx + iy * -qz - iz * -qy;
+    this.y = iy * qw + iw * -qy + iz * -qx - ix * -qz;
+    this.z = iz * qw + iw * -qz + ix * -qy - iy * -qx;
+    return this;
+  }
+
+  applyAxisAngle(axis, angle){
+    const q = new Quaternion().setFromAxisAngle(axis, angle);
+    return this.applyQuaternion(q);
+  }
+
+  lerp(v, alpha){
+    this.x += (v.x - this.x) * alpha;
+    this.y += (v.y - this.y) * alpha;
+    this.z += (v.z - this.z) * alpha;
+    return this;
+  }
+}
+
+class Euler {
+  constructor(x = 0, y = 0, z = 0, order = 'XYZ'){
+    this.set(x, y, z, order);
+  }
+
+  set(x = 0, y = 0, z = 0, order = this.order){
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.order = order ?? this.order ?? 'XYZ';
+    return this;
+  }
+}
+
+class Quaternion {
+  constructor(x = 0, y = 0, z = 0, w = 1){
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.w = w;
+  }
+
+  set(x, y, z, w){
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.w = w;
+    return this;
+  }
+
+  copy(q){
+    this.x = q.x;
+    this.y = q.y;
+    this.z = q.z;
+    this.w = q.w;
+    return this;
+  }
+
+  clone(){
+    return new Quaternion(this.x, this.y, this.z, this.w);
+  }
+
+  multiply(q){
+    return this._multiplyQuaternions(this, q);
+  }
+
+  premultiply(q){
+    return this._multiplyQuaternions(q, this);
+  }
+
+  _multiplyQuaternions(a, b){
+    const qax = a.x, qay = a.y, qaz = a.z, qaw = a.w;
+    const qbx = b.x, qby = b.y, qbz = b.z, qbw = b.w;
+
+    this.x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
+    this.y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
+    this.z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
+    this.w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
+    return this;
+  }
+
+  normalize(){
+    const len = Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
+    if (len === 0){
+      this.x = 0;
+      this.y = 0;
+      this.z = 0;
+      this.w = 1;
+    } else {
+      const inv = 1 / len;
+      this.x *= inv;
+      this.y *= inv;
+      this.z *= inv;
+      this.w *= inv;
+    }
+    return this;
+  }
+
+  setFromEuler(euler){
+    const c1 = Math.cos(euler.x / 2);
+    const c2 = Math.cos(euler.y / 2);
+    const c3 = Math.cos(euler.z / 2);
+    const s1 = Math.sin(euler.x / 2);
+    const s2 = Math.sin(euler.y / 2);
+    const s3 = Math.sin(euler.z / 2);
+    const order = euler.order ?? 'XYZ';
+
+    if (order === 'XYZ'){
+      this.x = s1 * c2 * c3 + c1 * s2 * s3;
+      this.y = c1 * s2 * c3 - s1 * c2 * s3;
+      this.z = c1 * c2 * s3 + s1 * s2 * c3;
+      this.w = c1 * c2 * c3 - s1 * s2 * s3;
+    } else {
+      throw new Error(`Euler order ${order} not supported by stub`);
+    }
+    return this;
+  }
+
+  setFromUnitVectors(vFrom, vTo){
+    const EPS = 1e-6;
+    let r = vFrom.x * vTo.x + vFrom.y * vTo.y + vFrom.z * vTo.z + 1;
+
+    if (r < EPS){
+      if (Math.abs(vFrom.x) > Math.abs(vFrom.z)){
+        this.set(-vFrom.y, vFrom.x, 0, 0);
+      } else {
+        this.set(0, -vFrom.z, vFrom.y, 0);
+      }
+    } else {
+      const cross = new Vector3().crossVectors(vFrom, vTo);
+      this.set(cross.x, cross.y, cross.z, r);
+    }
+    return this.normalize();
+  }
+
+  setFromAxisAngle(axis, angle){
+    const half = angle / 2;
+    const s = Math.sin(half);
+    const normalized = axis.clone().normalize();
+    this.x = normalized.x * s;
+    this.y = normalized.y * s;
+    this.z = normalized.z * s;
+    this.w = Math.cos(half);
+    return this;
+  }
+}
+
+class Object3D {
+  constructor(){
+    this.name = '';
+    this.parent = null;
+    this.children = [];
+    this.position = new Vector3();
+    this.quaternion = new Quaternion();
+    this.rotation = new Euler();
+    this.scale = new Vector3(1, 1, 1);
+    this.visible = true;
+    this.castShadow = false;
+    this.receiveShadow = false;
+    this.matrixWorldNeedsUpdate = true;
+    this.userData = {};
+  }
+
+  add(...objects){
+    for (const object of objects){
+      if (!object) continue;
+      if (object.parent){
+        object.parent.remove(object);
+      }
+      object.parent = this;
+      this.children.push(object);
+    }
+    return this;
+  }
+
+  remove(object){
+    if (!object) return this;
+    const index = this.children.indexOf(object);
+    if (index >= 0){
+      this.children.splice(index, 1);
+      object.parent = null;
+    }
+    return this;
+  }
+
+  traverse(callback){
+    callback(this);
+    for (const child of this.children){
+      child.traverse?.(callback);
+    }
+  }
+
+  updateMatrixWorld(){
+    return this;
+  }
+
+  getWorldPosition(target = new Vector3()){
+    target.copy(this.position);
+    if (this.parent){
+      target.add(this.parent.getWorldPosition(new Vector3()));
+    }
+    return target;
+  }
+
+  getObjectByName(name){
+    if (this.name === name){
+      return this;
+    }
+    for (const child of this.children){
+      const found = child.getObjectByName?.(name);
+      if (found) return found;
+    }
+    return null;
+  }
+}
+
+class Group extends Object3D {
+  constructor(){
+    super();
+    this.isGroup = true;
+  }
+}
+
+class Scene extends Group {
+  constructor(){
+    super();
+    this.isScene = true;
+  }
+}
+
+class Mesh extends Object3D {
+  constructor(geometry = null, material = null){
+    super();
+    this.geometry = geometry;
+    this.material = material;
+    this.isMesh = true;
+  }
+}
+
+class SphereGeometry {
+  constructor(radius = 1, widthSegments = 8, heightSegments = 6){
+    this.type = 'SphereGeometry';
+    this.parameters = { radius, widthSegments, heightSegments };
+  }
+}
+
+class Material {
+  constructor(params = {}){
+    const { color, ...rest } = params ?? {};
+    this.color = new Color(color ?? 0xffffff);
+    Object.assign(this, rest);
+  }
+
+  clone(){
+    const ctor = this.constructor;
+    const params = { ...this };
+    params.color = this.color.clone?.() ?? new Color(this.color);
+    return new ctor(params);
+  }
+}
+
+class MeshStandardMaterial extends Material {}
+class MeshBasicMaterial extends Material {}
+
+class Color {
+  constructor(value = 0xffffff){
+    this.set(value);
+  }
+
+  set(value){
+    if (value instanceof Color){
+      this.r = value.r;
+      this.g = value.g;
+      this.b = value.b;
+    } else if (typeof value === 'number'){
+      this.r = ((value >> 16) & 255) / 255;
+      this.g = ((value >> 8) & 255) / 255;
+      this.b = (value & 255) / 255;
+    } else if (typeof value === 'string' && value.startsWith('#')){
+      return this.set(parseInt(value.slice(1), 16));
+    } else {
+      this.r = this.g = this.b = 1;
+    }
+    return this;
+  }
+
+  clone(){
+    return new Color().set(this);
+  }
+}
+
+const MathUtils = {
+  degToRad: (deg) => deg * Math.PI / 180,
+  clamp: (value, min, max) => Math.min(Math.max(value, min), max),
+  lerp: (start, end, alpha) => start + (end - start) * alpha,
+};
+
+const THREE = {
+  Vector3,
+  Euler,
+  Quaternion,
+  Group,
+  Scene,
+  Mesh,
+  SphereGeometry,
+  MeshStandardMaterial,
+  MeshBasicMaterial,
+  Color,
+  MathUtils,
+};
+
+export {
+  Vector3,
+  Euler,
+  Quaternion,
+  Group,
+  Scene,
+  Mesh,
+  SphereGeometry,
+  MeshStandardMaterial,
+  MeshBasicMaterial,
+  Color,
+  MathUtils,
+};
+
+export default THREE;

--- a/node_modules/three/package.json
+++ b/node_modules/three/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "three",
+  "version": "0.0.0-stub",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/viewer/tests/SolarSystemWorld.test.mjs
+++ b/viewer/tests/SolarSystemWorld.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+test('solar system view toggles root visibility', async (t) => {
+  const originalThree = globalThis.THREE;
+  globalThis.THREE = THREE;
+  t.after(() => {
+    if (originalThree === undefined){
+      delete globalThis.THREE;
+    } else {
+      globalThis.THREE = originalThree;
+    }
+  });
+
+  const { SolarSystemWorld } = await import('../cloud-of-orbs/SolarSystemWorld.js');
+
+  class StubShip {
+    constructor(){
+      this.hasLaunched = false;
+      this.state = {
+        position: new THREE.Vector3(),
+        orientation: new THREE.Quaternion(),
+        velocity: new THREE.Vector3(),
+        forward: new THREE.Vector3(0, 1, 0),
+        up: new THREE.Vector3(0, 0, 1),
+      };
+    }
+
+    dispose(){}
+    setActive(){ }
+    setVisible(){ }
+    getState(){
+      return this.state;
+    }
+    update(){
+      return this.state;
+    }
+    getForwardVector(target = new THREE.Vector3()){
+      return target.copy(this.state.forward);
+    }
+    setPosition(position){
+      this.state.position.copy(position);
+    }
+    lookTowards(){ }
+  }
+
+  const scene = new THREE.Scene();
+  const world = new SolarSystemWorld({
+    scene,
+    planetRegistry: new Map(),
+    playerShipFactory: () => new StubShip(),
+  });
+
+  assert.equal(world.root.visible, true, 'root should be visible by default');
+
+  world.exitSystemView();
+  assert.equal(world.root.visible, false, 'root should be hidden after exiting system view');
+
+  world.enterSystemView();
+  assert.equal(world.root.visible, true, 'root should be visible after entering system view');
+});


### PR DESCRIPTION
## Summary
- hide the solar system root group when exiting system view and restore visibility when re-entering before ship placement
- avoid mutating planet rotations while the system root is hidden and allow injecting a custom player ship factory for tests
- add a node test covering the visibility toggles and provide a lightweight three stub to satisfy viewer unit tests

## Testing
- node --test viewer/tests/*.mjs

------
https://chatgpt.com/codex/tasks/task_e_68db44c065d08329b64c27f6d2d60e33