### PR TITLE
Tune space flight and torpedo impacts

### DIFF
--- a/terra-sandbox/sandbox/InputManager.js
+++ b/terra-sandbox/sandbox/InputManager.js
@@ -14,6 +14,7 @@ const DEFAULT_KEY_BINDINGS = {
   brake: ['Space'],
   throttleUp: [],
   throttleDown: [],
+  fire: ['KeyF'],
 };
 
 const DEADZONE = 0.06;
@@ -88,6 +89,10 @@ export class InputManager {
 
     // throttle impulses (mouse wheel adds bursts)
     this.throttleImpulse = 0;
+
+    this.buttonStates = {
+      fire: false,
+    };
 
     // camera orbit
     this.cameraOrbitSensitivity = {
@@ -217,6 +222,9 @@ export class InputManager {
     this.throttleImpulse = 0;
 
     const brake = (this.keyBindings.brake || []).some((key) => this.activeKeys.has(key));
+    const fireHeld = (this.keyBindings.fire || []).some((key) => this.activeKeys.has(key));
+    const firePressed = fireHeld && !this.buttonStates.fire;
+    this.buttonStates.fire = fireHeld;
 
     // --- Analog (pointer) contributions ---
     const pointerYaw = applyDeadzone(this.pointer.x * this.pointerSensitivity.yaw);
@@ -246,6 +254,7 @@ export class InputManager {
 
     return {
       plane: { pitch, roll, yaw, throttleAdjust, brake, aim: planeAim },
+      fire: firePressed,
       car: {
         throttle: pitchDigital,
         steer: yawDigital,
@@ -283,6 +292,7 @@ export function describeControls(mode = 'plane') {
       { label: 'Turn', detail: 'A yaw & roll left · D yaw & roll right' },
       { label: 'Throttle', detail: 'Mouse wheel to adjust thrust' },
       { label: 'Brake', detail: 'Space for airbrake' },
+      { label: 'Fire', detail: 'Press F to launch torpedoes' },
       { label: 'Camera', detail: 'Hold Left Mouse to orbit view' },
       { label: 'Mode', detail: 'Press 1 for plane · 2 for car' },
     ],

--- a/terra-sandbox/sandbox/ProjectileSystem.js
+++ b/terra-sandbox/sandbox/ProjectileSystem.js
@@ -1,0 +1,258 @@
+import { requireTHREE } from '../shared/threeSetup.js';
+
+const THREE = requireTHREE();
+
+if (!THREE) throw new Error('ProjectileSystem requires THREE to be available');
+
+const FORWARD = new THREE.Vector3(0, 1, 0);
+const TMP_QUAT = new THREE.Quaternion();
+
+export class ProjectileSystem {
+  constructor({ scene, world } = {}){
+    if (!scene) throw new Error('ProjectileSystem requires a scene reference');
+    this.scene = scene;
+    this.world = world ?? null;
+
+    this.projectiles = [];
+    this.explosions = [];
+
+    this.cooldown = 0;
+    this.cooldownDuration = 0.65;
+    this.maxLife = 14;
+    this.missileSpeed = 420;
+    this.craterRadius = 480;
+    this.craterDepth = 320;
+    this.craterRimHeight = 120;
+    this.planetExplosionScale = 34;
+    this.spaceExplosionScale = 18;
+
+    this.shared = this._createSharedAssets();
+  }
+
+  setWorld(world){
+    this.world = world;
+  }
+
+  tryFire({ position, orientation, velocity } = {}){
+    if (this.cooldown > 0) return false;
+    if (!position || !orientation) return false;
+
+    this.cooldown = this.cooldownDuration;
+    const spawnPos = position.clone();
+    const direction = FORWARD.clone().applyQuaternion(orientation).normalize();
+    spawnPos.addScaledVector(direction, 8);
+    spawnPos.addScaledVector(new THREE.Vector3(0, 0, -0.8), 1);
+
+    const velocityVector = direction.clone().multiplyScalar(this.missileSpeed);
+    if (velocity) velocityVector.add(velocity.clone());
+
+    const group = new THREE.Group();
+    group.name = 'TorpedoProjectile';
+
+    const body = new THREE.Mesh(this.shared.bodyGeometry.clone(), this.shared.bodyMaterial.clone());
+    body.castShadow = true;
+    body.receiveShadow = false;
+    group.add(body);
+
+    const nose = new THREE.Mesh(this.shared.noseGeometry.clone(), this.shared.noseMaterial.clone());
+    nose.position.set(0, 1.3, 0);
+    group.add(nose);
+
+    const glow = new THREE.Mesh(this.shared.glowGeometry.clone(), this.shared.glowMaterial.clone());
+    glow.position.set(0, -1.1, 0);
+    group.add(glow);
+
+    this.scene.add(group);
+
+    const projectile = {
+      mesh: group,
+      position: spawnPos,
+      velocity: velocityVector,
+      direction,
+      life: 0,
+      maxLife: this.maxLife,
+    };
+    this._alignMesh(projectile);
+    this.projectiles.push(projectile);
+    return true;
+  }
+
+  update(dt, { scenario = 'planet', originOffset = null, spaceBodies = [] } = {}){
+    const delta = Math.max(0, dt ?? 0);
+    this.cooldown = Math.max(0, this.cooldown - delta);
+
+    const origin = originOffset ?? new THREE.Vector3();
+
+    for (let i = this.projectiles.length - 1; i >= 0; i -= 1){
+      const projectile = this.projectiles[i];
+      projectile.life += delta;
+      if (projectile.life > projectile.maxLife){
+        this._disposeProjectileIndex(i);
+        continue;
+      }
+
+      projectile.position.addScaledVector(projectile.velocity, delta);
+      this._alignMesh(projectile);
+
+      let impacted = false;
+
+      if (scenario === 'planet' && this.world){
+        const ground = this.world.getHeightAt(projectile.position.x, projectile.position.y);
+        if (Number.isFinite(ground) && projectile.position.z <= ground + 2){
+          const impactPos = projectile.position.clone();
+          impactPos.z = ground;
+          const speed = projectile.velocity.length();
+          const speedScale = THREE.MathUtils.clamp(speed / this.missileSpeed, 0.6, 1.9);
+          this._spawnExplosion(impactPos, this.planetExplosionScale * speedScale, 1.2);
+          const worldX = impactPos.x + origin.x;
+          const worldY = impactPos.y + origin.y;
+          const radius = this.craterRadius * speedScale;
+          const depth = this.craterDepth * (0.85 + 0.15 * speedScale);
+          const rimHeight = this.craterRimHeight * (0.75 + 0.25 * speedScale);
+          this.world.addDynamicCrater?.({ worldX, worldY, radius, depth, rimHeight });
+          this._disposeProjectileIndex(i);
+          impacted = true;
+        }
+      }
+
+      if (!impacted && scenario === 'space' && Array.isArray(spaceBodies)){
+        for (let b = 0; b < spaceBodies.length; b += 1){
+          const body = spaceBodies[b];
+          const radius = body?.radius ?? 0;
+          if (radius <= 0) continue;
+          const pos = body.position ?? body.mesh?.position;
+          if (!pos) continue;
+          const distance = projectile.position.distanceTo(pos);
+          if (distance <= radius){
+            const impactPos = projectile.position.clone();
+            this._spawnExplosion(impactPos, this.spaceExplosionScale, 0.8);
+            this._disposeProjectileIndex(i);
+            impacted = true;
+            break;
+          }
+        }
+      }
+
+      if (impacted) continue;
+
+      const distance = projectile.position.length();
+      if (distance > 120000){
+        this._disposeProjectileIndex(i);
+      }
+    }
+
+    for (let e = this.explosions.length - 1; e >= 0; e -= 1){
+      const explosion = this.explosions[e];
+      explosion.life += delta;
+      const t = explosion.life / explosion.duration;
+      if (t >= 1){
+        this.scene.remove(explosion.mesh);
+        explosion.mesh.traverse((obj) => {
+          if (obj.material?.dispose) obj.material.dispose();
+          if (obj.geometry?.dispose) obj.geometry.dispose();
+        });
+        this.explosions.splice(e, 1);
+        continue;
+      }
+      const lerpT = Math.pow(t, 0.6);
+      const baseScale = explosion.initialScale ?? 1;
+      const targetScale = Math.max(baseScale, explosion.scaleTarget ?? baseScale);
+      const scale = THREE.MathUtils.lerp(baseScale, targetScale, lerpT);
+      const baseScaleZ = explosion.initialZScale ?? baseScale * 0.6;
+      const targetScaleZ = Math.max(baseScaleZ, targetScale * 0.5);
+      const scaleZ = THREE.MathUtils.lerp(baseScaleZ, targetScaleZ, lerpT);
+      explosion.mesh.scale.set(scale, scale, scaleZ);
+      const mat = explosion.material;
+      if (mat){
+        mat.opacity = THREE.MathUtils.lerp(explosion.startOpacity, 0, t * t);
+        mat.needsUpdate = true;
+      }
+    }
+  }
+
+  handleOriginShift(shift){
+    if (!shift) return;
+    this.projectiles.forEach((projectile) => {
+      projectile.position.sub(shift);
+      this._alignMesh(projectile);
+    });
+    this.explosions.forEach((explosion) => {
+      explosion.mesh.position.sub(shift);
+    });
+  }
+
+  _createSharedAssets(){
+    const bodyGeometry = new THREE.CylinderGeometry(0.25, 0.32, 2.6, 16, 1, true);
+    bodyGeometry.rotateZ(Math.PI / 2);
+    const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0xd5daf0, metalness: 0.6, roughness: 0.32, emissive: 0x101424, emissiveIntensity: 0.2 });
+
+    const noseGeometry = new THREE.ConeGeometry(0.32, 0.9, 16);
+    noseGeometry.rotateZ(Math.PI / 2);
+    const noseMaterial = new THREE.MeshStandardMaterial({ color: 0xff9c73, metalness: 0.4, roughness: 0.26, emissive: 0x331a11, emissiveIntensity: 0.3 });
+
+    const glowGeometry = new THREE.ConeGeometry(0.42, 1.8, 12, 1, true);
+    glowGeometry.rotateZ(-Math.PI / 2);
+    const glowMaterial = new THREE.MeshBasicMaterial({ color: 0xffe0a8, transparent: true, opacity: 0.9, blending: THREE.AdditiveBlending, depthWrite: false, toneMapped: false });
+
+    const explosionGeometry = new THREE.SphereGeometry(1, 24, 24);
+
+    return {
+      bodyGeometry,
+      bodyMaterial,
+      noseGeometry,
+      noseMaterial,
+      glowGeometry,
+      glowMaterial,
+      explosionGeometry,
+    };
+  }
+
+  _spawnExplosion(position, targetScale = 24, opacityScale = 1){
+    const material = new THREE.MeshBasicMaterial({
+      color: 0xffc893,
+      transparent: true,
+      opacity: THREE.MathUtils.clamp(0.9 * opacityScale, 0.15, 1.4),
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      toneMapped: false,
+    });
+    const mesh = new THREE.Mesh(this.shared.explosionGeometry.clone(), material);
+    mesh.position.copy(position);
+    const initialScale = Math.max(1.2, targetScale * 0.12);
+    mesh.scale.set(initialScale, initialScale, initialScale * 0.6);
+    const resolvedTargetScale = Math.max(initialScale * 1.4, targetScale);
+    mesh.name = 'MissileExplosion';
+    this.scene.add(mesh);
+    this.explosions.push({
+      mesh,
+      material,
+      life: 0,
+      duration: 1.6,
+      scaleTarget: resolvedTargetScale,
+      startOpacity: material.opacity,
+      initialScale,
+      initialZScale: initialScale * 0.6,
+    });
+  }
+
+  _alignMesh(projectile){
+    if (!projectile.mesh) return;
+    projectile.mesh.position.copy(projectile.position);
+    const direction = projectile.velocity.clone().normalize();
+    TMP_QUAT.setFromUnitVectors(FORWARD, direction);
+    projectile.mesh.quaternion.copy(TMP_QUAT);
+  }
+
+  _disposeProjectileIndex(index){
+    const projectile = this.projectiles[index];
+    if (!projectile) return;
+    if (projectile.mesh){
+      this.scene.remove(projectile.mesh);
+      projectile.mesh.traverse((obj) => {
+        if (obj.material?.dispose) obj.material.dispose();
+        if (obj.geometry?.dispose) obj.geometry.dispose();
+      });
+    }
+    this.projectiles.splice(index, 1);
+  }
+}

--- a/terra-sandbox/sandbox/SpaceScene.js
+++ b/terra-sandbox/sandbox/SpaceScene.js
@@ -1,0 +1,208 @@
+import { createRng } from '../world/noiseUtils.js';
+import { requireTHREE } from '../shared/threeSetup.js';
+
+const THREE = requireTHREE();
+
+if (!THREE) throw new Error('SpaceScene requires THREE to be available');
+
+const TMP_VECTOR = new THREE.Vector3();
+
+export class SpaceScene {
+  constructor({ scene, seed = 928371 } = {}){
+    if (!scene) throw new Error('SpaceScene requires a scene reference');
+    this.scene = scene;
+    this.seed = seed >>> 0;
+    this.group = new THREE.Group();
+    this.group.name = 'SolarSystemSpace';
+    this.scene.add(this.group);
+    this.group.visible = false;
+
+    this.sectorSize = 9000;
+    this.generatedSectors = new Map();
+    this.generatedBodies = [];
+    this.orbiters = [];
+    this.bodies = [];
+
+    this._rngBase = createRng(this.seed ^ 0x5f3562c3);
+
+    this._buildBackdrop();
+    this._buildSolarSystem();
+  }
+
+  setVisible(visible){
+    this.group.visible = !!visible;
+    if (this.sunLight) this.sunLight.visible = !!visible;
+    if (this.backdrop) this.backdrop.visible = !!visible;
+  }
+
+  update(dt = 0, shipPosition = null){
+    const delta = Math.max(0, dt);
+    this.orbiters.forEach((orbiter) => {
+      orbiter.angle += delta * orbiter.orbitSpeed;
+      orbiter.pivot.rotation.z = orbiter.angle;
+      if (orbiter.mesh){
+        orbiter.mesh.rotation.y += delta * orbiter.spinSpeed;
+      }
+    });
+
+    if (shipPosition){
+      this._populateAround(shipPosition);
+    }
+  }
+
+  getBodies(){
+    this.bodies.length = 0;
+    this.orbiters.forEach((orb) => {
+      if (!orb.mesh) return;
+      const pos = orb.mesh.getWorldPosition(TMP_VECTOR.set(0, 0, 0));
+      this.bodies.push({ position: pos.clone(), radius: orb.collisionRadius ?? orb.radius ?? 400, mesh: orb.mesh });
+    });
+    this.generatedBodies.forEach((body) => {
+      this.bodies.push({ position: body.position.clone(), radius: body.radius, mesh: body.mesh });
+    });
+    return this.bodies;
+  }
+
+  _buildBackdrop(){
+    const starCount = 2800;
+    const positions = new Float32Array(starCount * 3);
+    const colors = new Float32Array(starCount * 3);
+    const rng = this._rngBase;
+    const radius = 42000;
+    for (let i = 0; i < starCount; i += 1){
+      const u = rng();
+      const v = rng();
+      const theta = 2 * Math.PI * u;
+      const phi = Math.acos(2 * v - 1);
+      const r = radius;
+      positions[i * 3 + 0] = r * Math.sin(phi) * Math.cos(theta);
+      positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+      positions[i * 3 + 2] = r * Math.cos(phi);
+      const twinkle = 0.8 + rng() * 0.2;
+      colors[i * 3 + 0] = 0.8 * twinkle;
+      colors[i * 3 + 1] = 0.9 * twinkle;
+      colors[i * 3 + 2] = twinkle;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    const material = new THREE.PointsMaterial({ size: 16, sizeAttenuation: true, vertexColors: true, transparent: true, opacity: 0.82 });
+    const stars = new THREE.Points(geometry, material);
+    stars.name = 'SpaceBackdropStars';
+    this.group.add(stars);
+    this.backdrop = stars;
+  }
+
+  _buildSolarSystem(){
+    const sunGeometry = new THREE.SphereGeometry(780, 64, 64);
+    const sunMaterial = new THREE.MeshBasicMaterial({ color: 0xffd74a, toneMapped: false });
+    const sunMesh = new THREE.Mesh(sunGeometry, sunMaterial);
+    sunMesh.name = 'CentralSun';
+    this.group.add(sunMesh);
+    this.sun = sunMesh;
+
+    const glowGeometry = new THREE.SphereGeometry(920, 48, 48);
+    const glowMaterial = new THREE.MeshBasicMaterial({ color: 0xfff6c9, transparent: true, opacity: 0.4, blending: THREE.AdditiveBlending, depthWrite: false });
+    const glowMesh = new THREE.Mesh(glowGeometry, glowMaterial);
+    glowMesh.name = 'SunGlow';
+    this.group.add(glowMesh);
+
+    const sunLight = new THREE.PointLight(0xfff0aa, 4.2, 0, 0.018);
+    sunLight.position.set(0, 0, 0);
+    sunLight.castShadow = false;
+    this.group.add(sunLight);
+    this.sunLight = sunLight;
+
+    const planetConfigs = [
+      { radius: 2400, size: 540, color: 0x70a9ff, orbitSpeed: 0.06, tilt: 0.18, banding: 0.2 },
+      { radius: 3600, size: 680, color: 0xffc58b, orbitSpeed: 0.035, tilt: -0.12, banding: 0.35 },
+      { radius: 5200, size: 820, color: 0xa98cff, orbitSpeed: 0.018, tilt: 0.28, banding: 0.42 },
+    ];
+
+    planetConfigs.forEach((config, index) => {
+      const pivot = new THREE.Object3D();
+      pivot.name = `OrbitPivot_${index}`;
+      this.group.add(pivot);
+      const planet = this._createPlanetMesh(config.size, config.color, { banding: config.banding, tilt: config.tilt });
+      planet.position.set(config.radius, 0, config.tilt * config.radius * 0.5);
+      pivot.add(planet);
+      const initialAngle = this._rngBase() * Math.PI * 2;
+      this.orbiters.push({
+        mesh: planet,
+        pivot,
+        angle: initialAngle,
+        orbitSpeed: config.orbitSpeed,
+        spinSpeed: 0.12 + index * 0.04,
+        radius: config.size * 0.5,
+        collisionRadius: config.size * 0.62,
+      });
+    });
+  }
+
+  _createPlanetMesh(diameter, baseColor, { banding = 0, tilt = 0 } = {}){
+    const geometry = new THREE.SphereGeometry(diameter * 0.5, 48, 48);
+    const material = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(baseColor),
+      roughness: 0.65,
+      metalness: 0.05,
+      emissive: new THREE.Color(baseColor).multiplyScalar(0.08),
+      emissiveIntensity: 0.45,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.rotation.z = tilt;
+    if (banding > 0){
+      const noise = createRng((this.seed ^ 0x9e3779b9) >>> 0);
+      const colors = geometry.attributes.position;
+      const vertexCount = colors.count;
+      const colorAttr = new Float32Array(vertexCount * 3);
+      for (let i = 0; i < vertexCount; i += 1){
+        const y = geometry.attributes.position.getY(i) / (diameter * 0.5);
+        const shade = 0.9 + Math.sin(y * Math.PI * (1 + banding)) * 0.08 + (noise() - 0.5) * 0.05;
+        const c = new THREE.Color(baseColor).multiplyScalar(shade);
+        colorAttr[i * 3 + 0] = c.r;
+        colorAttr[i * 3 + 1] = c.g;
+        colorAttr[i * 3 + 2] = c.b;
+      }
+      geometry.setAttribute('color', new THREE.BufferAttribute(colorAttr, 3));
+      material.vertexColors = true;
+    }
+    mesh.name = 'OrbitingPlanet';
+    return mesh;
+  }
+
+  _populateAround(position){
+    const sectorX = Math.floor(position.x / this.sectorSize);
+    const sectorY = Math.floor(position.y / this.sectorSize);
+    for (let dx = -1; dx <= 1; dx += 1){
+      for (let dy = -1; dy <= 1; dy += 1){
+        this._ensureSector(sectorX + dx, sectorY + dy);
+      }
+    }
+  }
+
+  _ensureSector(sx, sy){
+    const key = `${sx}:${sy}`;
+    if (this.generatedSectors.has(key)) return;
+    this.generatedSectors.set(key, true);
+    if (Math.abs(sx) <= 1 && Math.abs(sy) <= 1) return; // keep near-sun clear
+
+    const seed = ((sx * 374761393) ^ (sy * 668265263) ^ this.seed) >>> 0;
+    const rng = createRng(seed);
+    const count = 1 + Math.floor(rng() * 2);
+    const baseX = sx * this.sectorSize;
+    const baseY = sy * this.sectorSize;
+    for (let i = 0; i < count; i += 1){
+      const px = baseX + (rng() - 0.5) * this.sectorSize * 0.8;
+      const py = baseY + (rng() - 0.5) * this.sectorSize * 0.8;
+      const pz = (rng() - 0.5) * 1600;
+      const radius = 320 + rng() * 520;
+      const color = new THREE.Color().setHSL(rng(), 0.48, 0.55 + rng() * 0.15);
+      const planet = this._createPlanetMesh(radius * 2, color.getHex(), { banding: 0.25 + rng() * 0.45, tilt: (rng() - 0.5) * 0.6 });
+      planet.position.set(px, py, pz);
+      this.group.add(planet);
+      this.generatedBodies.push({ mesh: planet, position: planet.position.clone(), radius: radius * 1.05 });
+    }
+  }
+}

--- a/terra-sandbox/sandbox/main.js
+++ b/terra-sandbox/sandbox/main.js
@@ -5,6 +5,8 @@ import { ChaseCamera } from './ChaseCamera.js';
 import { WorldStreamer } from './WorldStreamer.js';
 import { CollisionSystem } from './CollisionSystem.js';
 import { HUD } from './HUD.js';
+import { SpaceScene } from './SpaceScene.js';
+import { ProjectileSystem } from './ProjectileSystem.js';
 import {
   createRenderer,
   createPerspectiveCamera,
@@ -14,19 +16,28 @@ import {
 
 const THREE = requireTHREE();
 
+const SCENARIOS = { PLANET: 'planet', SPACE: 'space' };
 const SKY_CEILING = 1800;
+const SPACE_CEILING = 22000;
+const SPACE_TRANSITION_ALTITUDE = 5000;
+const SPACE_RETURN_ALTITUDE = 4400;
 const ORIGIN_REBASE_DISTANCE = 1400;
 const ORIGIN_REBASE_DISTANCE_SQ = ORIGIN_REBASE_DISTANCE * ORIGIN_REBASE_DISTANCE;
 
+const PLANET_BACKGROUND = new THREE.Color(0x90b6ff);
+const SPACE_BACKGROUND = new THREE.Color(0x050913);
+const planetFog = new THREE.Fog(0xa4c6ff, 1500, 4200);
+const PLANET_BODY_BACKGROUND = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)';
+const SPACE_BODY_BACKGROUND = 'radial-gradient(140deg, #020512 0%, #050c18 46%, #000000 100%)';
+
 document.body.style.margin = '0';
 document.body.style.overflow = 'hidden';
+document.body.style.background = PLANET_BODY_BACKGROUND;
 const renderer = createRenderer();
 
-document.body.style.background = 'linear-gradient(180deg, #79a7ff 0%, #cfe5ff 45%, #f6fbff 100%)';
-
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x90b6ff);
-scene.fog = new THREE.Fog(0xa4c6ff, 1500, 4200);
+scene.background = PLANET_BACKGROUND.clone();
+scene.fog = planetFog;
 
 const camera = createPerspectiveCamera({ fov: 60, near: 0.1, far: 20000 });
 
@@ -43,6 +54,11 @@ sun.shadow.camera.top = 800;
 sun.shadow.camera.bottom = -800;
 sun.shadow.camera.far = 2200;
 scene.add(sun);
+const BASE_HEMISPHERE_INTENSITY = hemisphere.intensity;
+const BASE_SUN_INTENSITY = sun.intensity;
+
+const spaceScene = new SpaceScene({ scene, seed: 1836311903 });
+spaceScene.setVisible(false);
 
 const world = new WorldStreamer({ scene, chunkSize: 640, radius: 3, seed: 982451653 });
 
@@ -51,6 +67,16 @@ scene.add(planeMesh);
 
 const planeController = new PlaneController();
 planeController.attachMesh(planeMesh);
+planeController.setAuxiliaryLightsActive(false);
+const BASE_PLANE_GRAVITY = planeController.gravity;
+const BASE_PROPULSOR_LIFT = planeController.propulsorLift;
+const BASE_MIN_SPEED = planeController.minSpeed;
+const BASE_MAX_SPEED = planeController.maxSpeed;
+const BASE_MAX_BOOST_SPEED = planeController.maxBoostSpeed;
+const BASE_ACCELERATION = planeController.acceleration;
+const BASE_AFTERBURNER_ACCELERATION = planeController.afterburnerAcceleration;
+const BASE_DRAG = planeController.drag;
+const BASE_BRAKE_DRAG = planeController.brakeDrag;
 
 const carRig = createCarRig();
 scene.add(carRig.carMesh);
@@ -90,6 +116,7 @@ const carControls = describeControls('car');
 const hud = new HUD({ controls: planeControls });
 hud.setDropHandler(dropVehicleFromDrone);
 const collisionSystem = new CollisionSystem({ world, crashMargin: 2.2, obstaclePadding: 3 });
+const projectileSystem = new ProjectileSystem({ scene, world });
 updateDropButtonState();
 
 const startAnchor = new THREE.Vector3(0, -320, 0);
@@ -106,6 +133,7 @@ const TMP_EULER = new THREE.Euler();
 
 const VEHICLE_MODES = { PLANE: 'plane', CAR: 'car' };
 let activeVehicle = VEHICLE_MODES.PLANE;
+let activeScenario = SCENARIOS.PLANET;
 let carAttachedToDrone = true;
 
 function computeStartPosition(){
@@ -159,6 +187,76 @@ function computeDroneHoldPosition(){
 
 function updateDropButtonState(){
   hud.setDropEnabled(carAttachedToDrone && activeVehicle === VEHICLE_MODES.PLANE);
+}
+
+function applyPlanetEnvironment(){
+  document.body.style.background = PLANET_BODY_BACKGROUND;
+  if (!scene.background || !scene.background.isColor){
+    scene.background = PLANET_BACKGROUND.clone();
+  } else {
+    scene.background.copy(PLANET_BACKGROUND);
+  }
+  scene.fog = planetFog;
+  hemisphere.intensity = BASE_HEMISPHERE_INTENSITY;
+  sun.intensity = BASE_SUN_INTENSITY;
+  sun.visible = true;
+  world.worldGroup.visible = true;
+  if (world._ocean) world._ocean.visible = true;
+  spaceScene.setVisible(false);
+  planeController.setAuxiliaryLightsActive(false);
+  planeController.gravity = BASE_PLANE_GRAVITY;
+  planeController.propulsorLift = BASE_PROPULSOR_LIFT;
+  planeController.minSpeed = BASE_MIN_SPEED;
+  planeController.maxSpeed = BASE_MAX_SPEED;
+  planeController.maxBoostSpeed = BASE_MAX_BOOST_SPEED;
+  planeController.acceleration = BASE_ACCELERATION;
+  planeController.afterburnerAcceleration = BASE_AFTERBURNER_ACCELERATION;
+  planeController.drag = BASE_DRAG;
+  planeController.brakeDrag = BASE_BRAKE_DRAG;
+}
+
+function applySpaceEnvironment(){
+  document.body.style.background = SPACE_BODY_BACKGROUND;
+  if (!scene.background || !scene.background.isColor){
+    scene.background = SPACE_BACKGROUND.clone();
+  } else {
+    scene.background.copy(SPACE_BACKGROUND);
+  }
+  scene.fog = null;
+  hemisphere.intensity = BASE_HEMISPHERE_INTENSITY * 0.3;
+  sun.visible = false;
+  world.worldGroup.visible = false;
+  if (world._ocean) world._ocean.visible = false;
+  spaceScene.setVisible(true);
+  planeController.setAuxiliaryLightsActive(true, 1.3);
+  planeController.gravity = BASE_PLANE_GRAVITY * 0.14;
+  planeController.propulsorLift = BASE_PROPULSOR_LIFT * 0.32;
+  planeController.minSpeed = Math.min(8, BASE_MIN_SPEED * 0.25);
+  planeController.maxSpeed = BASE_MAX_SPEED * 1.8;
+  planeController.maxBoostSpeed = BASE_MAX_BOOST_SPEED * 2.2;
+  planeController.acceleration = BASE_ACCELERATION * 1.5;
+  planeController.afterburnerAcceleration = BASE_AFTERBURNER_ACCELERATION * 1.7;
+  planeController.drag = BASE_DRAG * 0.35;
+  planeController.brakeDrag = BASE_BRAKE_DRAG * 0.5;
+}
+
+function enterSpaceScenario(){
+  if (activeScenario === SCENARIOS.SPACE) return;
+  activeScenario = SCENARIOS.SPACE;
+  applySpaceEnvironment();
+  if (activeVehicle !== VEHICLE_MODES.PLANE){
+    activatePlaneMode();
+  }
+  resetCar({ attachToDrone: true });
+  hud.showMessage('Leaving atmosphere', 1400);
+}
+
+function enterPlanetScenario(){
+  if (activeScenario === SCENARIOS.PLANET) return;
+  activeScenario = SCENARIOS.PLANET;
+  applyPlanetEnvironment();
+  world.update(planeController.position);
+  hud.showMessage('Atmospheric re-entry', 1400);
 }
 
 function resetCar({ alignCamera = false, attachToDrone = false } = {}){
@@ -240,13 +338,21 @@ function activateCarMode({ focus = true } = {}){
 
 resetPlane();
 resetCar({ attachToDrone: true });
+applyPlanetEnvironment();
 
 enableWindowResizeHandling({ renderer, camera });
 
 function clampAltitude(controller, ground){
-  if (controller.position.z > SKY_CEILING){
-    controller.position.z = SKY_CEILING;
-    if (controller.velocity.z > 0) controller.velocity.z = 0;
+  if (activeScenario === SCENARIOS.PLANET){
+    if (controller.position.z > SKY_CEILING){
+      controller.position.z = SKY_CEILING;
+      if (controller.velocity.z > 0) controller.velocity.z = 0;
+    }
+  } else if (activeScenario === SCENARIOS.SPACE){
+    if (controller.position.z > SPACE_CEILING){
+      controller.position.z = SPACE_CEILING;
+      if (controller.velocity.z > 0) controller.velocity.z = 0;
+    }
   }
 }
 
@@ -254,6 +360,10 @@ let lastTime = performance.now();
 
 function setActiveVehicle(mode){
   if (mode === activeVehicle) return;
+  if (activeScenario === SCENARIOS.SPACE && mode === VEHICLE_MODES.CAR){
+    hud.showMessage('Ground vehicle unavailable in space', 1000);
+    return;
+  }
   if (mode === VEHICLE_MODES.PLANE){
     activatePlaneMode();
   } else if (mode === VEHICLE_MODES.CAR){
@@ -279,7 +389,18 @@ function animate(now){
   lastTime = now;
 
   const inputSample = input.readState(dt);
-  const planeInput = crashCooldown > 0 ? { pitch: 0, yaw: 0, roll: 0, throttleAdjust: 0, brake: false } : inputSample.plane;
+  const planeInputRaw = inputSample.plane;
+  const planeInput = crashCooldown > 0
+    ? {
+        pitch: 0,
+        yaw: 0,
+        roll: 0,
+        throttleAdjust: 0,
+        brake: false,
+        aim: { x: planeController.aim?.x ?? 0, y: planeController.aim?.y ?? 0 },
+      }
+    : planeInputRaw;
+  const firePressed = crashCooldown > 0 ? false : !!inputSample.fire;
 
   if (crashCooldown > 0){
     crashCooldown = Math.max(0, crashCooldown - dt);
@@ -293,7 +414,22 @@ function animate(now){
 
     const planeState = planeController.getState();
 
-    if (crashCooldown <= 0){
+    const altitude = planeState.altitude ?? 0;
+    if (activeScenario === SCENARIOS.PLANET && altitude > SPACE_TRANSITION_ALTITUDE){
+      enterSpaceScenario();
+    } else if (activeScenario === SCENARIOS.SPACE && altitude < SPACE_RETURN_ALTITUDE){
+      enterPlanetScenario();
+    }
+
+    if (firePressed){
+      projectileSystem.tryFire({
+        position: planeState.position.clone(),
+        orientation: planeState.orientation.clone(),
+        velocity: planeState.velocity.clone(),
+      });
+    }
+
+    if (crashCooldown <= 0 && activeScenario === SCENARIOS.PLANET){
       const collision = collisionSystem.evaluate(planeState);
       if (collision.crashed){
         crashCount += 1;
@@ -325,8 +461,10 @@ function animate(now){
       lastCarPosition.copy(carController.position);
     }
 
-    rebaseWorldIfNeeded(planeController.position);
-    world.update(planeState.position);
+    if (activeScenario === SCENARIOS.PLANET){
+      rebaseWorldIfNeeded(planeController.position);
+      world.update(planeState.position);
+    }
     chaseCamera.update(planeState, dt, inputSample.cameraOrbit);
 
     hud.update({
@@ -336,7 +474,7 @@ function animate(now){
       elapsedTime: elapsedFlightTime,
       distance: traveledDistance,
     });
-  } else {
+  } else if (activeScenario === SCENARIOS.PLANET){
     carController.update(dt, inputSample.car, {
       sampleGroundHeight: (x, y) => world.getHeightAt(x, y),
     });
@@ -360,12 +498,21 @@ function animate(now){
       elapsedTime: elapsedDriveTime,
       distance: drivenDistance,
     });
+  } else {
+    chaseCamera.update(planeController.getState(), dt, inputSample.cameraOrbit);
   }
+
+  spaceScene.update(dt, activeScenario === SCENARIOS.SPACE ? planeController.position : null);
+
+  const originOffset = world.getOriginOffset ? world.getOriginOffset() : new THREE.Vector3();
+  const spaceBodies = activeScenario === SCENARIOS.SPACE ? spaceScene.getBodies() : [];
+  projectileSystem.update(dt, { scenario: activeScenario, originOffset, spaceBodies });
 
   renderer.render(scene, camera);
 }
 
 function rebaseWorldIfNeeded(referencePosition){
+  if (activeScenario !== SCENARIOS.PLANET) return;
   const pos = referencePosition ?? planeController.position;
   const distanceSq = pos.x * pos.x + pos.y * pos.y;
   if (distanceSq > ORIGIN_REBASE_DISTANCE_SQ){
@@ -379,6 +526,7 @@ function rebaseWorldIfNeeded(referencePosition){
     lastPlanePosition.sub(shift);
     lastCarPosition.sub(shift);
     world.handleOriginShift(shift);
+    projectileSystem.handleOriginShift(shift);
   }
 }
 


### PR DESCRIPTION
## Summary
- boost the plane’s space-only flight tuning for faster interplanetary travel while restoring atmospheric handling on re-entry
- enlarge and brighten the solar system’s central sun to emphasize the space scene centerpiece
- scale torpedo explosions and craters with impact speed so terrain hits carve massive destruction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbefde66fc8329a5059a028db2a0aa