### PR TITLE
Update Mars sandbox renderer for modern Three.js

### DIFF
--- a/terra-sandbox/mars/marsSandbox.js
+++ b/terra-sandbox/mars/marsSandbox.js
@@ -99,11 +99,11 @@ export class MarsSandbox {
     });
     const rendererPixelRatio = Math.min(1, window.devicePixelRatio || 1);
     this.renderer.setPixelRatio(rendererPixelRatio);
-    this.renderer.outputEncoding = THREE.sRGBEncoding;
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
     this.renderer.toneMappingExposure = 1.18;
     this.renderer.shadowMap.enabled = false;
-    this.renderer.physicallyCorrectLights = true;
+    this.renderer.useLegacyLights = false;
 
     this.scene = new THREE.Scene();
     const fogColor = new THREE.Color('#080512');


### PR DESCRIPTION
## Summary
- replace deprecated renderer properties with current Three.js equivalents to eliminate warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc843c7c508329b0731ef054b20319