### PR TITLE
Spawn craft in cave and reposition minimap overlay

### DIFF
--- a/terra-sandbox/mars/index.html
+++ b/terra-sandbox/mars/index.html
@@ -136,15 +136,20 @@
         color: rgba(255, 210, 190, 0.75);
       }
 
-      .nav-tools canvas {
-        display: block;
-        width: 100%;
-        max-width: 240px;
-        aspect-ratio: 1 / 1;
+      #mars-minimap {
+        position: fixed;
+        bottom: 3vh;
+        right: 3vw;
+        top: auto;
+        left: auto;
+        width: 10vw;
+        height: 10vh;
         border-radius: 10px;
         border: 1px solid rgba(255, 180, 150, 0.28);
         background: rgba(10, 7, 12, 0.85);
-        box-shadow: 0 0 18px rgba(255, 140, 90, 0.12);
+        box-shadow: 0 0 18px rgba(255, 140, 90, 0.18);
+        pointer-events: none;
+        z-index: 20;
       }
 
       .beacon-list {


### PR DESCRIPTION
## Summary
- derive a subterranean spawn transform from cave volume queries and reuse it for initialize/reset/regenerate
- tighten vehicle collision parameters to keep the craft inside the cavern walls
- anchor the minimap canvas as a fixed 10% viewport overlay in the bottom-right corner

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc71ac958c83298d9bee95162017b7