### PR TITLE
Add keyboard controls to adjust Mars auxiliary lights

### DIFF
--- a/terra-sandbox/mars/index.html
+++ b/terra-sandbox/mars/index.html
@@ -240,7 +240,7 @@
       <section class="readout" aria-label="Control guide">
         <label>Flight Controls</label>
         <p style="margin:0;font-size:0.85rem;color:rgba(255,200,182,0.75);line-height:1.4;">
-          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire · N navigation lights · L landing lights · B deploy beacon · X clear beacons
+          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire · N navigation lights · L toggle landing lights · +/- adjust landing lights · B deploy beacon · X clear beacons
         </p>
       </section>
     </aside>

--- a/terra-sandbox/mars/input.js
+++ b/terra-sandbox/mars/input.js
@@ -155,6 +155,8 @@ export class MarsInputManager {
       firing: this.primaryFire,
       toggleNavigationLights: this._consumePressed(['KeyN', 'KeyV']),
       toggleAuxiliaryLights: this._consumePressed('KeyL'),
+      increaseAuxiliaryLights: this._consumePressed(['Equal', 'NumpadAdd']),
+      decreaseAuxiliaryLights: this._consumePressed(['Minus', 'NumpadSubtract']),
       dropBeacon: this._consumePressed('KeyB'),
       clearBeacons: this._consumePressed('KeyX'),
     };

--- a/terra-sandbox/mars/marsSandbox.js
+++ b/terra-sandbox/mars/marsSandbox.js
@@ -276,6 +276,25 @@ export class MarsSandbox {
       this.hud.setStatus(next ? 'Auxiliary landing lights engaged.' : 'Auxiliary landing lights offline.');
     }
 
+    const adjustAuxiliaryLights = (delta) => {
+      if (!this.vehicle?.adjustAuxiliaryLightLevel) return;
+      const nextLevel = this.vehicle.adjustAuxiliaryLightLevel(delta);
+      const enabled = this.vehicle.auxiliaryLightsEnabled && nextLevel > 0;
+      if (!enabled) {
+        this.hud.setStatus('Auxiliary landing lights offline.');
+      } else {
+        const percent = Math.round(nextLevel * 100);
+        this.hud.setStatus(`Auxiliary lighting output at ${percent}%.`);
+      }
+    };
+
+    if (inputState.increaseAuxiliaryLights) {
+      adjustAuxiliaryLights(0.1);
+    }
+    if (inputState.decreaseAuxiliaryLights) {
+      adjustAuxiliaryLights(-0.1);
+    }
+
     if (inputState.dropBeacon) {
       this._deployBeacon();
     }


### PR DESCRIPTION
## Summary
- allow the Mars sandbox input manager to react to +/- keys for auxiliary light control
- expose auxiliary light level helpers on the shared plane controller and update the sandbox HUD messaging
- document the new landing light adjustment shortcut in the Mars sandbox UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc748ca67c8329a9310a87da0bd236