### PR TITLE
Add advanced plane controller to Mars sandbox

### DIFF
--- a/terra-sandbox/mars/PlaneController.js
+++ b/terra-sandbox/mars/PlaneController.js
@@ -1,0 +1,105 @@
+import THREE from '../shared/threeProxy.js';
+import { PlaneController as BasePlaneController, createPlaneMesh } from '../sandbox/PlaneController.js';
+
+if (!THREE) throw new Error('Mars PlaneController requires THREE to be loaded globally');
+
+const FORWARD_AXIS = new THREE.Vector3(0, 1, 0);
+const DEFAULT_MUZZLE_OFFSET = new THREE.Vector3(0, 9.6, 1.6);
+
+export class MarsPlaneController extends BasePlaneController {
+  constructor(options = {}) {
+    const {
+      projectileVelocity = 720,
+      weaponCooldown = 0.16,
+      weaponHeatRise = 0.22,
+      weaponHeatDrop = 0.55,
+      muzzleOffset = DEFAULT_MUZZLE_OFFSET,
+      boostThrottle = 0.65,
+      ...rest
+    } = options;
+
+    super({
+      minSpeed: 26,
+      maxSpeed: 210,
+      maxBoostSpeed: 330,
+      acceleration: 52,
+      afterburnerAcceleration: 86,
+      gravity: 3.72,
+      propulsorLift: 3.72 * 1.08,
+      drag: 0.11,
+      brakeDrag: 0.46,
+      throttleResponse: 2.1,
+      ...rest,
+    });
+
+    this.weaponCooldownTime = weaponCooldown;
+    this.weaponHeatRise = weaponHeatRise;
+    this.weaponHeatDrop = weaponHeatDrop;
+    this.weaponCooldown = 0;
+    this.weaponHeat = 0;
+    this.projectileVelocity = projectileVelocity;
+    this.muzzleOffset = muzzleOffset.clone();
+    this.boostThrottle = boostThrottle;
+  }
+
+  reset(options = {}) {
+    super.reset(options);
+    this.weaponCooldown = 0;
+    this.weaponHeat = 0;
+  }
+
+  update(dt, input = {}, hooks = {}) {
+    if (dt <= 0) return;
+
+    this.weaponCooldown = Math.max(0, this.weaponCooldown - dt);
+    this.weaponHeat = Math.max(0, this.weaponHeat - this.weaponHeatDrop * dt);
+
+    const throttleAdjust = THREE.MathUtils.clamp(
+      (input.throttleAdjust ?? input.throttle ?? 0)
+        + (input.boost ? 0.55 : 0),
+      -1,
+      1,
+    );
+
+    super.update(dt, { ...input, throttleAdjust }, hooks);
+  }
+
+  firePrimary() {
+    if (this.weaponCooldown > 0 || this.weaponHeat >= 1) {
+      return null;
+    }
+    this.weaponCooldown = this.weaponCooldownTime;
+    this.weaponHeat = Math.min(1.2, this.weaponHeat + this.weaponHeatRise);
+
+    const direction = FORWARD_AXIS.clone().applyQuaternion(this.orientation).normalize();
+    const origin = this.muzzleOffset.clone().applyQuaternion(this.orientation).add(this.position);
+    const velocity = direction.clone().setLength(this.projectileVelocity).add(this.velocity);
+
+    return { origin, direction, velocity };
+  }
+
+  getState(sampleHeightFn) {
+    const base = super.getState();
+    let altitude = base.altitude;
+    if (typeof sampleHeightFn === 'function') {
+      const ground = sampleHeightFn(this.position.x, this.position.y);
+      if (Number.isFinite(ground)) {
+        altitude = this.position.z - ground;
+      }
+    }
+
+    return {
+      ...base,
+      speed: this.velocity.length(),
+      altitude,
+      throttle: this.throttle,
+      boost: this.throttle >= this.boostThrottle,
+      weapon: {
+        ready: this.weaponCooldown <= 0 && this.weaponHeat < 1,
+        heat: THREE.MathUtils.clamp(this.weaponHeat, 0, 1),
+      },
+    };
+  }
+}
+
+export { createPlaneMesh };

--- a/terra-sandbox/mars/chaseCamera.js
+++ b/terra-sandbox/mars/chaseCamera.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 
 const FORWARD = new THREE.Vector3(0, 1, 0);
 const UP = new THREE.Vector3(0, 0, 1);

--- a/terra-sandbox/mars/index.html
+++ b/terra-sandbox/mars/index.html
@@ -190,7 +190,7 @@
       <section class="readout" aria-label="Control guide">
         <label>Flight Controls</label>
         <p style="margin:0;font-size:0.85rem;color:rgba(255,200,182,0.75);line-height:1.4;">
-          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire
+          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire · N navigation lights · L landing lights
         </p>
       </section>
     </aside>

--- a/terra-sandbox/mars/projectiles.js
+++ b/terra-sandbox/mars/projectiles.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 
 const FORWARD = new THREE.Vector3(0, 1, 0);
 

--- a/terra-sandbox/mars/terrain.js
+++ b/terra-sandbox/mars/terrain.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 import { fractalNoise2D, ridgedNoise2D, warpCoordinate } from './noise.js';
 
 function createMulberry32(seed) {

--- a/terra-sandbox/mars/threeLoader.js
+++ b/terra-sandbox/mars/threeLoader.js
@@ -1,0 +1,36 @@
+const CDN_MODULE = 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+
+let loadPromise = null;
+
+async function loadThreeModule() {
+  if (!loadPromise) {
+    loadPromise = (async () => {
+      if (typeof window === 'undefined') {
+        try {
+          const module = await import('three');
+          return module?.default ?? module;
+        } catch (error) {
+          console.warn('[MarsSandbox] Failed to load local three module, falling back to CDN:', error);
+        }
+      }
+
+      const module = await import(CDN_MODULE);
+      return module?.default ?? module;
+    })();
+  }
+
+  return loadPromise;
+}
+
+const THREE = await loadThreeModule();
+
+if (typeof window !== 'undefined') {
+  if (!window.THREE) {
+    window.THREE = THREE;
+  }
+} else if (typeof globalThis !== 'undefined' && !globalThis.THREE) {
+  globalThis.THREE = THREE;
+}
+
+export { THREE };
+export default THREE;

--- a/terra-sandbox/mars/vehicle.js
+++ b/terra-sandbox/mars/vehicle.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { THREE } from './threeLoader.js';
 
 const FORWARD = new THREE.Vector3(0, 1, 0);
 const RIGHT = new THREE.Vector3(1, 0, 0);


### PR DESCRIPTION
## Summary
- add a Mars plane controller that wraps the shared flight model with Mars-specific propulsion and weapon handling
- update the Mars sandbox to use the plane controller, expose light toggles, and refresh HUD instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc3f58fe7083298aed9101de8ad048