### PR TITLE
Enhance Terra sandbox solar system and ship lighting controls

### DIFF
--- a/terra-sandbox/terra/hudConfig.js
+++ b/terra-sandbox/terra/hudConfig.js
@@ -62,6 +62,8 @@ export function createHud({
   mapOptions = [],
   onAmmoSelect,
   onMapSelect,
+  onToggleLights,
+  initialLightsActive,
   presets = createHudPresets(),
 } = {}){
   const hud = new TerraHUDClass({
@@ -70,6 +72,8 @@ export function createHud({
     mapOptions,
     onAmmoSelect,
     onMapSelect,
+    onToggleLights,
+    initialLightsActive,
   });
   return { hud, presets };
 }

--- a/terra-sandbox/terra/maps.json
+++ b/terra-sandbox/terra/maps.json
@@ -73,7 +73,7 @@
     {
       "id": "solar-system",
       "name": "Orbital Reach",
-      "description": "Expansive solar system with a radiant star and orbiting planets.",
+      "description": "Expansive solar system with a radiant star and twin orbiting planets.",
       "type": "solar-system",
       "environment": {
         "background": "#050912",
@@ -110,17 +110,6 @@
           "rotationSpeed": 0.11,
           "atmosphereColor": "#91f1b2",
           "atmosphereOpacity": 0.22
-        },
-        {
-          "name": "Crimoria",
-          "radius": 720,
-          "orbitRadius": 13800,
-          "orbitSpeed": 0.017,
-          "color": "#ff7366",
-          "emissive": "#8b1c19",
-          "orbitHeight": 480,
-          "rotationSpeed": 0.15,
-          "ring": { "innerRadius": 900, "outerRadius": 1280, "color": "#ffc9a4", "opacity": 0.28, "tilt": 16 }
         }
       ]
     }

--- a/terra-sandbox/terra/vehicles.js
+++ b/terra-sandbox/terra/vehicles.js
@@ -61,6 +61,7 @@ export function createVehicleSystem({
   const vehicles = new Map();
   const trackedVehicles = [];
   let activeVehicleId = null;
+  let navigationLightsEnabled = true;
 
   const METERS_PER_LATITUDE_DEGREE = 111320;
 
@@ -184,6 +185,7 @@ export function createVehicleSystem({
       throttle: 1,
     });
     if (planeController){
+      planeController.setNavigationLightsEnabled?.(navigationLightsEnabled);
       planeController.throttle = 1;
       planeController.targetThrottle = 1;
       const diveDirection = new THREE.Vector3(0, 1, 0).applyQuaternion(planeController.orientation).normalize();
@@ -698,6 +700,13 @@ export function createVehicleSystem({
     focusCameraOnVehicle(vehicle);
   }
 
+  function setNavigationLightsEnabled(enabled){
+    navigationLightsEnabled = !!enabled;
+    for (const vehicle of vehicles.values()){
+      vehicle.modes?.plane?.controller?.setNavigationLightsEnabled?.(navigationLightsEnabled);
+    }
+  }
+
   function update({ dt, elapsedTime, inputSample, movementScale = 1 }){
     const clampedScale = Number.isFinite(movementScale) ? Math.max(0, movementScale) : 1;
     for (const vehicle of vehicles.values()){
@@ -751,6 +760,8 @@ export function createVehicleSystem({
     registerVehicleCrash,
     handleProjectileHit,
     teleportActiveVehicle,
+    setNavigationLightsEnabled,
+    getNavigationLightsEnabled: () => navigationLightsEnabled,
   };
 }
   function teleportActiveVehicle({ position = null, velocity = null } = {}){


### PR DESCRIPTION
## Summary
- make Orbital Reach the default fallback map, remove the third planet, and spawn players near the primary planet when entering the solar system
- update SolarSystemWorld to orbit planets around the sun and expose a spawn helper while supporting the lighter solar scene
- add dynamic propulsion visuals and navigation light toggles with a HUD control that keeps the ship lights state in sync

## Testing
- Manual: Loaded `terra-sandbox/terra/` in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dbd97153f0832986c7acf7e82fa9d3