### PR TITLE
Make viewer handler optional

### DIFF
--- a/go-broker/main.go
+++ b/go-broker/main.go
@@ -516,11 +516,13 @@ func buildHandler(b *Broker) (http.Handler, error) {
 	}
 
 	// serve viewer static files (resolve relative to this source file)
-	viewerDir, err := resolveViewerDir()
-	if err != nil {
+	if viewerDir, err := resolveViewerDir(); err == nil {
+		mux.Handle("/viewer/", http.StripPrefix("/viewer/", http.FileServer(http.Dir(viewerDir))))
+	} else if errors.Is(err, os.ErrNotExist) {
+		log.Println("viewer directory not found; skipping /viewer/ handler registration")
+	} else {
 		return nil, err
 	}
-	mux.Handle("/viewer/", http.StripPrefix("/viewer/", http.FileServer(http.Dir(viewerDir))))
 
 	terraSandboxDir, err := resolveTerraSandboxDir()
 	if err != nil {


### PR DESCRIPTION
## Summary
- skip registering the `/viewer/` handler when the static directory is absent while keeping other routes intact
- add helpers for creating and temporarily removing the viewer fixture in tests
- cover both presence and absence of the viewer directory with new test cases

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbd112e11883298e2966f9663ffdf6