### PR TITLE
Add combat-ready vehicle experience to Mars sandbox

### DIFF
--- a/terra-sandbox/README.md
+++ b/terra-sandbox/README.md
@@ -10,6 +10,9 @@ Open [`index.html`](./index.html) in a browser (served from a local web server) 
 
 - `index.html` – entry point that loads Three.js and bootstraps the Terra sandbox module.
 
+- `mars/` – fully self-contained Ares Expanse sandbox with procedural terrain generation and HUD. The Mars sandbox does not
+  rely on shared helpers or `maps.json`; every system (noise, terrain authoring, lighting, and HUD wiring) lives directly
+  inside this folder so it can be iterated in isolation.
 - `terra/` – Terra-specific gameplay logic, HUD, world streamer wiring, and map configuration.
 - `sandbox/` – reusable controllers, camera helpers, HUD overlays, and supporting systems extracted from the original viewer.
 - `shared/` – shared Three.js bootstrap helpers.

--- a/terra-sandbox/mars/chaseCamera.js
+++ b/terra-sandbox/mars/chaseCamera.js
@@ -1,0 +1,60 @@
+import * as THREE from 'three';
+
+const FORWARD = new THREE.Vector3(0, 1, 0);
+const UP = new THREE.Vector3(0, 0, 1);
+
+export class MarsChaseCamera {
+  constructor({ camera, distance = 48, height = 16, lookAhead = 22, responsiveness = 6 } = {}) {
+    this.camera = camera;
+    this.distance = distance;
+    this.height = height;
+    this.lookAhead = lookAhead;
+    this.responsiveness = responsiveness;
+    this.target = null;
+    this._position = new THREE.Vector3();
+    this._desired = new THREE.Vector3();
+    this._lookTarget = new THREE.Vector3();
+  }
+
+  follow(target) {
+    this.target = target;
+    if (target) {
+      this.snap();
+    }
+  }
+
+  update(dt) {
+    if (!this.target) return;
+    const blend = dt > 0 ? 1 - Math.exp(-this.responsiveness * dt) : 1;
+
+    const forward = FORWARD.clone().applyQuaternion(this.target.orientation ?? this.target.quaternion);
+    const up = UP.clone().applyQuaternion(this.target.orientation ?? this.target.quaternion);
+
+    this._desired.copy(this.target.position)
+      .addScaledVector(forward, -this.distance)
+      .addScaledVector(up, this.height);
+
+    if (this._position.lengthSq() === 0) {
+      this._position.copy(this._desired);
+    } else {
+      this._position.lerp(this._desired, blend);
+    }
+
+    this.camera.position.copy(this._position);
+
+    this._lookTarget.copy(this.target.position).addScaledVector(forward, this.lookAhead);
+    this.camera.lookAt(this._lookTarget);
+  }
+
+  snap() {
+    if (!this.target) return;
+    const forward = FORWARD.clone().applyQuaternion(this.target.orientation ?? this.target.quaternion);
+    const up = UP.clone().applyQuaternion(this.target.orientation ?? this.target.quaternion);
+    this._position.copy(this.target.position)
+      .addScaledVector(forward, -this.distance)
+      .addScaledVector(up, this.height);
+    this.camera.position.copy(this._position);
+    this._lookTarget.copy(this.target.position).addScaledVector(forward, this.lookAhead);
+    this.camera.lookAt(this._lookTarget);
+  }
+}

--- a/terra-sandbox/mars/hud.js
+++ b/terra-sandbox/mars/hud.js
@@ -1,0 +1,66 @@
+function formatNumber(value, digits = 0) {
+  return value.toLocaleString(undefined, { maximumFractionDigits: digits, minimumFractionDigits: digits });
+}
+
+export class MarsHUD {
+  constructor({
+    statusLabel,
+    altitudeOutput,
+    temperatureOutput,
+    windOutput,
+    speedOutput,
+    throttleOutput,
+    weaponOutput,
+    seedOutput,
+  }) {
+    this.statusLabel = statusLabel;
+    this.altitudeOutput = altitudeOutput;
+    this.temperatureOutput = temperatureOutput;
+    this.windOutput = windOutput;
+    this.speedOutput = speedOutput;
+    this.throttleOutput = throttleOutput;
+    this.weaponOutput = weaponOutput;
+    this.seedOutput = seedOutput;
+  }
+
+  setStatus(text) {
+    if (this.statusLabel) {
+      this.statusLabel.textContent = text;
+    }
+  }
+
+  setSeed(seed) {
+    if (this.seedOutput) {
+      this.seedOutput.textContent = seed;
+    }
+  }
+
+  updateEnvironment({ temperature, wind } = {}) {
+    if (this.temperatureOutput && typeof temperature === 'number') {
+      this.temperatureOutput.textContent = `${Math.round(temperature)} °C`;
+    }
+    if (this.windOutput && typeof wind === 'number') {
+      this.windOutput.textContent = `${Math.round(wind)} m/s`;
+    }
+  }
+
+  updateVehicle({ altitude, speed, throttle, boost, weaponReady, heat } = {}) {
+    if (this.altitudeOutput && typeof altitude === 'number') {
+      this.altitudeOutput.textContent = formatNumber(Math.max(0, altitude));
+    }
+    if (this.speedOutput && typeof speed === 'number') {
+      this.speedOutput.textContent = `${formatNumber(Math.max(0, speed), 0)} km/h`;
+    }
+    if (this.throttleOutput && typeof throttle === 'number') {
+      const boostSuffix = boost ? ' +BOOST' : '';
+      this.throttleOutput.textContent = `${Math.round(throttle * 100)}%${boostSuffix}`;
+    }
+    if (this.weaponOutput) {
+      if (!weaponReady) {
+        this.weaponOutput.textContent = `Cooling (${Math.round(Math.max(0, heat) * 100)}%)`;
+      } else {
+        this.weaponOutput.textContent = 'Ready';
+      }
+    }
+  }
+}

