### PR TITLE
Add Mars sandbox Three.js loader

### DIFF
--- a/terra-sandbox/mars/chaseCamera.js
+++ b/terra-sandbox/mars/chaseCamera.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 
 const FORWARD = new THREE.Vector3(0, 1, 0);
 const UP = new THREE.Vector3(0, 0, 1);

--- a/terra-sandbox/mars/marsSandbox.js
+++ b/terra-sandbox/mars/marsSandbox.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 import { MarsVehicle, createMarsSkiff } from './vehicle.js';
 import { MarsChaseCamera } from './chaseCamera.js';
 import { MarsInputManager } from './input.js';

--- a/terra-sandbox/mars/projectiles.js
+++ b/terra-sandbox/mars/projectiles.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 
 const FORWARD = new THREE.Vector3(0, 1, 0);
 

--- a/terra-sandbox/mars/terrain.js
+++ b/terra-sandbox/mars/terrain.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 import { fractalNoise2D, ridgedNoise2D, warpCoordinate } from './noise.js';
 
 function createMulberry32(seed) {

--- a/terra-sandbox/mars/threeLoader.js
+++ b/terra-sandbox/mars/threeLoader.js
@@ -1,0 +1,36 @@
+const CDN_MODULE = 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+
+let loadPromise = null;
+
+async function loadThreeModule() {
+  if (!loadPromise) {
+    loadPromise = (async () => {
+      if (typeof window === 'undefined') {
+        try {
+          const module = await import('three');
+          return module?.default ?? module;
+        } catch (error) {
+          console.warn('[MarsSandbox] Failed to load local three module, falling back to CDN:', error);
+        }
+      }
+
+      const module = await import(CDN_MODULE);
+      return module?.default ?? module;
+    })();
+  }
+
+  return loadPromise;
+}
+
+const THREE = await loadThreeModule();
+
+if (typeof window !== 'undefined') {
+  if (!window.THREE) {
+    window.THREE = THREE;
+  }
+} else if (typeof globalThis !== 'undefined' && !globalThis.THREE) {
+  globalThis.THREE = THREE;
+}
+
+export { THREE };
+export default THREE;

--- a/terra-sandbox/mars/vehicle.js
+++ b/terra-sandbox/mars/vehicle.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 
 const FORWARD = new THREE.Vector3(0, 1, 0);
 const RIGHT = new THREE.Vector3(1, 0, 0);


### PR DESCRIPTION
## Summary
- add a Mars sandbox Three.js loader that dynamically imports the module and exposes it globally
- update Mars gameplay modules to consume the loader instead of the bare `three` specifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3f58fe7083298aed9101de8ad048