### PR TITLE
Add volumetric cave navigation, minimap, and cave ambience

### DIFF
--- a/terra-sandbox/mars/PlaneController.js
+++ b/terra-sandbox/mars/PlaneController.js
@@ -79,13 +79,13 @@ export class MarsPlaneController extends BasePlaneController {
     return { origin, direction, velocity };
   }
 
-  getState(sampleHeightFn) {
+  getState(volumeQueryFn) {
     const base = super.getState();
     let altitude = base.altitude;
-    if (typeof sampleHeightFn === 'function') {
-      const ground = sampleHeightFn(this.position.x, this.position.y);
-      if (Number.isFinite(ground)) {
-        altitude = this.position.z - ground;
+    if (typeof volumeQueryFn === 'function') {
+      const sample = volumeQueryFn(this.position, { radius: 0 });
+      if (sample && Number.isFinite(sample.floor)) {
+        altitude = this.position.z - sample.floor;
       }
     }
 

--- a/terra-sandbox/mars/hud.js
+++ b/terra-sandbox/mars/hud.js
@@ -2,6 +2,16 @@ function formatNumber(value, digits = 0) {
   return value.toLocaleString(undefined, { maximumFractionDigits: digits, minimumFractionDigits: digits });
 }
 
+function hexToRgba(hex, alpha = 1) {
+  if (!hex) return `rgba(255,255,255,${alpha})`;
+  const normalized = hex.replace('#', '');
+  const value = parseInt(normalized, 16);
+  const r = (value >> 16) & 0xff;
+  const g = (value >> 8) & 0xff;
+  const b = value & 0xff;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 export class MarsHUD {
   constructor({
     statusLabel,
@@ -12,6 +22,8 @@ export class MarsHUD {
     throttleOutput,
     weaponOutput,
     seedOutput,
+    minimapCanvas,
+    beaconList,
   }) {
     this.statusLabel = statusLabel;
     this.altitudeOutput = altitudeOutput;
@@ -21,6 +33,10 @@ export class MarsHUD {
     this.throttleOutput = throttleOutput;
     this.weaponOutput = weaponOutput;
     this.seedOutput = seedOutput;
+    this.minimapCanvas = minimapCanvas || null;
+    this.minimapCtx = minimapCanvas ? minimapCanvas.getContext('2d') : null;
+    this.beaconList = beaconList || null;
+    this._lastBeaconSummary = '';
   }
 
   setStatus(text) {
@@ -60,6 +76,103 @@ export class MarsHUD {
         this.weaponOutput.textContent = `Cooling (${Math.round(Math.max(0, heat) * 100)}%)`;
       } else {
         this.weaponOutput.textContent = 'Ready';
+      }
+    }
+  }
+
+  updateNavigation({ vehiclePosition, beacons = [], exploredChunks = [], chunkSize = 16 } = {}) {
+    if (this.minimapCtx && vehiclePosition) {
+      const canvas = this.minimapCanvas;
+      const ctx = this.minimapCtx;
+      const width = canvas.width;
+      const height = canvas.height;
+      const padding = 10;
+      const rangeChunks = 5;
+      const viewRadius = Math.max(chunkSize * rangeChunks, 1);
+      const scale = (width - padding * 2) / (viewRadius * 2);
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = 'rgba(8, 5, 12, 0.92)';
+      ctx.fillRect(0, 0, width, height);
+      ctx.strokeStyle = 'rgba(120, 90, 130, 0.35)';
+      ctx.strokeRect(0.5, 0.5, width - 1, height - 1);
+
+      const worldToMap = (wx, wy) => ({
+        x: width / 2 + (wx - vehiclePosition.x) * scale,
+        y: height / 2 - (wy - vehiclePosition.y) * scale,
+      });
+
+      for (const entry of exploredChunks) {
+        const center = entry?.center;
+        if (!center) continue;
+        const dx = center.x - vehiclePosition.x;
+        const dy = center.y - vehiclePosition.y;
+        if (Math.abs(dx) > viewRadius + chunkSize || Math.abs(dy) > viewRadius + chunkSize) continue;
+        const map = worldToMap(center.x, center.y);
+        const size = chunkSize * scale;
+        const biome = entry?.metadata?.biome ?? 'ember';
+        const hazards = Math.abs(entry?.metadata?.hazards ?? 0);
+        const palette = {
+          lumenite: '#4dc9ff',
+          siltstone: '#ffb15c',
+          ember: '#ff7048',
+        };
+        const color = palette[biome] ?? '#ff8468';
+        const alpha = 0.2 + Math.min(0.55, hazards * 0.28);
+        ctx.fillStyle = hexToRgba(color, alpha);
+        ctx.fillRect(map.x - size / 2, map.y - size / 2, size, size);
+      }
+
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(width / 2, padding);
+      ctx.lineTo(width / 2, height - padding);
+      ctx.moveTo(padding, height / 2);
+      ctx.lineTo(width - padding, height / 2);
+      ctx.stroke();
+
+      ctx.fillStyle = 'rgba(88, 224, 255, 0.9)';
+      for (const beacon of beacons) {
+        const pos = beacon?.position;
+        if (!pos) continue;
+        const point = worldToMap(pos.x, pos.y);
+        ctx.beginPath();
+        ctx.arc(point.x, point.y, 4, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      const forwardLength = 8;
+      const triangleSize = 10;
+      ctx.fillStyle = 'rgba(255, 219, 120, 0.95)';
+      ctx.beginPath();
+      ctx.moveTo(width / 2, height / 2 - triangleSize);
+      ctx.lineTo(width / 2 - triangleSize * 0.6, height / 2 + triangleSize * 0.8);
+      ctx.lineTo(width / 2 + triangleSize * 0.6, height / 2 + triangleSize * 0.8);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+      ctx.fillRect(width / 2 - 1, height / 2 - forwardLength, 2, forwardLength);
+    }
+
+    if (this.beaconList) {
+      const summary = beacons
+        .map((beacon) => `${beacon.index}:${Math.round(Math.max(0, beacon.distance || 0))}`)
+        .join('|');
+      if (summary !== this._lastBeaconSummary) {
+        this.beaconList.innerHTML = '';
+        for (const beacon of beacons) {
+          const li = document.createElement('li');
+          const distance = Math.round(Math.max(0, beacon.distance || 0));
+          li.textContent = `Beacon ${beacon.index}: ${distance.toLocaleString()} m`;
+          this.beaconList.appendChild(li);
+        }
+        if (beacons.length === 0) {
+          const li = document.createElement('li');
+          li.textContent = 'No active beacons';
+          li.style.opacity = '0.6';
+          this.beaconList.appendChild(li);
+        }
+        this._lastBeaconSummary = summary;
       }
     }
   }

--- a/terra-sandbox/mars/index.html
+++ b/terra-sandbox/mars/index.html
@@ -122,6 +122,44 @@
         transform: translateY(1px);
       }
 
+      .nav-tools {
+        margin-top: 1.5rem;
+        padding-top: 1rem;
+        border-top: 1px solid rgba(216, 122, 90, 0.18);
+      }
+
+      .nav-tools h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(255, 210, 190, 0.75);
+      }
+
+      .nav-tools canvas {
+        display: block;
+        width: 100%;
+        max-width: 240px;
+        aspect-ratio: 1 / 1;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 180, 150, 0.28);
+        background: rgba(10, 7, 12, 0.85);
+        box-shadow: 0 0 18px rgba(255, 140, 90, 0.12);
+      }
+
+      .beacon-list {
+        list-style: none;
+        margin: 0.75rem 0 0;
+        padding: 0;
+        font-size: 0.85rem;
+        line-height: 1.4;
+        color: rgba(255, 210, 200, 0.82);
+      }
+
+      .beacon-list li + li {
+        margin-top: 0.25rem;
+      }
+
       .scene {
         grid-area: scene;
         position: relative;
@@ -187,10 +225,17 @@
         <button type="button" data-action="reset">Recenter Craft</button>
         <button type="button" data-action="shuffle">Regenerate Terrain</button>
       </div>
+      <section class="nav-tools" aria-label="Navigation aids">
+        <h2>Survey Minimap</h2>
+        <canvas id="mars-minimap" width="220" height="220" aria-label="Exploration minimap"></canvas>
+        <ul id="mars-beacons" class="beacon-list">
+          <li style="opacity:0.6;">No active beacons</li>
+        </ul>
+      </section>
       <section class="readout" aria-label="Control guide">
         <label>Flight Controls</label>
         <p style="margin:0;font-size:0.85rem;color:rgba(255,200,182,0.75);line-height:1.4;">
-          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire · N navigation lights · L landing lights
+          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire · N navigation lights · L landing lights · B deploy beacon · X clear beacons
         </p>
       </section>
     </aside>

--- a/terra-sandbox/mars/input.js
+++ b/terra-sandbox/mars/input.js
@@ -155,6 +155,8 @@ export class MarsInputManager {
       firing: this.primaryFire,
       toggleNavigationLights: this._consumePressed(['KeyN', 'KeyV']),
       toggleAuxiliaryLights: this._consumePressed('KeyL'),
+      dropBeacon: this._consumePressed('KeyB'),
+      clearBeacons: this._consumePressed('KeyX'),
     };
   }
 }

--- a/terra-sandbox/mars/main.js
+++ b/terra-sandbox/mars/main.js
@@ -17,6 +17,8 @@ const speedOutput = getElement('mars-speed');
 const throttleOutput = getElement('mars-throttle');
 const weaponOutput = getElement('mars-weapon');
 const seedOutput = getElement('mars-seed');
+const minimapCanvas = getElement('mars-minimap');
+const beaconList = getElement('mars-beacons');
 
 const sandbox = new MarsSandbox({
   canvas,
@@ -28,6 +30,8 @@ const sandbox = new MarsSandbox({
   throttleOutput,
   weaponOutput,
   seedOutput,
+  minimapCanvas,
+  beaconList,
 });
 
 sandbox.initialize();


### PR DESCRIPTION
## Summary
- replace altitude sampling with signed-distance volume queries and clamp against floors, ceilings, and tunnel walls
- expose terrain density sampling for collisions and update the Mars sandbox with cave-centric lighting, audio, and chunk lifecycle handling
- add deployable beacons, HUD minimap rendering, and input/UI wiring for the new navigation aids

## Testing
- not run (UI-focused changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc643fa6508329b44b86fdc729582a