--- a/terra-sandbox/mars/index.html
+++ b/terra-sandbox/mars/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mars Sandbox</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at 40% 20%, #541f1d, #140607 70%);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        grid-template-columns: minmax(280px, 340px) 1fr;
+        grid-template-areas: 'hud scene';
+        background: transparent;
+      }
+
+      .hud {
+        grid-area: hud;
+        padding: 2.5rem 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        color: rgba(255, 228, 210, 0.9);
+        background: linear-gradient(180deg, rgba(52, 20, 17, 0.95) 0%, rgba(19, 7, 6, 0.85) 65%, rgba(15, 4, 5, 0.78) 100%);
+        backdrop-filter: blur(20px);
+        border-right: 1px solid rgba(216, 122, 90, 0.25);
+        box-shadow: inset -1px 0 0 rgba(255, 153, 111, 0.08);
+      }
+
+      .hud h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 2vw + 1rem, 2.4rem);
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: #ffc9a5;
+      }
+
+      .hud .status {
+        font-size: 1rem;
+        letter-spacing: 0.07em;
+        color: rgba(255, 210, 191, 0.82);
+        min-height: 2.25rem;
+      }
+
+      .hud .altitude {
+        font-size: clamp(1.4rem, 2vw + 0.8rem, 1.8rem);
+        font-weight: 600;
+        color: #ffe7c2;
+      }
+
+      .hud .readouts {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .hud .readout {
+        display: grid;
+        gap: 0.35rem;
+        padding-bottom: 0.9rem;
+        border-bottom: 1px solid rgba(216, 122, 90, 0.15);
+      }
+
+      .hud .readout:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
+
+      .hud label {
+        font-size: 0.82rem;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: rgba(255, 190, 159, 0.72);
+      }
+
+      .hud output {
+        font-size: 1.2rem;
+        color: rgba(255, 231, 198, 0.95);
+      }
+
+      .controls {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .controls button {
+        flex: 1 0 45%;
+        border: 1px solid rgba(255, 160, 120, 0.25);
+        border-radius: 8px;
+        padding: 0.6rem 0.9rem;
+        font-size: 0.95rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        background: rgba(120, 42, 31, 0.65);
+        color: #ffe1c8;
+        cursor: pointer;
+        transition: transform 150ms ease, background 150ms ease;
+      }
+
+      .controls button:hover,
+      .controls button:focus-visible {
+        background: rgba(174, 64, 45, 0.85);
+        transform: translateY(-1px);
+      }
+
+      .controls button:active {
+        transform: translateY(1px);
+      }
+
+      .scene {
+        grid-area: scene;
+        position: relative;
+      }
+
+      canvas {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      @media (max-width: 960px) {
+        body {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto 1fr;
+          grid-template-areas:
+            'hud'
+            'scene';
+        }
+
+        .hud {
+          padding: 1.5rem 1.75rem 2rem;
+          border-right: none;
+          border-bottom: 1px solid rgba(216, 122, 90, 0.2);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <aside class="hud" aria-live="polite">
+      <h1>Ares Expanse</h1>
+      <p class="status" id="mars-status">Booting atmospheric processors…</p>
+      <div class="altitude">Altitude <output id="mars-altitude">0</output> m</div>
+      <div class="readouts">
+        <div class="readout">
+          <label for="mars-temperature">Surface Temperature</label>
+          <output id="mars-temperature">-48 °C</output>
+        </div>
+        <div class="readout">
+          <label for="mars-wind">Wind Speed</label>
+          <output id="mars-wind">12 m/s</output>
+        </div>
+        <div class="readout">
+          <label for="mars-speed">Velocity</label>
+          <output id="mars-speed">0 km/h</output>
+        </div>
+        <div class="readout">
+          <label for="mars-throttle">Propulsion</label>
+          <output id="mars-throttle">0%</output>
+        </div>
+        <div class="readout">
+          <label for="mars-weapon">Weapon Systems</label>
+          <output id="mars-weapon">Arming…</output>
+        </div>
+        <div class="readout">
+          <label for="mars-seed">Simulation Seed</label>
+          <output id="mars-seed">-</output>
+        </div>
+      </div>
+      <div class="controls">
+        <button type="button" data-action="reset">Recenter Craft</button>
+        <button type="button" data-action="shuffle">Regenerate Terrain</button>
+      </div>
+      <section class="readout" aria-label="Control guide">
+        <label>Flight Controls</label>
+        <p style="margin:0;font-size:0.85rem;color:rgba(255,200,182,0.75);line-height:1.4;">
+          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire
+        </p>
+      </section>
+    </aside>
+    <main class="scene">
+      <canvas id="mars-canvas" aria-label="Mars terrain visualizer"></canvas>
+    </main>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/terra-sandbox/mars/input.js
+++ b/terra-sandbox/mars/input.js
@@ -1,0 +1,138 @@
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+const DEFAULT_SENSITIVITY = 0.0028;
+
+export class MarsInputManager {
+  constructor({ canvas, sensitivity = DEFAULT_SENSITIVITY } = {}) {
+    this.canvas = canvas;
+    this.sensitivity = sensitivity;
+    this.keys = new Set();
+    this.pointerLocked = false;
+    this.primaryFire = false;
+    this.aimX = 0;
+    this.aimY = 0;
+    this._listeners = [];
+
+    this._handleKeyDown = this._handleKeyDown.bind(this);
+    this._handleKeyUp = this._handleKeyUp.bind(this);
+    this._handlePointerDown = this._handlePointerDown.bind(this);
+    this._handlePointerUp = this._handlePointerUp.bind(this);
+    this._handleMouseMove = this._handleMouseMove.bind(this);
+    this._handlePointerLockChange = this._handlePointerLockChange.bind(this);
+    this._handleVisibilityChange = this._handleVisibilityChange.bind(this);
+
+    document.addEventListener('keydown', this._handleKeyDown);
+    document.addEventListener('keyup', this._handleKeyUp);
+    document.addEventListener('pointerlockchange', this._handlePointerLockChange);
+    document.addEventListener('visibilitychange', this._handleVisibilityChange);
+    document.addEventListener('mouseup', this._handlePointerUp);
+
+    if (this.canvas) {
+      this.canvas.addEventListener('click', () => {
+        if (!this.pointerLocked && this.canvas.requestPointerLock) {
+          this.canvas.requestPointerLock();
+        }
+      });
+      this.canvas.addEventListener('mousedown', this._handlePointerDown);
+    }
+  }
+
+  dispose() {
+    document.removeEventListener('keydown', this._handleKeyDown);
+    document.removeEventListener('keyup', this._handleKeyUp);
+    document.removeEventListener('pointerlockchange', this._handlePointerLockChange);
+    document.removeEventListener('visibilitychange', this._handleVisibilityChange);
+    document.removeEventListener('mouseup', this._handlePointerUp);
+    document.removeEventListener('mousemove', this._handleMouseMove);
+    if (this.canvas) {
+      this.canvas.removeEventListener('mousedown', this._handlePointerDown);
+    }
+  }
+
+  _handleKeyDown(event) {
+    this.keys.add(event.code);
+  }
+
+  _handleKeyUp(event) {
+    this.keys.delete(event.code);
+  }
+
+  _handlePointerDown(event) {
+    if (event.button === 0) {
+      this.primaryFire = true;
+    }
+  }
+
+  _handlePointerUp(event) {
+    if (event.button === 0) {
+      this.primaryFire = false;
+    }
+  }
+
+  _handleMouseMove(event) {
+    if (!this.pointerLocked) return;
+    const movementX = event.movementX || 0;
+    const movementY = event.movementY || 0;
+    this.aimX = clamp(this.aimX + movementX * this.sensitivity, -1, 1);
+    this.aimY = clamp(this.aimY + movementY * this.sensitivity, -1, 1);
+  }
+
+  _handlePointerLockChange() {
+    this.pointerLocked = document.pointerLockElement === this.canvas;
+    if (this.pointerLocked) {
+      document.addEventListener('mousemove', this._handleMouseMove);
+    } else {
+      document.removeEventListener('mousemove', this._handleMouseMove);
+      this.aimX = 0;
+      this.aimY = 0;
+      this.primaryFire = false;
+    }
+  }
+
+  _handleVisibilityChange() {
+    if (document.hidden) {
+      this.keys.clear();
+      this.primaryFire = false;
+    }
+  }
+
+  update(dt) {
+    const decay = dt > 0 ? Math.exp(-1.5 * dt) : 0;
+    if (!this.pointerLocked) {
+      this.aimX *= decay;
+      this.aimY *= decay;
+    } else {
+      this.aimX = clamp(this.aimX, -1, 1);
+      this.aimY = clamp(this.aimY, -1, 1);
+    }
+  }
+
+  _axis(positive, negative) {
+    const hasPositive = Array.isArray(positive)
+      ? positive.some((code) => this.keys.has(code))
+      : this.keys.has(positive);
+    const hasNegative = Array.isArray(negative)
+      ? negative.some((code) => this.keys.has(code))
+      : this.keys.has(negative);
+    if (hasPositive && !hasNegative) return 1;
+    if (hasNegative && !hasPositive) return -1;
+    return 0;
+  }
+
+  getState() {
+    return {
+      throttle: this._axis(['KeyW', 'ArrowUp'], ['KeyS', 'ArrowDown']),
+      yaw: this._axis('KeyD', 'KeyA'),
+      roll: this._axis('KeyE', 'KeyQ'),
+      pitch: this._axis('ArrowDown', 'ArrowUp'),
+      strafe: this._axis('KeyL', 'KeyJ'),
+      elevate: this._axis('KeyI', 'KeyK'),
+      boost: this.keys.has('ShiftLeft') || this.keys.has('ShiftRight'),
+      brake: this.keys.has('Space'),
+      aim: { x: this.aimX, y: this.aimY },
+      firing: this.primaryFire,
+    };
+  }
+}

--- a/terra-sandbox/mars/main.js
+++ b/terra-sandbox/mars/main.js
@@ -1,0 +1,54 @@
+import { MarsSandbox } from './marsSandbox.js';
+
+function getElement(id) {
+  const el = document.getElementById(id);
+  if (!el) {
+    throw new Error(`Missing required element: ${id}`);
+  }
+  return el;
+}
+
+const canvas = getElement('mars-canvas');
+const statusLabel = getElement('mars-status');
+const altitudeOutput = getElement('mars-altitude');
+const temperatureOutput = getElement('mars-temperature');
+const windOutput = getElement('mars-wind');
+const speedOutput = getElement('mars-speed');
+const throttleOutput = getElement('mars-throttle');
+const weaponOutput = getElement('mars-weapon');
+const seedOutput = getElement('mars-seed');
+
+const sandbox = new MarsSandbox({
+  canvas,
+  statusLabel,
+  altitudeOutput,
+  temperatureOutput,
+  windOutput,
+  speedOutput,
+  throttleOutput,
+  weaponOutput,
+  seedOutput,
+});
+
+sandbox.initialize();
+sandbox.start();
+
+const controls = document.querySelectorAll('.controls button[data-action]');
+controls.forEach((button) => {
+  const action = button.dataset.action;
+  button.addEventListener('click', () => {
+    if (action === 'reset') {
+      sandbox.resetVehicle();
+    } else if (action === 'shuffle') {
+      sandbox.regenerate();
+    }
+  });
+});
+
+window.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    sandbox.stop();
+  } else {
+    sandbox.start();
+  }
+});

--- a/terra-sandbox/mars/marsSandbox.js
+++ b/terra-sandbox/mars/marsSandbox.js
@@ -1,0 +1,328 @@
+import * as THREE from 'three';
+import { MarsVehicle, createMarsSkiff } from './vehicle.js';
+import { MarsChaseCamera } from './chaseCamera.js';
+import { MarsInputManager } from './input.js';
+import { MarsProjectileSystem } from './projectiles.js';
+import { MarsHUD } from './hud.js';
+import { createMarsTerrain, disposeMarsTerrain } from './terrain.js';
+
+function createMulberry32(seed) {
+  let a = seed >>> 0;
+  return function rng() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export class MarsSandbox {
+  constructor({
+    canvas,
+    statusLabel,
+    altitudeOutput,
+    temperatureOutput,
+    windOutput,
+    speedOutput,
+    throttleOutput,
+    weaponOutput,
+    seedOutput,
+  }) {
+    this.canvas = canvas;
+    this.clock = new THREE.Clock();
+    this.scene = null;
+    this.camera = null;
+    this.renderer = null;
+    this.sunLight = null;
+    this.fillLight = null;
+    this.surfaceGroup = null;
+    this.terrain = null;
+    this.seed = null;
+    this.rng = null;
+
+    this.vehicle = null;
+    this.vehicleMesh = null;
+    this.chaseCamera = null;
+    this.inputManager = null;
+    this.projectiles = null;
+    this.hud = new MarsHUD({
+      statusLabel,
+      altitudeOutput,
+      temperatureOutput,
+      windOutput,
+      speedOutput,
+      throttleOutput,
+      weaponOutput,
+      seedOutput,
+    });
+
+    this.animationHandle = null;
+    this.weaponColor = new THREE.Color('#ff9d5c');
+
+    this._handleResize = this._handleResize.bind(this);
+    this._update = this._update.bind(this);
+  }
+
+  initialize(seed) {
+    this.seed = typeof seed === 'number' ? seed : this._generateSeed();
+    this.rng = createMulberry32(this.seed);
+    this.hud.setSeed(this.seed.toString(16).toUpperCase());
+
+    this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas, antialias: true, alpha: true });
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.outputEncoding = THREE.sRGBEncoding;
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color('#200a07');
+    this.scene.fog = new THREE.FogExp2('#5a2216', 0.00032);
+
+    const aspect = this.canvas.clientWidth / this.canvas.clientHeight || window.innerWidth / window.innerHeight;
+    this.camera = new THREE.PerspectiveCamera(60, aspect, 0.1, 24000);
+
+    const ambient = new THREE.AmbientLight('#784233', 0.36);
+    this.scene.add(ambient);
+
+    this.sunLight = new THREE.DirectionalLight('#ffd9a0', 1.35);
+    this.sunLight.position.set(-560, 720, 420);
+    this.sunLight.castShadow = true;
+    this.sunLight.shadow.mapSize.set(2048, 2048);
+    this.sunLight.shadow.camera.near = 80;
+    this.sunLight.shadow.camera.far = 3600;
+    this.sunLight.shadow.camera.left = -1200;
+    this.sunLight.shadow.camera.right = 1200;
+    this.sunLight.shadow.camera.top = 1200;
+    this.sunLight.shadow.camera.bottom = -1200;
+    this.scene.add(this.sunLight);
+
+    this.fillLight = new THREE.DirectionalLight('#c06b42', 0.42);
+    this.fillLight.position.set(420, 260, -580);
+    this.scene.add(this.fillLight);
+
+    const skyGeometry = new THREE.SphereGeometry(6400, 32, 32);
+    const skyMaterial = new THREE.ShaderMaterial({
+      side: THREE.BackSide,
+      transparent: false,
+      uniforms: {
+        topColor: { value: new THREE.Color('#31110d') },
+        horizonColor: { value: new THREE.Color('#a14b2e') },
+        bottomColor: { value: new THREE.Color('#1c0706') },
+      },
+      vertexShader: `
+        varying float vY;
+        void main() {
+          vY = normalize(position).y * 0.5 + 0.5;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: `
+        varying float vY;
+        uniform vec3 topColor;
+        uniform vec3 horizonColor;
+        uniform vec3 bottomColor;
+        void main() {
+          float upper = smoothstep(0.3, 0.85, vY);
+          float lower = smoothstep(0.0, 0.4, vY);
+          vec3 col = mix(bottomColor, horizonColor, lower);
+          col = mix(col, topColor, upper);
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+    });
+    const sky = new THREE.Mesh(skyGeometry, skyMaterial);
+    sky.name = 'marsSky';
+    this.scene.add(sky);
+
+    this.surfaceGroup = new THREE.Group();
+    this.scene.add(this.surfaceGroup);
+
+    this._buildTerrain();
+
+    this.vehicle = new MarsVehicle();
+    if (this.terrain?.sampleHeight) {
+      this.vehicle.setTerrainSampler(this.terrain.sampleHeight);
+    }
+    const { group: vehicleMesh, attachments } = createMarsSkiff();
+    this.vehicle.attachMesh(vehicleMesh, attachments);
+    this.scene.add(vehicleMesh);
+    this.vehicleMesh = vehicleMesh;
+
+    const startHeight = this.terrain?.sampleHeight ? this.terrain.sampleHeight(0, 0) + 58 : 90;
+    this.vehicle.reset({ position: new THREE.Vector3(0, startHeight, 120) });
+
+    this.chaseCamera = new MarsChaseCamera({ camera: this.camera, distance: 68, height: 28, lookAhead: 36, responsiveness: 5.6 });
+    this.chaseCamera.follow(this.vehicle);
+
+    this.projectiles = new MarsProjectileSystem({ scene: this.scene });
+    this.inputManager = new MarsInputManager({ canvas: this.canvas });
+
+    this.hud.setStatus('Atmospheric skiff systems nominal. Weapons hot.');
+    this._updateWeather();
+    this._handleResize();
+    window.addEventListener('resize', this._handleResize);
+  }
+
+  start() {
+    if (!this.renderer) {
+      throw new Error('MarsSandbox not initialized');
+    }
+    if (this.animationHandle) return;
+    this.clock.start();
+    this.animationHandle = this.renderer.setAnimationLoop(this._update);
+  }
+
+  stop() {
+    if (this.animationHandle) {
+      this.renderer.setAnimationLoop(null);
+      this.animationHandle = null;
+    }
+  }
+
+  dispose() {
+    this.stop();
+    window.removeEventListener('resize', this._handleResize);
+    this.inputManager?.dispose?.();
+    this.projectiles?.dispose?.();
+    this.projectiles = null;
+    if (this.renderer) {
+      this.renderer.dispose();
+      this.renderer = null;
+    }
+    disposeMarsTerrain(this.terrain);
+    this.terrain = null;
+    this.scene = null;
+  }
+
+  resetCamera() {
+    this.chaseCamera?.snap?.();
+    this.hud.setStatus('Camera anchor reset.');
+  }
+
+  resetVehicle() {
+    if (!this.vehicle) return;
+    const ground = this.terrain?.sampleHeight ? this.terrain.sampleHeight(0, 0) : 0;
+    this.vehicle.reset({ position: new THREE.Vector3(0, ground + 58, 120) });
+    this.chaseCamera?.snap?.();
+    this.hud.setStatus('Aeroskiff repositioned at survey anchor.');
+  }
+
+  regenerate(seed) {
+    const nextSeed = typeof seed === 'number' ? seed : this._generateSeed();
+    this.seed = nextSeed;
+    this.rng = createMulberry32(this.seed);
+    this.hud.setSeed(this.seed.toString(16).toUpperCase());
+    this._buildTerrain();
+    if (this.terrain?.sampleHeight) {
+      this.vehicle?.setTerrainSampler(this.terrain.sampleHeight);
+      const ground = this.terrain.sampleHeight(0, 0);
+      this.vehicle?.reset({ position: new THREE.Vector3(0, ground + 58, 120) });
+      this.chaseCamera?.snap?.();
+    }
+    this._updateWeather();
+    this.hud.setStatus('Terrain regenerated. Navigation recalibrated.');
+  }
+
+  _buildTerrain() {
+    if (this.surfaceGroup && this.surfaceGroup.children.length > 0) {
+      for (const child of [...this.surfaceGroup.children]) {
+        this.surfaceGroup.remove(child);
+      }
+    }
+    if (this.terrain) {
+      disposeMarsTerrain(this.terrain);
+      this.terrain = null;
+    }
+    this.terrain = createMarsTerrain({ seed: this.seed, size: 2000, segments: 256 });
+    this.surfaceGroup.add(this.terrain.mesh);
+    this.surfaceGroup.add(this.terrain.rockField);
+    this.surfaceGroup.add(this.terrain.dustField);
+  }
+
+  _updateWeather() {
+    if (!this.rng) return;
+    const temperature = -70 + this.rng() * 35;
+    const gust = 6 + this.rng() * 26;
+    this.hud.updateEnvironment({ temperature, wind: gust });
+  }
+
+  _handleResize() {
+    if (!this.renderer || !this.camera) return;
+    const width = this.canvas.clientWidth || window.innerWidth - 340;
+    const height = this.canvas.clientHeight || window.innerHeight;
+    const dpr = window.devicePixelRatio || 1;
+    this.renderer.setPixelRatio(dpr);
+    this.renderer.setSize(width, height, false);
+    this.camera.aspect = width / Math.max(1, height);
+    this.camera.updateProjectionMatrix();
+  }
+
+  _update() {
+    const dt = this.clock.getDelta();
+    if (!this.vehicle || !this.scene) return;
+
+    this.inputManager?.update?.(dt);
+    const inputState = this.inputManager ? this.inputManager.getState() : {};
+    this.vehicle.update(dt, inputState, { gravity: 3.72 });
+
+    if (inputState.firing) {
+      const shot = this.vehicle.firePrimary();
+      if (shot) {
+        this.projectiles.fire({ origin: shot.origin, direction: shot.direction, velocity: shot.velocity, life: 4.5, color: this.weaponColor });
+      }
+    }
+
+    this.projectiles?.update?.(dt);
+    this.chaseCamera?.update?.(dt);
+
+    const vehicleState = this.vehicle.getState(this.terrain?.sampleHeight);
+    const speedKmh = vehicleState.speed * 3.6;
+    this.hud.updateVehicle({
+      altitude: vehicleState.altitude,
+      speed: speedKmh,
+      throttle: vehicleState.throttle,
+      boost: vehicleState.boost,
+      weaponReady: vehicleState.weapon.ready,
+      heat: vehicleState.weapon.heat,
+    });
+
+    const elapsed = this.clock.elapsedTime;
+    if (this.sunLight) {
+      const sunRadius = 820;
+      const angle = elapsed * 0.03;
+      this.sunLight.position.x = Math.cos(angle) * sunRadius;
+      this.sunLight.position.z = Math.sin(angle) * sunRadius;
+      this.sunLight.position.y = 640 + Math.sin(angle * 0.5) * 120;
+    }
+    if (this.fillLight) {
+      this.fillLight.intensity = 0.36 + Math.sin(elapsed * 0.25) * 0.08;
+    }
+
+    if (this.terrain?.dustField) {
+      const material = this.terrain.dustField.material;
+      material.opacity = 0.6 + Math.sin(elapsed * 0.8) * 0.08;
+      const geometry = this.terrain.dustField.geometry;
+      const positions = geometry.attributes.position;
+      const baseY = geometry.attributes.baseY;
+      for (let i = 0; i < positions.count; i += 1) {
+        const yIndex = i * 3 + 1;
+        const wave = Math.sin(elapsed * 0.6 + i * 0.25) * 0.65;
+        positions.array[yIndex] = baseY.array[i] + wave;
+      }
+      positions.needsUpdate = true;
+    }
+
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  _generateSeed() {
+    if (crypto?.getRandomValues) {
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      return buf[0] >>> 0;
+    }
+    return Math.floor(Math.random() * 0xffffffff);
+  }
+}

--- a/terra-sandbox/mars/noise.js
+++ b/terra-sandbox/mars/noise.js
@@ -1,0 +1,91 @@
+const GRADIENTS = [
+  [1, 1],
+  [-1, 1],
+  [1, -1],
+  [-1, -1],
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const TAU = Math.PI * 2;
+
+function fade(t) {
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function hash(x, y, seed) {
+  let h = Math.imul(x, 374761393) + Math.imul(y, 668265263) + Math.imul(seed, 362437);
+  h = (h ^ (h >>> 13)) >>> 0;
+  h = Math.imul(h, 1274126177);
+  return h ^ (h >>> 16);
+}
+
+function grad(hashValue, x, y) {
+  const g = GRADIENTS[hashValue & 7];
+  return g[0] * x + g[1] * y;
+}
+
+export function perlin2(x, y, seed = 0) {
+  const xi0 = Math.floor(x);
+  const yi0 = Math.floor(y);
+  const xf0 = x - xi0;
+  const yf0 = y - yi0;
+  const xi1 = xi0 + 1;
+  const yi1 = yi0 + 1;
+
+  const g00 = grad(hash(xi0, yi0, seed), xf0, yf0);
+  const g10 = grad(hash(xi1, yi0, seed), xf0 - 1, yf0);
+  const g01 = grad(hash(xi0, yi1, seed), xf0, yf0 - 1);
+  const g11 = grad(hash(xi1, yi1, seed), xf0 - 1, yf0 - 1);
+
+  const u = fade(xf0);
+  const v = fade(yf0);
+
+  const x1 = lerp(g00, g10, u);
+  const x2 = lerp(g01, g11, u);
+  return lerp(x1, x2, v);
+}
+
+export function fractalNoise2D(x, y, {
+  seed = 0,
+  octaves = 4,
+  lacunarity = 2,
+  gain = 0.5,
+  frequency = 0.0025,
+} = {}) {
+  let amp = 1;
+  let freq = frequency;
+  let total = 0;
+  let maxAmp = 0;
+
+  for (let i = 0; i < octaves; i += 1) {
+    total += perlin2(x * freq, y * freq, seed + i * 97) * amp;
+    maxAmp += amp;
+    amp *= gain;
+    freq *= lacunarity;
+  }
+
+  return maxAmp === 0 ? 0 : total / maxAmp;
+}
+
+export function ridgedNoise2D(x, y, options = {}) {
+  const value = fractalNoise2D(x, y, options);
+  const ridge = 1 - Math.abs(value);
+  return ridge * ridge;
+}
+
+export function warpCoordinate(x, y, { seed = 0, amplitude = 32, frequency = 0.004 } = {}) {
+  const angle = fractalNoise2D(x, y, { seed: seed + 421, frequency, octaves: 3, gain: 0.65 }) * TAU;
+  const strength = fractalNoise2D(x + 1000, y - 1000, { seed: seed + 997, frequency: frequency * 0.5, octaves: 2 }) * 0.5 + 0.5;
+  const offset = amplitude * strength;
+  return {
+    x: x + Math.cos(angle) * offset,
+    y: y + Math.sin(angle) * offset,
+  };
+}

--- a/terra-sandbox/mars/projectiles.js
+++ b/terra-sandbox/mars/projectiles.js
@@ -1,0 +1,87 @@
+import * as THREE from 'three';
+
+const FORWARD = new THREE.Vector3(0, 1, 0);
+
+export class MarsProjectileSystem {
+  constructor({ scene }) {
+    this.scene = scene;
+    this.projectiles = [];
+    this.pool = [];
+  }
+
+  _acquireMesh(color) {
+    if (this.pool.length > 0) {
+      const mesh = this.pool.pop();
+      if (mesh.material.emissive) {
+        mesh.material.emissive.set(color);
+      }
+      mesh.visible = true;
+      return mesh;
+    }
+    const geometry = new THREE.CylinderGeometry(0.4, 0.6, 3.6, 8, 1);
+    const material = new THREE.MeshStandardMaterial({
+      color,
+      emissive: color,
+      emissiveIntensity: 2.4,
+      roughness: 0.3,
+      metalness: 0.1,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    geometry.rotateX(Math.PI / 2);
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.name = 'marsProjectile';
+    return mesh;
+  }
+
+  fire({ origin, direction, speed = 720, velocity = null, life = 3.5, color = new THREE.Color('#ff9d5c') }) {
+    if (!origin || !direction) return;
+    const mesh = this._acquireMesh(color);
+    mesh.position.copy(origin);
+    const look = new THREE.Quaternion().setFromUnitVectors(FORWARD, direction.clone().normalize());
+    mesh.quaternion.copy(look);
+    if (!mesh.parent && this.scene) {
+      this.scene.add(mesh);
+    }
+    this.projectiles.push({
+      mesh,
+      velocity: velocity ? velocity.clone() : direction.clone().setLength(speed),
+      life,
+    });
+  }
+
+  update(dt) {
+    if (this.projectiles.length === 0) return;
+    for (let i = this.projectiles.length - 1; i >= 0; i -= 1) {
+      const projectile = this.projectiles[i];
+      projectile.life -= dt;
+      if (projectile.life <= 0) {
+        this._recycle(i);
+        continue;
+      }
+      projectile.mesh.position.addScaledVector(projectile.velocity, dt);
+    }
+  }
+
+  _recycle(index) {
+    const projectile = this.projectiles[index];
+    if (!projectile) return;
+    if (projectile.mesh) {
+      projectile.mesh.visible = false;
+      projectile.mesh.position.set(0, -9999, 0);
+      this.pool.push(projectile.mesh);
+    }
+    this.projectiles.splice(index, 1);
+  }
+
+  dispose() {
+    for (let i = this.projectiles.length - 1; i >= 0; i -= 1) {
+      this._recycle(i);
+    }
+    while (this.pool.length > 0) {
+      const mesh = this.pool.pop();
+      mesh.geometry?.dispose?.();
+      mesh.material?.dispose?.();
+    }
+  }
+}

--- a/terra-sandbox/mars/terrain.js
+++ b/terra-sandbox/mars/terrain.js
@@ -1,0 +1,326 @@
+import * as THREE from 'three';
+import { fractalNoise2D, ridgedNoise2D, warpCoordinate } from './noise.js';
+
+function createMulberry32(seed) {
+  let a = seed >>> 0;
+  return function rng() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomRange(rng, min, max) {
+  return min + (max - min) * rng();
+}
+
+function buildCraterField({ count, radiusRange, depthRange, area, rng }) {
+  const craters = [];
+  for (let i = 0; i < count; i += 1) {
+    craters.push({
+      x: randomRange(rng, -area, area),
+      z: randomRange(rng, -area, area),
+      radius: randomRange(rng, radiusRange[0], radiusRange[1]),
+      depth: randomRange(rng, depthRange[0], depthRange[1]),
+      rimHeight: randomRange(rng, 1.5, 4.5),
+      rimWidth: randomRange(rng, 0.12, 0.28),
+    });
+  }
+  return craters;
+}
+
+function applyCrater(height, x, z, crater) {
+  const dx = x - crater.x;
+  const dz = z - crater.z;
+  const dist = Math.sqrt(dx * dx + dz * dz);
+  if (dist > crater.radius) {
+    return height;
+  }
+
+  const t = 1 - dist / crater.radius;
+  const bowl = -(crater.depth * t * t * (1 - crater.rimWidth * t));
+  const rim = crater.rimHeight * Math.max(0, Math.pow(1 - dist / (crater.radius * 1.25), 3));
+  return height + bowl + rim;
+}
+
+function colorForHeight(height, minHeight, maxHeight) {
+  const normalized = Math.max(0, Math.min(1, (height - minHeight) / Math.max(1, maxHeight - minHeight)));
+  const low = new THREE.Color('#5a2316');
+  const mid = new THREE.Color('#b65835');
+  const high = new THREE.Color('#f7c586');
+
+  if (normalized < 0.35) {
+    return low.clone().lerp(mid, normalized / 0.35);
+  }
+  if (normalized > 0.78) {
+    return mid.clone().lerp(high, (normalized - 0.78) / 0.22);
+  }
+  const blend = (normalized - 0.35) / (0.78 - 0.35);
+  return mid.clone().lerp(new THREE.Color('#d2854f'), blend);
+}
+
+function createRockField({ terrainSize, sampleHeight, rng, count }) {
+  const geometry = new THREE.IcosahedronGeometry(1, 1);
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#7c4632'),
+    roughness: 0.95,
+    metalness: 0.04,
+    flatShading: true,
+  });
+  const instanced = new THREE.InstancedMesh(geometry, material, count);
+  instanced.castShadow = true;
+  instanced.receiveShadow = true;
+
+  const dummy = new THREE.Object3D();
+  const half = terrainSize / 2;
+
+  for (let i = 0; i < count; i += 1) {
+    const x = randomRange(rng, -half * 0.92, half * 0.92);
+    const z = randomRange(rng, -half * 0.92, half * 0.92);
+    const h = sampleHeight(x, z);
+    const scale = randomRange(rng, 2.2, 5.5);
+    dummy.position.set(x, h, z);
+    dummy.rotation.set(randomRange(rng, 0, Math.PI), randomRange(rng, 0, Math.PI * 2), randomRange(rng, 0, Math.PI));
+    dummy.scale.setScalar(scale * (0.45 + rng() * 0.4));
+    dummy.updateMatrix();
+    instanced.setMatrixAt(i, dummy.matrix);
+
+    const hueShift = 0.02 * (rng() - 0.5);
+    const rockColor = new THREE.Color('#8a543a');
+    rockColor.offsetHSL(hueShift, -0.12 * rng(), -0.1 * rng());
+    instanced.setColorAt(i, rockColor);
+  }
+  instanced.instanceMatrix.needsUpdate = true;
+  if (instanced.instanceColor) {
+    instanced.instanceColor.needsUpdate = true;
+  }
+  return instanced;
+}
+
+function createDustField({ terrainSize, rng, count }) {
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  const alphas = new Float32Array(count);
+  const baseY = new Float32Array(count);
+  const half = terrainSize / 2;
+  const colorA = new THREE.Color('#f8d2a2');
+  const colorB = new THREE.Color('#c96f3a');
+
+  for (let i = 0; i < count; i += 1) {
+    const baseIndex = i * 3;
+    const x = randomRange(rng, -half, half);
+    const z = randomRange(rng, -half, half);
+    const y = randomRange(rng, 12, 38);
+    positions[baseIndex] = x;
+    positions[baseIndex + 1] = y;
+    positions[baseIndex + 2] = z;
+    baseY[i] = y;
+
+    const mix = rng();
+    const color = colorA.clone().lerp(colorB, mix);
+    colors[baseIndex] = color.r;
+    colors[baseIndex + 1] = color.g;
+    colors[baseIndex + 2] = color.b;
+
+    alphas[i] = 0.35 + 0.4 * rng();
+  }
+
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  geometry.setAttribute('alpha', new THREE.BufferAttribute(alphas, 1));
+  geometry.setAttribute('baseY', new THREE.BufferAttribute(baseY, 1));
+
+  const material = new THREE.PointsMaterial({
+    size: 12,
+    color: new THREE.Color('#f8d2a2'),
+    transparent: true,
+    opacity: 0.75,
+    depthWrite: false,
+    vertexColors: true,
+    sizeAttenuation: true,
+  });
+
+  const points = new THREE.Points(geometry, material);
+  points.frustumCulled = false;
+  points.name = 'dustField';
+  return points;
+}
+
+export function createMarsTerrain({
+  size = 1600,
+  segments = 256,
+  seed = 1337,
+} = {}) {
+  const geometry = new THREE.PlaneGeometry(size, size, segments, segments);
+  geometry.rotateX(-Math.PI / 2);
+  const vertexCount = (segments + 1) * (segments + 1);
+  const positions = geometry.attributes.position;
+  const colors = new Float32Array(vertexCount * 3);
+  const colorAttr = new THREE.BufferAttribute(colors, 3);
+  geometry.setAttribute('color', colorAttr);
+
+  const heights = new Float32Array(vertexCount);
+  const rng = createMulberry32(seed);
+  const area = (size / 2) * 0.92;
+  const craterCount = Math.floor(randomRange(rng, 18, 34));
+  const craters = buildCraterField({
+    count: craterCount,
+    radiusRange: [48, 180],
+    depthRange: [8, 62],
+    area,
+    rng,
+  });
+
+  const half = size / 2;
+  const step = size / segments;
+  let minHeight = Infinity;
+  let maxHeight = -Infinity;
+
+  for (let zi = 0; zi <= segments; zi += 1) {
+    for (let xi = 0; xi <= segments; xi += 1) {
+      const vertexIndex = zi * (segments + 1) + xi;
+      const px = -half + xi * step;
+      const pz = -half + zi * step;
+      const warped = warpCoordinate(px, pz, {
+        seed,
+        amplitude: 46,
+        frequency: 0.0022,
+      });
+
+      const base = fractalNoise2D(warped.x, warped.y, {
+        seed,
+        frequency: 0.0016,
+        octaves: 5,
+        gain: 0.52,
+      });
+      const ridges = ridgedNoise2D(px, pz, {
+        seed: seed + 400,
+        frequency: 0.0009,
+        octaves: 4,
+        gain: 0.6,
+      });
+      const dunes = fractalNoise2D(px + 8000, pz - 8000, {
+        seed: seed + 9000,
+        frequency: 0.0045,
+        octaves: 3,
+        gain: 0.55,
+      });
+
+      let height = base * 120 + ridges * 210 + dunes * 16;
+      height += fractalNoise2D(px - 2000, pz + 2000, {
+        seed: seed + 12345,
+        frequency: 0.0005,
+        octaves: 2,
+        gain: 0.45,
+      }) * 140;
+
+      for (const crater of craters) {
+        height = applyCrater(height, px, pz, crater);
+      }
+
+      const altitudeBias = fractalNoise2D(px * 0.0004, pz * 0.0004, {
+        seed: seed + 555,
+        frequency: 0.0004,
+        octaves: 2,
+        gain: 0.65,
+      }) * 24;
+      height += altitudeBias;
+
+      heights[vertexIndex] = height;
+      positions.setY(vertexIndex, height);
+      minHeight = Math.min(minHeight, height);
+      maxHeight = Math.max(maxHeight, height);
+    }
+  }
+
+  positions.needsUpdate = true;
+
+  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex += 1) {
+    const height = heights[vertexIndex];
+    const color = colorForHeight(height, minHeight, maxHeight);
+    colors[vertexIndex * 3] = color.r;
+    colors[vertexIndex * 3 + 1] = color.g;
+    colors[vertexIndex * 3 + 2] = color.b;
+  }
+
+  geometry.computeVertexNormals();
+  geometry.attributes.normal.needsUpdate = true;
+  colorAttr.needsUpdate = true;
+
+  const material = new THREE.MeshStandardMaterial({
+    vertexColors: true,
+    roughness: 0.95,
+    metalness: 0.05,
+    flatShading: false,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.receiveShadow = true;
+  mesh.castShadow = false;
+  mesh.name = 'marsTerrain';
+
+  const sampleHeight = (x, z) => {
+    const fx = (x + half) / step;
+    const fz = (z + half) / step;
+    const xi = Math.floor(fx);
+    const zi = Math.floor(fz);
+    const tx = fx - xi;
+    const tz = fz - zi;
+
+    const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+    const ix0 = clamp(xi, 0, segments);
+    const iz0 = clamp(zi, 0, segments);
+    const ix1 = clamp(ix0 + 1, 0, segments);
+    const iz1 = clamp(iz0 + 1, 0, segments);
+
+    const idx = (ix, iz) => iz * (segments + 1) + ix;
+    const h00 = heights[idx(ix0, iz0)];
+    const h10 = heights[idx(ix1, iz0)];
+    const h01 = heights[idx(ix0, iz1)];
+    const h11 = heights[idx(ix1, iz1)];
+
+    const hx0 = h00 + (h10 - h00) * tx;
+    const hx1 = h01 + (h11 - h01) * tx;
+    return hx0 + (hx1 - hx0) * tz;
+  };
+
+  const rockField = createRockField({
+    terrainSize: size,
+    sampleHeight,
+    rng,
+    count: Math.floor(randomRange(rng, 160, 240)),
+  });
+
+  const dustField = createDustField({
+    terrainSize: size * 0.9,
+    rng,
+    count: Math.floor(randomRange(rng, 1800, 2600)),
+  });
+
+  return {
+    mesh,
+    rockField,
+    dustField,
+    sampleHeight,
+    stats: { minHeight, maxHeight, craters: craterCount },
+  };
+}
+
+export function disposeMarsTerrain(terrain) {
+  if (!terrain) return;
+  if (terrain.mesh) {
+    terrain.mesh.geometry?.dispose?.();
+    terrain.mesh.material?.dispose?.();
+  }
+  if (terrain.rockField) {
+    terrain.rockField.geometry?.dispose?.();
+    terrain.rockField.material?.dispose?.();
+  }
+  if (terrain.dustField) {
+    terrain.dustField.geometry?.dispose?.();
+    terrain.dustField.material?.dispose?.();
+  }
+}

--- a/terra-sandbox/mars/vehicle.js
+++ b/terra-sandbox/mars/vehicle.js
@@ -1,0 +1,370 @@
+import * as THREE from 'three';
+
+const FORWARD = new THREE.Vector3(0, 1, 0);
+const RIGHT = new THREE.Vector3(1, 0, 0);
+const UP = new THREE.Vector3(0, 0, 1);
+const TMP_VEC3 = new THREE.Vector3();
+const TMP_QUAT = new THREE.Quaternion();
+const TMP_EULER = new THREE.Euler();
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export class MarsVehicle {
+  constructor({
+    mass = 14,
+    baseThrust = 120,
+    boostMultiplier = 1.8,
+    throttleRate = 1.6,
+    throttleResponse = 4.2,
+    angularRate = { pitch: THREE.MathUtils.degToRad(120), yaw: THREE.MathUtils.degToRad(90), roll: THREE.MathUtils.degToRad(150) },
+    angularResponse = 6.5,
+    drag = 0.12,
+    lift = 0.9,
+    hoverHeight = 24,
+    hoverSpring = 4.6,
+    hoverDamping = 2.2,
+    weaponCooldown = 0.12,
+    weaponHeatRise = 0.22,
+    weaponHeatDrop = 0.55,
+  } = {}) {
+    this.mass = mass;
+    this.baseThrust = baseThrust;
+    this.boostMultiplier = boostMultiplier;
+    this.throttleRate = throttleRate;
+    this.throttleResponse = throttleResponse;
+    this.angularRate = angularRate;
+    this.angularResponse = angularResponse;
+    this.drag = drag;
+    this.lift = lift;
+    this.hoverHeight = hoverHeight;
+    this.hoverSpring = hoverSpring;
+    this.hoverDamping = hoverDamping;
+    this.weaponCooldownTime = weaponCooldown;
+    this.weaponHeatRise = weaponHeatRise;
+    this.weaponHeatDrop = weaponHeatDrop;
+
+    this.position = new THREE.Vector3();
+    this.velocity = new THREE.Vector3();
+    this.orientation = new THREE.Quaternion();
+    this.angularVelocity = new THREE.Vector3();
+    this.mesh = null;
+    this.attachments = {
+      thrusterLeft: null,
+      thrusterRight: null,
+      thrusterCore: null,
+      cockpitGlow: null,
+    };
+
+    this.targetThrottle = 0.4;
+    this.throttle = 0.4;
+    this.boosting = false;
+
+    this.weaponCooldown = 0;
+    this.weaponHeat = 0;
+
+    this.sampleHeight = null;
+  }
+
+  setTerrainSampler(fn) {
+    this.sampleHeight = fn;
+  }
+
+  attachMesh(mesh, attachments = {}) {
+    this.mesh = mesh;
+    this.attachments = {
+      thrusterLeft: attachments.thrusterLeft ?? null,
+      thrusterRight: attachments.thrusterRight ?? null,
+      thrusterCore: attachments.thrusterCore ?? null,
+      cockpitGlow: attachments.cockpitGlow ?? null,
+    };
+    if (this.mesh) {
+      this.mesh.position.copy(this.position);
+      this.mesh.quaternion.copy(this.orientation);
+    }
+  }
+
+  reset({ position = new THREE.Vector3(0, 180, 120), orientation, velocity } = {}) {
+    this.position.copy(position);
+    if (orientation instanceof THREE.Quaternion) {
+      this.orientation.copy(orientation);
+    } else {
+      this.orientation.setFromAxisAngle(UP, THREE.MathUtils.degToRad(180));
+    }
+    this.velocity.copy(velocity ?? new THREE.Vector3());
+    this.angularVelocity.set(0, 0, 0);
+    this.targetThrottle = 0.45;
+    this.throttle = 0.45;
+    this.boosting = false;
+    this.weaponCooldown = 0;
+    this.weaponHeat = 0;
+    this._syncMesh();
+  }
+
+  update(dt, input = {}, environment = {}) {
+    if (dt <= 0) return;
+    const { gravity = 3.72 } = environment; // Mars gravity m/s^2
+
+    this.targetThrottle = clamp(this.targetThrottle + (input.throttle ?? 0) * dt * this.throttleRate, 0, 1);
+    if (input.brake) {
+      this.targetThrottle = Math.max(0, this.targetThrottle - dt * this.throttleRate * 2.8);
+    }
+    const blend = 1 - Math.exp(-this.throttleResponse * dt);
+    this.throttle += (this.targetThrottle - this.throttle) * blend;
+
+    this.boosting = Boolean(input.boost) && this.throttle > 0.35;
+
+    const forward = this.getForwardVector();
+    const up = this.getUpVector();
+    const right = this.getRightVector();
+
+    const engineForce = this.baseThrust * this.throttle * (this.boosting ? this.boostMultiplier : 1);
+    this.velocity.addScaledVector(forward, engineForce * dt / this.mass);
+
+    const strafeInput = clamp(input.strafe ?? 0, -1, 1);
+    if (Math.abs(strafeInput) > 0) {
+      this.velocity.addScaledVector(right, strafeInput * this.baseThrust * 0.35 * dt / this.mass);
+    }
+    const elevateInput = clamp(input.elevate ?? 0, -1, 1);
+    if (Math.abs(elevateInput) > 0) {
+      this.velocity.addScaledVector(up, elevateInput * this.baseThrust * 0.3 * dt / this.mass);
+    }
+
+    // Drag in local space for stability
+    const localVelocity = new THREE.Vector3(
+      this.velocity.dot(right),
+      this.velocity.dot(forward),
+      this.velocity.dot(up),
+    );
+    localVelocity.x *= 1 - Math.min(1, this.drag * dt * 3.5);
+    localVelocity.y *= 1 - Math.min(1, this.drag * dt);
+    localVelocity.z *= 1 - Math.min(1, this.drag * dt * 2.2);
+    this.velocity.copy(
+      right.clone().multiplyScalar(localVelocity.x)
+        .add(forward.clone().multiplyScalar(localVelocity.y))
+        .add(up.clone().multiplyScalar(localVelocity.z)),
+    );
+
+    this.velocity.addScaledVector(up, this.lift * this.throttle * dt);
+    this.velocity.addScaledVector(UP, -gravity * dt);
+
+    // Hover spring to stay above terrain
+    if (this.sampleHeight) {
+      const ground = this.sampleHeight(this.position.x, this.position.z);
+      const altitude = this.position.y - ground;
+      const altitudeError = this.hoverHeight - altitude;
+      const verticalVelocity = this.velocity.dot(UP);
+      const correction = (altitudeError * this.hoverSpring - verticalVelocity * this.hoverDamping) * dt;
+      this.velocity.addScaledVector(UP, correction);
+    }
+
+    // Angular dynamics
+    const pitchInput = clamp(input.pitch ?? 0, -1, 1);
+    const yawInput = clamp(input.yaw ?? 0, -1, 1);
+    const rollInput = clamp(input.roll ?? 0, -1, 1);
+
+    const angularBlend = 1 - Math.exp(-this.angularResponse * dt);
+    this.angularVelocity.x += (pitchInput * this.angularRate.pitch - this.angularVelocity.x) * angularBlend;
+    this.angularVelocity.y += (yawInput * this.angularRate.yaw - this.angularVelocity.y) * angularBlend;
+    this.angularVelocity.z += (rollInput * this.angularRate.roll - this.angularVelocity.z) * angularBlend;
+
+    TMP_EULER.set(
+      this.angularVelocity.x * dt,
+      this.angularVelocity.y * dt,
+      this.angularVelocity.z * dt,
+      'XYZ',
+    );
+    TMP_QUAT.setFromEuler(TMP_EULER);
+    this.orientation.multiply(TMP_QUAT).normalize();
+
+    this.position.addScaledVector(this.velocity, dt);
+
+    if (this.sampleHeight) {
+      const ground = this.sampleHeight(this.position.x, this.position.z);
+      const minAltitude = ground + 6;
+      if (this.position.y < minAltitude) {
+        this.position.y = minAltitude;
+        const vertical = this.velocity.dot(UP);
+        if (vertical < 0) {
+          this.velocity.addScaledVector(UP, -vertical);
+        }
+      }
+    }
+
+    this.weaponCooldown = Math.max(0, this.weaponCooldown - dt);
+    this.weaponHeat = Math.max(0, this.weaponHeat - this.weaponHeatDrop * dt);
+
+    this._updateThrusterVisuals();
+    this._syncMesh();
+  }
+
+  firePrimary() {
+    if (this.weaponCooldown > 0 || this.weaponHeat >= 1) {
+      return null;
+    }
+    this.weaponCooldown = this.weaponCooldownTime;
+    this.weaponHeat = clamp(this.weaponHeat + this.weaponHeatRise, 0, 1.2);
+
+    const muzzle = this.getMuzzleWorldPosition();
+    const direction = this.getForwardVector();
+    const velocity = direction.clone().setLength(620).add(this.velocity);
+    return { origin: muzzle, direction, velocity };
+  }
+
+  getForwardVector() {
+    return FORWARD.clone().applyQuaternion(this.orientation);
+  }
+
+  getRightVector() {
+    return RIGHT.clone().applyQuaternion(this.orientation);
+  }
+
+  getUpVector() {
+    return UP.clone().applyQuaternion(this.orientation);
+  }
+
+  getSpeed() {
+    return this.velocity.length();
+  }
+
+  getMuzzleWorldPosition() {
+    const muzzleOffset = new THREE.Vector3(0, 10.5, 1.2);
+    return TMP_VEC3.copy(muzzleOffset).applyQuaternion(this.orientation).add(this.position);
+  }
+
+  _syncMesh() {
+    if (!this.mesh) return;
+    this.mesh.position.copy(this.position);
+    this.mesh.quaternion.copy(this.orientation);
+  }
+
+  _updateThrusterVisuals() {
+    const intensity = clamp(this.throttle * (this.boosting ? 1.4 : 1), 0, 1.5);
+    const heat = clamp(this.weaponHeat, 0, 1);
+    const scaleBase = 0.8 + intensity * 1.6;
+    const thrusterColor = new THREE.Color('#ff8347').lerp(new THREE.Color('#ffe5a3'), Math.min(1, this.boosting ? 1 : this.throttle));
+    if (this.attachments.thrusterLeft) {
+      this.attachments.thrusterLeft.scale.set(1, scaleBase, 1);
+      if (this.attachments.thrusterLeft.material?.emissive) {
+        this.attachments.thrusterLeft.material.emissive.copy(thrusterColor);
+      }
+    }
+    if (this.attachments.thrusterRight) {
+      this.attachments.thrusterRight.scale.set(1, scaleBase, 1);
+      if (this.attachments.thrusterRight.material?.emissive) {
+        this.attachments.thrusterRight.material.emissive.copy(thrusterColor);
+      }
+    }
+    if (this.attachments.thrusterCore) {
+      const coreScale = 0.6 + intensity * 1.2;
+      this.attachments.thrusterCore.scale.set(coreScale, coreScale, coreScale);
+      if (this.attachments.thrusterCore.material?.emissive) {
+        this.attachments.thrusterCore.material.emissive.copy(thrusterColor);
+      }
+    }
+    if (this.attachments.cockpitGlow && this.attachments.cockpitGlow.material?.emissive) {
+      const cockpitColor = new THREE.Color('#54c9ff').lerp(new THREE.Color('#ffe89f'), heat);
+      this.attachments.cockpitGlow.material.emissive.copy(cockpitColor);
+    }
+  }
+
+  getState(sampleHeightFn) {
+    const ground = sampleHeightFn ? sampleHeightFn(this.position.x, this.position.z) : 0;
+    const altitude = this.position.y - ground;
+    return {
+      position: this.position.clone(),
+      velocity: this.velocity.clone(),
+      speed: this.getSpeed(),
+      altitude,
+      throttle: this.throttle,
+      boost: this.boosting,
+      weapon: {
+        ready: this.weaponCooldown <= 0 && this.weaponHeat < 1,
+        heat: clamp(this.weaponHeat, 0, 1),
+      },
+    };
+  }
+}
+
+export function createMarsSkiff() {
+  const group = new THREE.Group();
+  group.name = 'marsSkiff';
+
+  const hullMaterial = new THREE.MeshStandardMaterial({ color: '#f0d9c3', metalness: 0.25, roughness: 0.4 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: '#d3613f', metalness: 0.3, roughness: 0.32 });
+  const wingMaterial = new THREE.MeshStandardMaterial({ color: '#803a28', metalness: 0.2, roughness: 0.5 });
+  const glassMaterial = new THREE.MeshStandardMaterial({ color: '#6fd6ff', metalness: 0.6, roughness: 0.1, transparent: true, opacity: 0.65, emissive: '#54c9ff', emissiveIntensity: 0.9 });
+  const thrusterMaterial = new THREE.MeshStandardMaterial({ color: '#ffb482', emissive: '#ff8442', emissiveIntensity: 1.2, roughness: 0.2, metalness: 0.1 });
+
+  const fuselageGeometry = new THREE.CapsuleGeometry(2.4, 12, 12, 24);
+  const fuselage = new THREE.Mesh(fuselageGeometry, hullMaterial);
+  fuselage.rotation.z = Math.PI / 2;
+  fuselage.castShadow = true;
+  fuselage.receiveShadow = true;
+  group.add(fuselage);
+
+  const cockpitGeometry = new THREE.SphereGeometry(2.6, 18, 16, 0, Math.PI * 2, 0, Math.PI / 2);
+  const cockpit = new THREE.Mesh(cockpitGeometry, glassMaterial);
+  cockpit.position.set(0, 2.6, 1.6);
+  cockpit.castShadow = true;
+  group.add(cockpit);
+
+  const intakeGeometry = new THREE.CylinderGeometry(1.6, 1.2, 1.4, 16, 1);
+  const intake = new THREE.Mesh(intakeGeometry, accentMaterial);
+  intake.rotation.x = Math.PI / 2;
+  intake.position.set(0, 7.4, -0.2);
+  intake.castShadow = true;
+  group.add(intake);
+
+  const wingGeometry = new THREE.BoxGeometry(16, 3, 0.6);
+  const wing = new THREE.Mesh(wingGeometry, wingMaterial);
+  wing.position.set(0, -0.6, -0.3);
+  wing.castShadow = true;
+  wing.receiveShadow = true;
+  group.add(wing);
+
+  const stabilizerGeometry = new THREE.BoxGeometry(8, 2, 0.5);
+  const stabilizer = new THREE.Mesh(stabilizerGeometry, wingMaterial);
+  stabilizer.position.set(0, -6.8, 0.8);
+  stabilizer.castShadow = true;
+  stabilizer.receiveShadow = true;
+  group.add(stabilizer);
+
+  const finGeometry = new THREE.BoxGeometry(0.6, 2.6, 4.2);
+  const fin = new THREE.Mesh(finGeometry, accentMaterial);
+  fin.position.set(0, -7.2, 2.6);
+  fin.castShadow = true;
+  group.add(fin);
+
+  const thrusterLeft = new THREE.Mesh(new THREE.CylinderGeometry(0.6, 1.2, 2.6, 12), thrusterMaterial.clone());
+  thrusterLeft.rotation.x = Math.PI / 2;
+  thrusterLeft.position.set(-3.8, -5.2, -0.2);
+  group.add(thrusterLeft);
+
+  const thrusterRight = thrusterLeft.clone();
+  thrusterRight.position.x *= -1;
+  group.add(thrusterRight);
+
+  const thrusterCoreGeometry = new THREE.SphereGeometry(1.1, 14, 12);
+  const thrusterCore = new THREE.Mesh(thrusterCoreGeometry, thrusterMaterial.clone());
+  thrusterCore.position.set(0, -7.4, -0.4);
+  group.add(thrusterCore);
+
+  const cannonGeometry = new THREE.CylinderGeometry(0.35, 0.35, 8.5, 10);
+  const cannon = new THREE.Mesh(cannonGeometry, accentMaterial);
+  cannon.rotation.x = Math.PI / 2;
+  cannon.position.set(0, 8.2, -1);
+  cannon.castShadow = true;
+  group.add(cannon);
+
+  return {
+    group,
+    attachments: {
+      thrusterLeft,
+      thrusterRight,
+      thrusterCore,
+      cockpitGlow: cockpit,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- expand the Mars HUD with propulsion, weapon, and flight control readouts tailored for the standalone sandbox
- add local Mars-specific input, chase camera, HUD, projectile, and vehicle controllers that replicate Terra sandbox capabilities
- integrate the aeroskiff, combat loop, and chase camera into the procedural Mars terrain generator with regeneration and reset hooks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc29a5fde48329b850c9ad885baa8c