### PR TITLE
Add match presets and orbital transition

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -63,6 +63,18 @@
       gap: 6px;
     }
 
+    #match-controls {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    #match-button-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 8px;
+    }
+
     .control-label {
       font-size: 12px;
       letter-spacing: 0.05em;
@@ -116,9 +128,31 @@
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), 0 10px 20px rgba(33, 73, 144, 0.45);
     }
 
+    .control-button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 4px 8px rgba(33, 73, 144, 0.25);
+    }
+
     .control-button.is-active {
       background: linear-gradient(135deg, #2f973d, #22772e);
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 10px 24px rgba(34, 119, 46, 0.45);
+    }
+
+    .match-button {
+      background: linear-gradient(135deg, #7c5cff, #5632d6);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 6px 12px rgba(63, 51, 140, 0.35);
+    }
+
+    .match-button.is-active {
+      background: linear-gradient(135deg, #2f973d, #22772e);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 10px 24px rgba(34, 119, 46, 0.45);
+    }
+
+    .match-button.is-pending {
+      background: linear-gradient(135deg, #f59e0b, #d97706);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 10px 24px rgba(217, 119, 6, 0.45);
     }
     /* Connection banner styles */
     #connection-banner {
@@ -271,6 +305,16 @@
     <button id="invert-axes-toggle" class="control-button">Invert Pitch/Roll</button>
     <button id="accelerate-forward" class="control-button">Start Forward Acceleration</button>
     <button id="reroute-waypoints" class="control-button">Cycle Autopilot Route</button>
+    <div id="match-controls">
+      <span class="control-label">Matches</span>
+      <div id="match-button-grid">
+        <button id="match-1-button" class="control-button match-button" type="button">Match 1</button>
+        <button id="match-2-button" class="control-button match-button" type="button">Match 2</button>
+        <button id="match-3-button" class="control-button match-button" type="button">Match 3</button>
+        <button id="match-4-button" class="control-button match-button" type="button">Match 4</button>
+      </div>
+      <p id="match-status" class="controls-subtext">Select a match to update autopilot routing.</p>
+    </div>
     <ul id="control-instructions"></ul>
     <p id="controls-footnote" class="controls-subtext">All controls are mirrored via keyboard shortcuts. Buttons update in real time as modes change.</p>
   </div>


### PR DESCRIPTION
## Summary
- add match preset buttons and UI styles so pilots can trigger specific waypoint routes directly from the console
- extend the viewer logic with match preset handling, HUD updates, and autopilot command tracking
- introduce an altitude-driven transition that swaps the surface world for the solar system scene and restores it when descending

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4ef492108329a8ad9521ce53dd58