### PR TITLE
Improve Mars cave visibility and flight controls

### DIFF
--- a/docs/mars-cave-immersion-tasks.md
+++ b/docs/mars-cave-immersion-tasks.md
@@ -1,0 +1,7 @@
+# Mars Cave Immersion Task Breakdown
+
+- [x] Expand the subterranean chunk streaming window so the surrounding cave geometry remains visible as the skiff travels through the tunnels.
+- [x] Remap the flight controls to aviation-style bindings (Arrow Up/Down throttle, Q/E yaw, A/B roll, W/S pitch) for better spatial orientation inside the cave.
+- [x] Align the third-person chase camera and lighting with the vehicle's motion so the player feels embedded in the cave environment.
+
+These tasks support the request to make the cave traversal readable and immersive while piloting the Mars surveyor.

--- a/terra-sandbox/mars/chaseCamera.js
+++ b/terra-sandbox/mars/chaseCamera.js
@@ -4,16 +4,27 @@ const FORWARD = new THREE.Vector3(0, 1, 0);
 const UP = new THREE.Vector3(0, 0, 1);
 
 export class MarsChaseCamera {
-  constructor({ camera, distance = 48, height = 16, lookAhead = 22, responsiveness = 6 } = {}) {
+  constructor({
+    camera,
+    distance = 48,
+    height = 16,
+    lookAhead = 22,
+    responsiveness = 6,
+    rollFollow = true,
+    rollResponsiveness = 4.2,
+  } = {}) {
     this.camera = camera;
     this.distance = distance;
     this.height = height;
     this.lookAhead = lookAhead;
     this.responsiveness = responsiveness;
+    this.rollFollow = rollFollow;
+    this.rollResponsiveness = rollResponsiveness;
     this.target = null;
     this._position = new THREE.Vector3();
     this._desired = new THREE.Vector3();
     this._lookTarget = new THREE.Vector3();
+    this._cameraUp = new THREE.Vector3(0, 0, 1);
   }
 
   follow(target) {
@@ -26,6 +37,7 @@ export class MarsChaseCamera {
   update(dt) {
     if (!this.target) return;
     const blend = dt > 0 ? 1 - Math.exp(-this.responsiveness * dt) : 1;
+    const rollBlend = dt > 0 ? 1 - Math.exp(-this.rollResponsiveness * dt) : 1;
 
     const forward = FORWARD.clone().applyQuaternion(this.target.orientation ?? this.target.quaternion);
     const up = UP.clone().applyQuaternion(this.target.orientation ?? this.target.quaternion);
@@ -42,6 +54,17 @@ export class MarsChaseCamera {
 
     this.camera.position.copy(this._position);
 
+    if (this.rollFollow) {
+      if (this._cameraUp.lengthSq() === 0) {
+        this._cameraUp.copy(up);
+      } else {
+        this._cameraUp.lerp(up, rollBlend);
+      }
+      this.camera.up.copy(this._cameraUp).normalize();
+    } else {
+      this.camera.up.set(0, 0, 1);
+    }
+
     this._lookTarget.copy(this.target.position).addScaledVector(forward, this.lookAhead);
     this.camera.lookAt(this._lookTarget);
   }
@@ -54,6 +77,12 @@ export class MarsChaseCamera {
       .addScaledVector(forward, -this.distance)
       .addScaledVector(up, this.height);
     this.camera.position.copy(this._position);
+    if (this.rollFollow) {
+      this._cameraUp.copy(up);
+      this.camera.up.copy(this._cameraUp).normalize();
+    } else {
+      this.camera.up.set(0, 0, 1);
+    }
     this._lookTarget.copy(this.target.position).addScaledVector(forward, this.lookAhead);
     this.camera.lookAt(this._lookTarget);
   }

--- a/terra-sandbox/mars/index.html
+++ b/terra-sandbox/mars/index.html
@@ -240,7 +240,7 @@
       <section class="readout" aria-label="Control guide">
         <label>Flight Controls</label>
         <p style="margin:0;font-size:0.85rem;color:rgba(255,200,182,0.75);line-height:1.4;">
-          W/S throttle · A/D yaw · Q/E roll · Arrow keys pitch · Shift boost · Space brake · Left click fire · N navigation lights · L landing lights · B deploy beacon · X clear beacons
+          Arrow ↑/↓ throttle · Q/E yaw · A roll left · B roll right · W pitch down · S pitch up · Shift boost · Space brake · Left click fire · N navigation lights · L toggle landing lights · +/- adjust landing lights · R deploy beacon · X clear beacons
         </p>
       </section>
     </aside>

--- a/terra-sandbox/mars/input.js
+++ b/terra-sandbox/mars/input.js
@@ -142,20 +142,22 @@ export class MarsInputManager {
   }
 
   getState() {
-    const throttleAdjust = this._axis(['KeyW', 'ArrowUp'], ['KeyS', 'ArrowDown']);
+    const throttleAdjust = this._axis('ArrowUp', 'ArrowDown');
     return {
       throttleAdjust,
       throttle: throttleAdjust,
-      yaw: this._axis('KeyD', 'KeyA'),
-      roll: this._axis('KeyE', 'KeyQ'),
-      pitch: this._axis('ArrowDown', 'ArrowUp'),
+      yaw: this._axis('KeyE', 'KeyQ'),
+      roll: this._axis('KeyB', 'KeyA'),
+      pitch: this._axis('KeyS', 'KeyW'),
       boost: this.keys.has('ShiftLeft') || this.keys.has('ShiftRight'),
       brake: this.keys.has('Space'),
       aim: { x: this.aimX, y: this.aimY },
       firing: this.primaryFire,
       toggleNavigationLights: this._consumePressed(['KeyN', 'KeyV']),
       toggleAuxiliaryLights: this._consumePressed('KeyL'),
-      dropBeacon: this._consumePressed('KeyB'),
+      increaseAuxiliaryLights: this._consumePressed(['Equal', 'NumpadAdd']),
+      decreaseAuxiliaryLights: this._consumePressed(['Minus', 'NumpadSubtract']),
+      dropBeacon: this._consumePressed('KeyR'),
       clearBeacons: this._consumePressed('KeyX'),
     };
   }


### PR DESCRIPTION
## Summary
- expand the Mars cave terrain streaming radius, refresh material lighting, and capture the vehicle altitude when selecting chunks for rendering
- brighten the sandbox with updated fog, ambient lighting, a stronger drone spotlight, and a chase camera that rolls with the skiff for third-person immersion
- remap the keyboard bindings and on-screen guide to aviation-style controls and document the completed immersion tasks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc748ca67c8329a9310a87da0bd236