### PR TITLE
Add web-based tunnelcave sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ This starter project wires together three pieces so you can focus on gameplay an
 - `python-sim/`: Python simulation client that publishes telemetry and cake drops.
 - `viewer/`: A minimal three.js web client that subscribes to the broker feed.
   - Switch between available aircraft kits with the **Aircraft Model** dropdown in the viewer. Assets are cached locally so toggling sets is instant, your last choice is remembered in `localStorage`, and the legacy `?modelSet=` query parameter still works for deep links.
+- `tunnelcave_sandbox_web/`: Self-contained Next.js + three.js endless cave sandbox that runs entirely in the browser.
+
+## Tunnelcave Sandbox (Next.js)
+
+Looking for a fully browser-hosted version of the tunnelcave prototype? The `tunnelcave_sandbox_web/` directory contains a standalone Next.js application that reproduces the endless cave, deterministic streaming, spawn selection, and third-person camera behaviors directly in React + three.js. To run it locally:
+
+```bash
+cd tunnelcave_sandbox_web
+npm install
+npm run dev
+```
+
+By default the dev server listens on [`http://localhost:3000`](http://localhost:3000). Open the page to load the sandbox, then use **W/S** to adjust throttle, **A/D** to bank, **Shift** to tighten the follow camera, and **Space** to level the craft. The entire pipeline lives within the Next.js app, so it can be deployed to any static Next-friendly host without referencing the Python or Go stacks.
 
 ## Viewer connection banner
 

--- a/tunnelcave_sandbox/__init__.py
+++ b/tunnelcave_sandbox/__init__.py
@@ -1,0 +1,36 @@
+"""Tunnelcave sandbox package.
+
+This package bundles all logic required to generate an endless cave
+environment following the "Tunnelcave Sandbox" specification. The
+modules are intentionally small so every file stays well below the
+800-line limit requested by the user.
+"""
+
+from .vector import Vector3
+from .noise import NoiseConfig, noise3
+from .direction_field import DivergenceFreeField
+from .frame import OrthonormalFrame
+from .geometry import RingSample, ChunkGeometry
+from .terrain_generator import TunnelTerrainGenerator, TunnelParams
+from .probe import RingProbe
+from .spawn import SpawnPlanner, SpawnRequest, SpawnResult
+from .streaming import ChunkStreamer
+from .camera import ThirdPersonCamera
+
+__all__ = [
+    "Vector3",
+    "NoiseConfig",
+    "noise3",
+    "DivergenceFreeField",
+    "OrthonormalFrame",
+    "RingSample",
+    "ChunkGeometry",
+    "TunnelTerrainGenerator",
+    "TunnelParams",
+    "RingProbe",
+    "SpawnPlanner",
+    "SpawnRequest",
+    "SpawnResult",
+    "ChunkStreamer",
+    "ThirdPersonCamera",
+]

--- a/tunnelcave_sandbox/camera.py
+++ b/tunnelcave_sandbox/camera.py
@@ -1,0 +1,32 @@
+"""Third-person camera smoothing utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .vector import Vector3
+
+
+@dataclass
+class CameraParams:
+    follow_distance: float
+    height_offset: float
+    lateral_offset: float
+    smoothing: float
+
+
+@dataclass
+class ThirdPersonCamera:
+    params: CameraParams
+    position: Vector3
+    target: Vector3
+
+    def update(self, ship_position: Vector3, frame_right: Vector3, frame_up: Vector3, frame_forward: Vector3, dt: float) -> None:
+        desired = (
+            ship_position
+            - frame_forward * self.params.follow_distance
+            + frame_right * self.params.lateral_offset
+            + frame_up * self.params.height_offset
+        )
+        lerp_factor = 1.0 - pow(0.5, dt / max(1e-4, self.params.smoothing))
+        self.position = self.position * (1.0 - lerp_factor) + desired * lerp_factor
+        self.target = self.target * (1.0 - lerp_factor) + ship_position * lerp_factor

--- a/tunnelcave_sandbox/direction_field.py
+++ b/tunnelcave_sandbox/direction_field.py
@@ -1,0 +1,80 @@
+"""Direction field and jolt management for the tunnel path."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable
+
+from .noise import curl_noise
+from .vector import Vector3, rotate_towards
+
+
+@dataclass(frozen=True)
+class FieldParams:
+    world_seed: int
+    dir_freq: float
+    dir_blend: float
+    max_turn_per_step_rad: float
+    jolt_every_meters: float
+    jolt_strength: float
+
+
+class DivergenceFreeField:
+    """Produces smooth directions along the path using curl noise."""
+
+    def __init__(self, params: FieldParams) -> None:
+        self._params = params
+
+    def next_direction(
+        self,
+        position: Vector3,
+        previous_direction: Vector3,
+        step_index: int,
+        arc_length: float,
+    ) -> Vector3:
+        """Evaluate the field at ``position`` and apply smoothing & jolts."""
+
+        raw_x, raw_y, raw_z = curl_noise(self._params.world_seed, (position.x, position.y, position.z), self._params.dir_freq)
+        raw_dir = Vector3(raw_x, raw_y, raw_z)
+        if raw_dir.length() < 1e-6:
+            raw_dir = Vector3.unit_z()
+
+        blended = previous_direction.lerp(raw_dir, self._params.dir_blend).normalized()
+        jolted = self._apply_jolt(blended, step_index, arc_length)
+        clamped = rotate_towards(previous_direction, jolted, self._params.max_turn_per_step_rad)
+        return clamped.normalized()
+
+    def _apply_jolt(self, direction: Vector3, step_index: int, arc_length: float) -> Vector3:
+        params = self._params
+        if params.jolt_every_meters <= 0.0 or params.jolt_strength <= 0.0:
+            return direction
+
+        # Each step decides deterministically whether a jolt happens by
+        # hashing its global index and the chunk-scaled arc length.
+        hashed = _hash64(params.world_seed, step_index)
+        threshold = 1.0 - math.exp(-arc_length / max(1e-5, params.jolt_every_meters))
+        if (hashed & 0xFFFFFFFF) / 0xFFFFFFFF > threshold:
+            return direction
+
+        unit = _pseudo_random_unit(hashed ^ 0xABCDEF)
+        jolted = (direction + unit * params.jolt_strength).normalized()
+        return jolted
+
+
+def _hash64(seed: int, value: int) -> int:
+    v = seed ^ (value + 0x9E3779B97F4A7C15)
+    v = (v ^ (v >> 30)) * 0xBF58476D1CE4E5B9
+    v = (v ^ (v >> 27)) * 0x94D049BB133111EB
+    v = v ^ (v >> 31)
+    return v & 0xFFFFFFFFFFFFFFFF
+
+
+def _pseudo_random_unit(hash_value: int) -> Vector3:
+    x = ((hash_value >> 0) & 0xFFFF) / 0xFFFF * 2.0 - 1.0
+    y = ((hash_value >> 16) & 0xFFFF) / 0xFFFF * 2.0 - 1.0
+    z = ((hash_value >> 32) & 0xFFFF) / 0xFFFF * 2.0 - 1.0
+    vec = Vector3(x, y, z)
+    length = vec.length()
+    if length < 1e-5:
+        return Vector3.unit_z()
+    return vec / length

--- a/tunnelcave_sandbox/frame.py
+++ b/tunnelcave_sandbox/frame.py
@@ -1,0 +1,63 @@
+"""Orthonormal frame utilities for the cave path."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .vector import Vector3, orthonormalize
+
+
+@dataclass(frozen=True)
+class OrthonormalFrame:
+    """Coordinate frame that travels along the tunnel path."""
+
+    origin: Vector3
+    forward: Vector3
+    right: Vector3
+    up: Vector3
+
+    def transport(self, new_origin: Vector3, new_forward: Vector3) -> "OrthonormalFrame":
+        """Move the frame using parallel transport.
+
+        The method keeps the in-plane axes free of unnecessary spins by
+        rotating them only by the minimal rotation that maps the old
+        forward direction into the new forward direction.
+        """
+
+        old_forward = self.forward
+        new_forward_norm = new_forward.normalized()
+        dot = max(-1.0, min(1.0, old_forward.dot(new_forward_norm)))
+        angle = math.acos(dot)
+        if angle < 1e-6:
+            return OrthonormalFrame(new_origin, new_forward_norm, self.right, self.up)
+
+        axis = old_forward.cross(new_forward_norm)
+        axis_length = axis.length()
+        if axis_length < 1e-8:
+            # The directions are opposite. We rotate around a stable axis
+            # that depends only on the forward vector to avoid sudden flips.
+            axis = self.right if abs(old_forward.dot(self.right)) < 0.9 else self.up
+            axis_length = axis.length()
+        axis = axis / axis_length
+
+        right_rotated = _rotate_vector(self.right, axis, angle)
+        up_rotated = _rotate_vector(self.up, axis, angle)
+        return OrthonormalFrame(new_origin, new_forward_norm, right_rotated, up_rotated)
+
+    @staticmethod
+    def initial(origin: Vector3, forward: Vector3) -> "OrthonormalFrame":
+        fwd, up, right = orthonormalize(forward, Vector3(0.0, 1.0, 0.0))
+        return OrthonormalFrame(origin, fwd, right, up)
+
+
+def _rotate_vector(vector: Vector3, axis: Vector3, angle: float) -> Vector3:
+    """Rotate ``vector`` around ``axis`` by ``angle`` radians."""
+
+    sin_theta = math.sin(angle)
+    cos_theta = math.cos(angle)
+    axis = axis.normalized()
+    return (
+        vector * cos_theta
+        + axis.cross(vector) * sin_theta
+        + axis * axis.dot(vector) * (1.0 - cos_theta)
+    )

--- a/tunnelcave_sandbox/geometry.py
+++ b/tunnelcave_sandbox/geometry.py
@@ -1,0 +1,89 @@
+"""Data structures describing the generated tunnel geometry."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Sequence, Tuple
+
+from .frame import OrthonormalFrame
+from .vector import Vector3
+
+
+@dataclass(frozen=True)
+class RingSample:
+    """A single ring along the tunnel center line."""
+
+    frame: OrthonormalFrame
+    radius: float
+    roughness_profile: Tuple[float, ...]
+
+    @property
+    def center(self) -> Vector3:
+        return self.frame.origin
+
+    @property
+    def forward(self) -> Vector3:
+        return self.frame.forward
+
+    def radius_at_angle(self, angle_index: float) -> float:
+        sides = len(self.roughness_profile)
+        base_index = int(angle_index) % sides
+        next_index = (base_index + 1) % sides
+        t = angle_index - int(angle_index)
+        return self.roughness_profile[base_index] * (1.0 - t) + self.roughness_profile[next_index] * t
+
+    def diameter_stats(self) -> Tuple[float, float, float]:
+        values = list(self.roughness_profile)
+        mean = sum(values) * 2.0 / len(values)
+        min_val = min(values) * 2.0
+        variance = sum((v - mean * 0.5) ** 2 for v in values) / len(values)
+        return min_val, mean, variance
+
+
+@dataclass
+class MeshChunk:
+    vertices: List[Vector3]
+    indices: List[int]
+
+
+@dataclass
+class SDFChunk:
+    ring_indexes: Tuple[int, ...]
+    radii: Tuple[float, ...]
+
+
+@dataclass
+class ChunkGeometry:
+    """Combined geometry information for a single chunk."""
+
+    chunk_index: int
+    rings: Tuple[RingSample, ...]
+    mesh: MeshChunk | None = None
+    sdf: SDFChunk | None = None
+    aabb_min: Vector3 = field(default_factory=Vector3.zero)
+    aabb_max: Vector3 = field(default_factory=Vector3.zero)
+    widest_ring_index: int = 0
+    min_radius: float = 0.0
+    max_radius: float = 0.0
+
+    def update_bounds(self) -> None:
+        mins = [float("inf"), float("inf"), float("inf")]
+        maxs = [float("-inf"), float("-inf"), float("-inf")]
+        for ring in self.rings:
+            for axis in (ring.frame.right, ring.frame.up):
+                for s in (-1.0, 1.0):
+                    point = ring.center + axis * (ring.radius * s)
+                    mins[0] = min(mins[0], point.x)
+                    mins[1] = min(mins[1], point.y)
+                    mins[2] = min(mins[2], point.z)
+                    maxs[0] = max(maxs[0], point.x)
+                    maxs[1] = max(maxs[1], point.y)
+                    maxs[2] = max(maxs[2], point.z)
+        self.aabb_min = Vector3.from_iter(mins)
+        self.aabb_max = Vector3.from_iter(maxs)
+
+    def summary(self) -> str:
+        return (
+            f"Chunk {self.chunk_index}: rings={len(self.rings)}, "
+            f"radius range=({self.min_radius:.2f}, {self.max_radius:.2f}), "
+            f"widest ring={self.widest_ring_index}"
+        )

--- a/tunnelcave_sandbox/noise.py
+++ b/tunnelcave_sandbox/noise.py
@@ -1,0 +1,117 @@
+"""Deterministic smooth noise helpers used throughout the sandbox."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class NoiseConfig:
+    seed: int
+    frequency: float
+
+
+# -- Hash helpers ---------------------------------------------------------
+
+def _hash3(seed: int, x: int, y: int, z: int) -> int:
+    value = seed ^ (x * 374761393) ^ (y * 668265263) ^ (z * 2147483647)
+    value = (value ^ (value >> 13)) * 1274126177
+    value = value ^ (value >> 16)
+    return value & 0xFFFFFFFF
+
+
+def _gradient(seed: int, x: int, y: int, z: int) -> Tuple[float, float, float]:
+    h = _hash3(seed, x, y, z)
+    # Use the low bits to generate a normalized gradient vector.
+    hx = ((h >> 0) & 0xFF) / 255.0 * 2.0 - 1.0
+    hy = ((h >> 8) & 0xFF) / 255.0 * 2.0 - 1.0
+    hz = ((h >> 16) & 0xFF) / 255.0 * 2.0 - 1.0
+    length = math.sqrt(hx * hx + hy * hy + hz * hz) or 1.0
+    return hx / length, hy / length, hz / length
+
+
+def _fade(t: float) -> float:
+    return t * t * t * (t * (t * 6 - 15) + 10)
+
+
+def _lerp(a: float, b: float, t: float) -> float:
+    return a + (b - a) * t
+
+
+# -- Noise evaluators -----------------------------------------------------
+
+def noise3(seed: int, x: float, y: float, z: float) -> float:
+    """Classic Perlin-style gradient noise in 3D."""
+
+    xi = math.floor(x)
+    yi = math.floor(y)
+    zi = math.floor(z)
+
+    xf = x - xi
+    yf = y - yi
+    zf = z - zi
+
+    gradients = {}
+    dot_vals = {}
+    for dx in (0, 1):
+        for dy in (0, 1):
+            for dz in (0, 1):
+                gx, gy, gz = _gradient(seed, xi + dx, yi + dy, zi + dz)
+                dot = (xf - dx) * gx + (yf - dy) * gy + (zf - dz) * gz
+                gradients[(dx, dy, dz)] = (gx, gy, gz)
+                dot_vals[(dx, dy, dz)] = dot
+
+    u = _fade(xf)
+    v = _fade(yf)
+    w = _fade(zf)
+
+    x1 = _lerp(dot_vals[(0, 0, 0)], dot_vals[(1, 0, 0)], u)
+    x2 = _lerp(dot_vals[(0, 1, 0)], dot_vals[(1, 1, 0)], u)
+    x3 = _lerp(dot_vals[(0, 0, 1)], dot_vals[(1, 0, 1)], u)
+    x4 = _lerp(dot_vals[(0, 1, 1)], dot_vals[(1, 1, 1)], u)
+
+    y1 = _lerp(x1, x2, v)
+    y2 = _lerp(x3, x4, v)
+
+    return _lerp(y1, y2, w)
+
+
+def noise3_periodic(seed: int, x: float, y: float, z: float, period: float) -> float:
+    """3D noise with a period along the ``z`` axis.
+
+    The function wraps the coordinate in a sine/cosine space so that
+    samples at ``angle`` and ``angle + 2π`` are identical. This is used
+    for the angular roughness to avoid seams when stitching rings.
+    """
+
+    sin_a = math.sin(z)
+    cos_a = math.cos(z)
+    scale = 1.0 / max(1e-5, period)
+    return noise3(seed, x * scale + sin_a, y * scale + cos_a, z * scale)
+
+
+def curl_noise(seed: int, position: Tuple[float, float, float], frequency: float) -> Tuple[float, float, float]:
+    """Curl of a vector potential made of three independent noise fields."""
+
+    px, py, pz = position
+    scale = frequency
+    sample = (px * scale, py * scale, pz * scale)
+    eps = 0.01
+
+    ax = noise3(seed + 101, *sample)
+    ay = noise3(seed + 257, *sample)
+    az = noise3(seed + 409, *sample)
+
+    d_az_dy = (noise3(seed + 409, sample[0], sample[1] + eps, sample[2]) - noise3(seed + 409, sample[0], sample[1] - eps, sample[2])) / (2 * eps)
+    d_ay_dz = (noise3(seed + 257, sample[0], sample[1], sample[2] + eps) - noise3(seed + 257, sample[0], sample[1], sample[2] - eps)) / (2 * eps)
+    d_ax_dz = (noise3(seed + 101, sample[0], sample[1], sample[2] + eps) - noise3(seed + 101, sample[0], sample[1], sample[2] - eps)) / (2 * eps)
+    d_az_dx = (noise3(seed + 409, sample[0] + eps, sample[1], sample[2]) - noise3(seed + 409, sample[0] - eps, sample[1], sample[2])) / (2 * eps)
+    d_ay_dx = (noise3(seed + 257, sample[0] + eps, sample[1], sample[2]) - noise3(seed + 257, sample[0] - eps, sample[1], sample[2])) / (2 * eps)
+    d_ax_dy = (noise3(seed + 101, sample[0], sample[1] + eps, sample[2]) - noise3(seed + 101, sample[0], sample[1] - eps, sample[2])) / (2 * eps)
+
+    curl_x = d_az_dy - d_ay_dz
+    curl_y = d_ax_dz - d_az_dx
+    curl_z = d_ay_dx - d_ax_dy
+
+    return curl_x, curl_y, curl_z

--- a/tunnelcave_sandbox/probe.py
+++ b/tunnelcave_sandbox/probe.py
@@ -1,0 +1,50 @@
+"""Ring probing utilities for spawn placement."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
+
+from .geometry import RingSample
+from .vector import Vector3
+
+
+@dataclass(frozen=True)
+class ProbeSample:
+    axis: Vector3
+    distances: Tuple[float, float]
+
+
+class RingProbe:
+    """Provides clearance estimates for a ring by sampling diameters."""
+
+    def __init__(self, ring: RingSample) -> None:
+        self._ring = ring
+
+    def clearance_along(self, axis: Vector3) -> Tuple[float, float, float]:
+        axis_plane = self._project_to_plane(axis)
+        if axis_plane.length() < 1e-6:
+            raise ValueError("Axis must not be parallel to the forward vector")
+        axis_plane = axis_plane.normalized()
+        angle = math.atan2(axis_plane.dot(self._ring.frame.up), axis_plane.dot(self._ring.frame.right))
+        sides = len(self._ring.roughness_profile)
+        angle_index = (angle / math.tau) * sides
+        radius_pos = self._ring.radius_at_angle(angle_index % sides)
+        radius_neg = self._ring.radius_at_angle((angle_index + sides / 2) % sides)
+        return radius_pos, radius_neg, radius_pos + radius_neg
+
+    def min_mean_variance(self, sample_count: int = 8) -> Tuple[float, float, float]:
+        values = []
+        for i in range(sample_count):
+            angle = (i / sample_count) * math.tau
+            axis = self._ring.frame.right * math.cos(angle) + self._ring.frame.up * math.sin(angle)
+            _, _, diameter = self.clearance_along(axis)
+            values.append(diameter)
+        mean = sum(values) / len(values)
+        min_val = min(values)
+        variance = sum((v - mean) ** 2 for v in values) / len(values)
+        return min_val, mean, variance
+
+    def _project_to_plane(self, vector: Vector3) -> Vector3:
+        forward = self._ring.forward
+        return vector - forward * vector.dot(forward)

--- a/tunnelcave_sandbox/sandbox_demo.py
+++ b/tunnelcave_sandbox/sandbox_demo.py
@@ -1,0 +1,53 @@
+"""Small demonstration harness for the tunnel sandbox."""
+from __future__ import annotations
+
+import math
+
+from .camera import CameraParams, ThirdPersonCamera
+from .spawn import SpawnPlanner, SpawnRequest
+from .streaming import ChunkStreamer
+from .terrain_generator import TunnelParams, TunnelTerrainGenerator
+from .vector import Vector3
+
+
+def build_default_params() -> TunnelParams:
+    return TunnelParams(
+        world_seed=1337,
+        chunk_length=60.0,
+        ring_step=4.0,
+        tube_sides=16,
+        dir_freq=0.05,
+        dir_blend=0.65,
+        radius_base=8.0,
+        radius_var=2.0,
+        radius_freq=0.015,
+        rough_amp=0.8,
+        rough_freq=0.12,
+        jolt_every_meters=120.0,
+        jolt_strength=0.35,
+        max_turn_per_step_rad=0.7,
+        mode="mesh+sdf",
+    )
+
+
+def main() -> None:
+    params = build_default_params()
+    generator = TunnelTerrainGenerator(params)
+    streamer = ChunkStreamer(generator)
+    streamer.update(0)
+    print(streamer.band_summary())
+
+    planner = SpawnPlanner(generator.rings())
+    result = planner.plan(SpawnRequest(arc_window=(0, 80), craft_radius=1.5))
+    print("Spawn position:", result.position)
+    camera = ThirdPersonCamera(
+        params=CameraParams(follow_distance=12.0, height_offset=5.0, lateral_offset=0.0, smoothing=0.3),
+        position=result.position - result.forward * 10.0,
+        target=result.position,
+    )
+    camera.update(result.position, result.right, result.up, result.forward, dt=0.016)
+    print("Camera position:", camera.position)
+
+
+if __name__ == "__main__":
+    main()

--- a/tunnelcave_sandbox/sdf.py
+++ b/tunnelcave_sandbox/sdf.py
@@ -1,0 +1,36 @@
+"""Signed distance utilities for the tunnel."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .geometry import RingSample
+from .noise import noise3
+from .vector import Vector3
+
+
+def distance_to_segment(point: Vector3, a: Vector3, b: Vector3) -> float:
+    ab = b - a
+    ap = point - a
+    ab_len_sq = ab.dot(ab)
+    if ab_len_sq == 0.0:
+        return ap.length()
+    t = max(0.0, min(1.0, ap.dot(ab) / ab_len_sq))
+    closest = a + ab * t
+    return (point - closest).length()
+
+
+@dataclass(frozen=True)
+class SignedDistanceField:
+    rings: Sequence[RingSample]
+    noise_seed: int
+    noise_amplitude: float
+
+    def evaluate(self, point: Vector3) -> float:
+        distances = []
+        for ring in self.rings:
+            distances.append(distance_to_segment(point, ring.center, ring.center + ring.forward))
+        base_distance = min(distances) - max(r.radius for r in self.rings)
+        detail = self.noise_amplitude * noise3(self.noise_seed, point.x, point.y, point.z)
+        return base_distance + detail

--- a/tunnelcave_sandbox/spawn.py
+++ b/tunnelcave_sandbox/spawn.py
@@ -1,0 +1,77 @@
+"""Spawn selection logic for the tunnel sandbox."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .geometry import RingSample
+from .probe import RingProbe
+from .vector import Vector3
+
+
+@dataclass(frozen=True)
+class SpawnRequest:
+    arc_window: tuple[int, int]
+    craft_radius: float
+
+
+@dataclass(frozen=True)
+class SpawnResult:
+    position: Vector3
+    forward: Vector3
+    right: Vector3
+    up: Vector3
+
+
+class SpawnPlanner:
+    """Searches rings for a safe deterministic spawn pose."""
+
+    def __init__(self, rings: Sequence[RingSample]) -> None:
+        self._rings = rings
+
+    def plan(self, request: SpawnRequest) -> SpawnResult:
+        start, end = request.arc_window
+        candidate_indexes = list(range(max(0, start), min(len(self._rings), end)))
+        scored = []
+        for index in candidate_indexes:
+            ring = self._rings[index]
+            probe = RingProbe(ring)
+            min_d, mean_d, variance = probe.min_mean_variance(12)
+            score = mean_d - variance - abs(mean_d - min_d)
+            scored.append((score, index))
+        scored.sort(reverse=True)
+        for _, index in scored:
+            result = self._try_ring(index, request.craft_radius)
+            if result is not None:
+                return result
+        widest_index = max(range(len(self._rings)), key=lambda i: self._rings[i].radius)
+        fallback = self._try_ring(widest_index, request.craft_radius)
+        if fallback is None:
+            raise RuntimeError("Failed to find safe spawn pose")
+        return fallback
+
+    def _try_ring(self, index: int, craft_radius: float) -> SpawnResult | None:
+        ring = self._rings[index]
+        probe = RingProbe(ring)
+        best_axis = None
+        best_margin = -float("inf")
+        best_distances = (0.0, 0.0)
+        for i in range(16):
+            angle = (i / 16) * math.tau
+            axis = ring.frame.right * math.cos(angle) + ring.frame.up * math.sin(angle)
+            dist_pos, dist_neg, diameter = probe.clearance_along(axis)
+            margin = min(dist_pos, dist_neg) - craft_radius
+            if margin > best_margin:
+                best_margin = margin
+                best_axis = axis.normalized()
+                best_distances = (dist_pos, dist_neg)
+        if best_axis is None or best_margin <= 0.0:
+            return None
+        dist_pos, dist_neg = best_distances
+        midpoint_shift = (dist_pos - dist_neg) * 0.5
+        position = ring.center + best_axis * midpoint_shift
+        forward = ring.forward
+        right = best_axis
+        up = forward.cross(right).normalized()
+        return SpawnResult(position=position, forward=forward, right=right, up=up)

--- a/tunnelcave_sandbox/streaming.py
+++ b/tunnelcave_sandbox/streaming.py
@@ -1,0 +1,30 @@
+"""Chunk streaming helper."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+from .geometry import ChunkGeometry
+from .terrain_generator import TunnelTerrainGenerator
+
+
+@dataclass
+class ChunkStreamer:
+    generator: TunnelTerrainGenerator
+    band: tuple[int, int] = (-2, 3)
+    loaded: Dict[int, ChunkGeometry] = field(default_factory=dict)
+
+    def update(self, current_chunk: int) -> None:
+        start = current_chunk + self.band[0]
+        end = current_chunk + self.band[1]
+        desired = set(index for index in range(start, end + 1) if index >= 0)
+        to_unload = [index for index in self.loaded.keys() if index not in desired]
+        for index in to_unload:
+            del self.loaded[index]
+        for index in desired:
+            if index not in self.loaded:
+                self.loaded[index] = self.generator.generate_chunk(index)
+
+    def band_summary(self) -> str:
+        keys = sorted(self.loaded.keys())
+        return ", ".join(f"{k}:{self.loaded[k].summary()}" for k in keys)

--- a/tunnelcave_sandbox/terrain_generator.py
+++ b/tunnelcave_sandbox/terrain_generator.py
@@ -1,0 +1,162 @@
+"""High-level tunnel generation entry point."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from .direction_field import DivergenceFreeField, FieldParams
+from .frame import OrthonormalFrame
+from .geometry import ChunkGeometry, MeshChunk, RingSample, SDFChunk
+from .noise import noise3, noise3_periodic
+from .vector import Vector3
+
+
+@dataclass(frozen=True)
+class TunnelParams:
+    world_seed: int
+    chunk_length: float
+    ring_step: float
+    tube_sides: int
+    dir_freq: float
+    dir_blend: float
+    radius_base: float
+    radius_var: float
+    radius_freq: float
+    rough_amp: float
+    rough_freq: float
+    jolt_every_meters: float
+    jolt_strength: float
+    max_turn_per_step_rad: float
+    mode: str
+
+
+class TunnelTerrainGenerator:
+    """Generates chunks on demand while caching previously computed rings."""
+
+    def __init__(self, params: TunnelParams) -> None:
+        if params.tube_sides < 3:
+            raise ValueError("tube_sides must be >= 3")
+        if params.radius_base <= params.rough_amp:
+            raise ValueError("roughness amplitude must be smaller than base radius")
+        self._params = params
+        field_params = FieldParams(
+            world_seed=params.world_seed,
+            dir_freq=params.dir_freq,
+            dir_blend=params.dir_blend,
+            max_turn_per_step_rad=params.max_turn_per_step_rad,
+            jolt_every_meters=params.jolt_every_meters,
+            jolt_strength=params.jolt_strength,
+        )
+        self._field = DivergenceFreeField(field_params)
+        self._global_rings: List[RingSample] = []
+        self._global_s_positions: List[float] = []
+        self._rings_per_chunk = int(round(params.chunk_length / params.ring_step)) + 1
+        self._ensure_ring(0)
+
+    def generate_chunk(self, chunk_index: int) -> ChunkGeometry:
+        start = chunk_index * (self._rings_per_chunk - 1)
+        end = start + self._rings_per_chunk
+        self._ensure_ring(end)
+        rings = tuple(self._global_rings[start:end])
+        chunk = ChunkGeometry(chunk_index=chunk_index, rings=rings)
+        chunk.min_radius = min(r.radius for r in rings)
+        chunk.max_radius = max(r.radius for r in rings)
+        chunk.widest_ring_index = max(range(len(rings)), key=lambda i: rings[i].radius)
+        chunk.update_bounds()
+        if self._params.mode in ("mesh", "mesh+sdf"):
+            chunk.mesh = self._build_mesh(rings)
+        if self._params.mode in ("sdf", "mesh+sdf"):
+            chunk.sdf = self._build_sdf(chunk_index, rings)
+        return chunk
+
+    def rings(self) -> Tuple[RingSample, ...]:
+        """Return all generated rings so far."""
+
+        return tuple(self._global_rings)
+
+    def _ensure_ring(self, index: int) -> None:
+        while len(self._global_rings) <= index:
+            self._append_ring()
+
+    def _append_ring(self) -> None:
+        params = self._params
+        index = len(self._global_rings)
+        if index == 0:
+            origin = Vector3.zero()
+            forward = Vector3.unit_z()
+            frame = OrthonormalFrame.initial(origin, forward)
+            radius = params.radius_base
+            roughness = tuple([params.radius_base] * params.tube_sides)
+            ring = RingSample(frame=frame, radius=radius, roughness_profile=roughness)
+            self._global_rings.append(ring)
+            self._global_s_positions.append(0.0)
+            return
+
+        prev_ring = self._global_rings[-1]
+        prev_s = self._global_s_positions[-1]
+        arc_length = prev_s + params.ring_step
+        direction = self._field.next_direction(prev_ring.center, prev_ring.forward, index, arc_length)
+        origin = prev_ring.center + direction * params.ring_step
+        frame = prev_ring.frame.transport(origin, direction)
+
+        radius = params.radius_base + params.radius_var * noise3(
+            params.world_seed + 2000, arc_length * params.radius_freq, 0.0, 0.0
+        )
+        radius = max(radius, params.radius_base * 0.2)
+
+        roughness_profile = self._build_roughness_profile(index, frame, radius, arc_length)
+        ring = RingSample(frame=frame, radius=radius, roughness_profile=roughness_profile)
+        self._global_rings.append(ring)
+        self._global_s_positions.append(arc_length)
+
+    def _build_roughness_profile(
+        self, index: int, frame: OrthonormalFrame, radius: float, arc_length: float
+    ) -> Tuple[float, ...]:
+        params = self._params
+        sides = params.tube_sides
+        values: List[float] = []
+        for side in range(sides):
+            angle = (side / sides) * math.tau
+            noise_value = noise3_periodic(
+                params.world_seed + 4000,
+                frame.origin.x * params.rough_freq,
+                frame.origin.y * params.rough_freq,
+                angle + arc_length * params.rough_freq,
+                period=math.tau,
+            )
+            rough = radius + params.rough_amp * noise_value
+            rough = max(rough, radius * 0.5)
+            values.append(rough)
+        return tuple(values)
+
+    def _build_mesh(self, rings: Tuple[RingSample, ...]) -> MeshChunk:
+        vertices: List[Vector3] = []
+        indices: List[int] = []
+        sides = self._params.tube_sides
+        for ring_idx, ring in enumerate(rings):
+            for side in range(sides):
+                angle = (side / sides) * math.tau
+                axis = ring.frame.right * math.cos(angle) + ring.frame.up * math.sin(angle)
+                radius = ring.roughness_profile[side]
+                vertices.append(ring.center + axis * radius)
+            if ring_idx == 0:
+                continue
+            base_prev = (ring_idx - 1) * sides
+            base_curr = ring_idx * sides
+            for side in range(sides):
+                next_side = (side + 1) % sides
+                indices.extend([
+                    base_prev + side,
+                    base_curr + side,
+                    base_curr + next_side,
+                    base_prev + side,
+                    base_curr + next_side,
+                    base_prev + next_side,
+                ])
+        return MeshChunk(vertices=vertices, indices=indices)
+
+    def _build_sdf(self, chunk_index: int, rings: Tuple[RingSample, ...]) -> SDFChunk:
+        indexes = tuple(range(chunk_index * (self._rings_per_chunk - 1), chunk_index * (self._rings_per_chunk - 1) + len(rings)))
+        radii = tuple(r.radius for r in rings)
+        return SDFChunk(ring_indexes=indexes, radii=radii)

--- a/tunnelcave_sandbox/vector.py
+++ b/tunnelcave_sandbox/vector.py
@@ -1,0 +1,144 @@
+"""Lightweight 3D vector math utilities.
+
+The sandbox keeps vector arithmetic extremely small and explicit so
+that every deterministic step in the cave generation is easy to audit.
+The functions offered here are intentionally minimal: only what the
+rest of the sandbox needs is implemented.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Vector3:
+    """Immutable 3D vector with a handful of math helpers."""
+
+    x: float
+    y: float
+    z: float
+
+    def __add__(self, other: "Vector3") -> "Vector3":
+        return Vector3(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other: "Vector3") -> "Vector3":
+        return Vector3(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    def __mul__(self, scalar: float) -> "Vector3":
+        return Vector3(self.x * scalar, self.y * scalar, self.z * scalar)
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, scalar: float) -> "Vector3":
+        return Vector3(self.x / scalar, self.y / scalar, self.z / scalar)
+
+    def dot(self, other: "Vector3") -> float:
+        return self.x * other.x + self.y * other.y + self.z * other.z
+
+    def cross(self, other: "Vector3") -> "Vector3":
+        return Vector3(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x,
+        )
+
+    def length(self) -> float:
+        return math.sqrt(self.dot(self))
+
+    def normalized(self) -> "Vector3":
+        length = self.length()
+        if length == 0.0:
+            raise ValueError("Cannot normalize zero-length vector")
+        return self / length
+
+    def lerp(self, other: "Vector3", t: float) -> "Vector3":
+        return self * (1.0 - t) + other * t
+
+    def clamp_length(self, max_length: float) -> "Vector3":
+        length = self.length()
+        if length <= max_length:
+            return self
+        if length == 0.0:
+            return self
+        return self * (max_length / length)
+
+    @staticmethod
+    def zero() -> "Vector3":
+        return Vector3(0.0, 0.0, 0.0)
+
+    @staticmethod
+    def unit_z() -> "Vector3":
+        return Vector3(0.0, 0.0, 1.0)
+
+    @staticmethod
+    def from_iter(values: Iterable[float]) -> "Vector3":
+        x, y, z = values
+        return Vector3(float(x), float(y), float(z))
+
+
+def orthonormalize(forward: Vector3, up_hint: Vector3) -> tuple[Vector3, Vector3, Vector3]:
+    """Return a right-handed orthonormal basis given a forward vector.
+
+    The function follows the classic "Gram-Schmidt with fallback"
+    approach: project the hint vector out of the forward component and
+    renormalize. Should the hint happen to be parallel to the forward
+    vector, a simple deterministic fallback axis is used instead.
+    """
+
+    fwd = forward.normalized()
+    up_projected = up_hint - fwd * fwd.dot(up_hint)
+    length = up_projected.length()
+    if length < 1e-6:
+        # Deterministic fallback based solely on the forward components.
+        fallback = Vector3(1.0, 0.0, 0.0) if abs(fwd.z) > 0.707 else Vector3(0.0, 0.0, 1.0)
+        up_projected = fallback - fwd * fwd.dot(fallback)
+        length = up_projected.length()
+    up = up_projected / length
+    right = fwd.cross(up)
+    return fwd, up, right
+
+
+def rotate_towards(vector: Vector3, target: Vector3, max_angle_rad: float) -> Vector3:
+    """Rotate ``vector`` toward ``target`` without exceeding ``max_angle_rad``.
+
+    The rotation is carried out in the plane spanned by ``vector`` and
+    ``target``. When the angle already falls within the limit no change
+    is applied. This helper is used to clamp the direction field
+    updates so the curve cannot fold onto itself between two rings.
+    """
+
+    if max_angle_rad <= 0.0:
+        return vector
+
+    v_norm = vector.normalized()
+    t_norm = target.normalized()
+    dot = max(-1.0, min(1.0, v_norm.dot(t_norm)))
+    angle = math.acos(dot)
+    if angle <= max_angle_rad:
+        return t_norm
+
+    axis = v_norm.cross(t_norm)
+    axis_len = axis.length()
+    if axis_len < 1e-8:
+        # Vectors are parallel or antiparallel. When antiparallel we
+        # pick a deterministic perpendicular axis.
+        if dot < 0.0:
+            if abs(v_norm.z) < 0.9:
+                axis = v_norm.cross(Vector3.unit_z())
+            else:
+                axis = v_norm.cross(Vector3(0.0, 1.0, 0.0))
+            axis_len = axis.length()
+            if axis_len < 1e-8:
+                return v_norm
+        else:
+            return v_norm
+    axis = axis / axis_len
+    sin_theta = math.sin(max_angle_rad)
+    cos_theta = math.cos(max_angle_rad)
+    return (
+        v_norm * cos_theta
+        + axis.cross(v_norm) * sin_theta
+        + axis * axis.dot(v_norm) * (1.0 - cos_theta)
+    )

--- a/tunnelcave_sandbox_web/app/layout.tsx
+++ b/tunnelcave_sandbox_web/app/layout.tsx
@@ -1,0 +1,19 @@
+import "../styles/globals.css";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Tunnelcave Sandbox",
+  description: "Procedural endless cave flight sandbox"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tunnelcave_sandbox_web/app/page.module.css
+++ b/tunnelcave_sandbox_web/app/page.module.css
@@ -1,0 +1,32 @@
+.main {
+  position: relative;
+  flex: 1;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
+.footer {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.6rem 1rem;
+  color: #cbd5f5;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(6px);
+}
+
+.footer span:first-child {
+  font-weight: 600;
+  color: #f8fafc;
+}

--- a/tunnelcave_sandbox_web/app/page.tsx
+++ b/tunnelcave_sandbox_web/app/page.tsx
@@ -1,0 +1,18 @@
+import { SandboxCanvas } from "../components/SandboxCanvas";
+import styles from "./page.module.css";
+
+export default function Page() {
+  return (
+    <main className={styles.main}>
+      <SandboxCanvas />
+      <footer className={styles.footer}>
+        <span>
+          Deterministic endless cave sandbox. Built with Next.js, React, and three.js.
+        </span>
+        <span>
+          Hold Shift to tighten camera lag · Press Space to level wings
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/tunnelcave_sandbox_web/components/ControlsOverlay.module.css
+++ b/tunnelcave_sandbox_web/components/ControlsOverlay.module.css
@@ -1,0 +1,52 @@
+.overlay {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  max-width: 320px;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  backdrop-filter: blur(8px);
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.subtitle {
+  margin: 0.1rem 0 0.75rem;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.metrics {
+  display: flex;
+  gap: 0.75rem;
+  font-family: "Roboto Mono", "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  margin-bottom: 0.75rem;
+}
+
+.metrics strong {
+  color: #f8fafc;
+}
+
+.instructions {
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  padding-top: 0.75rem;
+}
+
+.instructions ul {
+  padding-left: 1.25rem;
+  margin: 0.4rem 0 0;
+}
+
+.instructions li {
+  margin-bottom: 0.3rem;
+}

--- a/tunnelcave_sandbox_web/components/ControlsOverlay.tsx
+++ b/tunnelcave_sandbox_web/components/ControlsOverlay.tsx
@@ -1,0 +1,34 @@
+import styles from "./ControlsOverlay.module.css";
+
+interface OverlayProps {
+  speed: number;
+  targetSpeed: number;
+}
+
+export function ControlsOverlay({ speed, targetSpeed }: OverlayProps) {
+  return (
+    <div className={styles.overlay}>
+      <div>
+        <h1 className={styles.title}>Tunnelcave Sandbox</h1>
+        <p className={styles.subtitle}>Procedural endless cave flight demo</p>
+      </div>
+      <div className={styles.metrics}>
+        <span>
+          Speed: <strong>{speed.toFixed(1)} m/s</strong>
+        </span>
+        <span>
+          Target: <strong>{targetSpeed.toFixed(1)} m/s</strong>
+        </span>
+      </div>
+      <div className={styles.instructions}>
+        <p>Controls</p>
+        <ul>
+          <li>W / S – Increase or decrease throttle</li>
+          <li>A / D – Bank craft left / right</li>
+          <li>Space – Reset roll</li>
+          <li>Shift – Boost follow camera tightness</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/tunnelcave_sandbox_web/components/SandboxCanvas.tsx
+++ b/tunnelcave_sandbox_web/components/SandboxCanvas.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { defaultParams } from "../lib/config";
+import { createSimulation, updateSimulation, type SimulationParams } from "../lib/world";
+import type { SimulationState } from "../lib/world";
+import type { ChunkData } from "../lib/terrain";
+import { ControlsOverlay } from "./ControlsOverlay";
+
+interface InputState {
+  throttle: number;
+  roll: number;
+  boost: boolean;
+  resetRoll: boolean;
+}
+
+function buildCraftMesh() {
+  const geometry = new THREE.BufferGeometry();
+  const vertices = new Float32Array([
+    0, 0, 1.5,
+    -0.8, 0, -1,
+    0.8, 0, -1,
+    0, 0.45, -0.5,
+    0, -0.45, -0.5
+  ]);
+  const indices = new Uint16Array([
+    0, 1, 3,
+    0, 3, 2,
+    0, 2, 4,
+    0, 4, 1,
+    1, 4, 3,
+    3, 4, 2,
+    2, 1, 3
+  ]);
+  geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  geometry.computeVertexNormals();
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xf97316,
+    flatShading: false,
+    metalness: 0.2,
+    roughness: 0.6
+  });
+  return new THREE.Mesh(geometry, material);
+}
+
+function createChunkMesh(chunk: ChunkData) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(chunk.positions, 3));
+  geometry.setAttribute("normal", new THREE.BufferAttribute(chunk.normals, 3));
+  geometry.setIndex(new THREE.BufferAttribute(chunk.indices, 1));
+  geometry.computeVertexNormals();
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x334155,
+    flatShading: true,
+    side: THREE.DoubleSide
+  });
+  return new THREE.Mesh(geometry, material);
+}
+
+export function SandboxCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const simRef = useRef<SimulationState | null>(null);
+  const rafRef = useRef<number>();
+  const inputRef = useRef<InputState>({ throttle: 0, roll: 0, boost: false, resetRoll: false });
+  const [speed, setSpeed] = useState(0);
+  const [targetSpeed, setTargetSpeed] = useState(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setClearColor(0x020617);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 2000);
+
+    const ambient = new THREE.AmbientLight(0xbfdcff, 0.5);
+    const mainLight = new THREE.DirectionalLight(0xffffff, 1.2);
+    mainLight.position.set(30, 60, 25);
+    scene.add(ambient, mainLight);
+
+    const craftMesh = buildCraftMesh();
+    scene.add(craftMesh);
+
+    const chunkMeshes = new Map<number, THREE.Mesh>();
+
+    const simParams: SimulationParams = {
+      sandbox: defaultParams,
+      camera: {
+        followDistance: 12,
+        heightOffset: 4,
+        lateralOffset: 0,
+        smoothing: 3
+      },
+      craftRadius: 2.2
+    };
+
+    const simulation = createSimulation(simParams);
+    simRef.current = simulation;
+
+    function syncChunks() {
+      if (!simRef.current) return;
+      for (const [index, chunk] of simRef.current.band.chunks.entries()) {
+        if (!chunkMeshes.has(index)) {
+          const mesh = createChunkMesh(chunk);
+          chunkMeshes.set(index, mesh);
+          scene.add(mesh);
+        }
+      }
+      for (const [index, mesh] of chunkMeshes.entries()) {
+        if (!simRef.current.band.chunks.has(index)) {
+          scene.remove(mesh);
+          mesh.geometry.dispose();
+          if (Array.isArray(mesh.material)) {
+            mesh.material.forEach((m) => m.dispose());
+          } else {
+            mesh.material.dispose();
+          }
+          chunkMeshes.delete(index);
+        }
+      }
+    }
+
+    syncChunks();
+
+    let lastTime = performance.now();
+
+    const handleResize = () => {
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+    };
+
+    const keyDown = (event: KeyboardEvent) => {
+      if (event.repeat) return;
+      if (event.code === "KeyW") inputRef.current.throttle = 1;
+      if (event.code === "KeyS") inputRef.current.throttle = -1;
+      if (event.code === "KeyA") inputRef.current.roll = -1;
+      if (event.code === "KeyD") inputRef.current.roll = 1;
+      if (event.code === "ShiftLeft" || event.code === "ShiftRight") inputRef.current.boost = true;
+      if (event.code === "Space") inputRef.current.resetRoll = true;
+    };
+
+    const keyUp = (event: KeyboardEvent) => {
+      if (event.code === "KeyW" && inputRef.current.throttle > 0) inputRef.current.throttle = 0;
+      if (event.code === "KeyS" && inputRef.current.throttle < 0) inputRef.current.throttle = 0;
+      if (event.code === "KeyA" && inputRef.current.roll < 0) inputRef.current.roll = 0;
+      if (event.code === "KeyD" && inputRef.current.roll > 0) inputRef.current.roll = 0;
+      if (event.code === "ShiftLeft" || event.code === "ShiftRight") inputRef.current.boost = false;
+    };
+
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("keydown", keyDown);
+    window.addEventListener("keyup", keyUp);
+
+    const animate = () => {
+      if (!simRef.current) return;
+      const now = performance.now();
+      const dt = Math.min(0.05, (now - lastTime) / 1000);
+      lastTime = now;
+      const params: SimulationParams = {
+        sandbox: simParams.sandbox,
+        camera: {
+          ...simParams.camera,
+          smoothing: inputRef.current.boost ? 6 : simParams.camera.smoothing
+        },
+        craftRadius: simParams.craftRadius
+      };
+      updateSimulation(
+        simRef.current,
+        params,
+        {
+          throttleDelta: inputRef.current.throttle,
+          rollDelta: inputRef.current.roll
+        },
+        dt
+      );
+      if (inputRef.current.resetRoll) {
+        simRef.current.craft.roll = 0;
+        simRef.current.craft.rollRate = 0;
+        inputRef.current.resetRoll = false;
+      }
+      syncChunks();
+      const { craft, camera: cam } = simRef.current;
+      craftMesh.position.set(craft.position[0], craft.position[1], craft.position[2]);
+      const basis = new THREE.Matrix4().makeBasis(
+        new THREE.Vector3(craft.right[0], craft.right[1], craft.right[2]),
+        new THREE.Vector3(craft.up[0], craft.up[1], craft.up[2]),
+        new THREE.Vector3(craft.forward[0], craft.forward[1], craft.forward[2])
+      );
+      craftMesh.setRotationFromMatrix(basis);
+      camera.position.set(cam.position[0], cam.position[1], cam.position[2]);
+      camera.lookAt(new THREE.Vector3(craft.position[0], craft.position[1], craft.position[2]));
+      renderer.render(scene, camera);
+      setSpeed(craft.speed);
+      setTargetSpeed(craft.targetSpeed);
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("keydown", keyDown);
+      window.removeEventListener("keyup", keyUp);
+      renderer.dispose();
+      for (const mesh of chunkMeshes.values()) {
+        mesh.geometry.dispose();
+        if (Array.isArray(mesh.material)) {
+          mesh.material.forEach((m) => m.dispose());
+        } else {
+          mesh.material.dispose();
+        }
+      }
+      craftMesh.geometry.dispose();
+      (craftMesh.material as THREE.Material).dispose();
+    };
+  }, []);
+
+  return (
+    <>
+      <canvas ref={canvasRef} style={{ width: "100vw", height: "100vh", display: "block" }} />
+      <ControlsOverlay speed={speed} targetSpeed={targetSpeed} />
+    </>
+  );
+}

--- a/tunnelcave_sandbox_web/lib/camera.ts
+++ b/tunnelcave_sandbox_web/lib/camera.ts
@@ -1,0 +1,42 @@
+import { add, scale, Vec3 } from "./vector";
+
+export interface CameraRig {
+  position: Vec3;
+  target: Vec3;
+}
+
+export interface CameraParams {
+  followDistance: number;
+  heightOffset: number;
+  lateralOffset: number;
+  smoothing: number;
+}
+
+export function createCameraRig(initialPosition: Vec3): CameraRig {
+  return {
+    position: [...initialPosition],
+    target: [...initialPosition]
+  };
+}
+
+export function updateCameraRig(
+  rig: CameraRig,
+  craftPosition: Vec3,
+  forward: Vec3,
+  right: Vec3,
+  up: Vec3,
+  params: CameraParams,
+  dt: number
+) {
+  const desired = add(
+    add(add(craftPosition, scale(forward, -params.followDistance)), scale(up, params.heightOffset)),
+    scale(right, params.lateralOffset)
+  );
+  const alpha = 1 - Math.exp(-params.smoothing * dt);
+  rig.position[0] += (desired[0] - rig.position[0]) * alpha;
+  rig.position[1] += (desired[1] - rig.position[1]) * alpha;
+  rig.position[2] += (desired[2] - rig.position[2]) * alpha;
+  rig.target[0] += (craftPosition[0] - rig.target[0]) * alpha;
+  rig.target[1] += (craftPosition[1] - rig.target[1]) * alpha;
+  rig.target[2] += (craftPosition[2] - rig.target[2]) * alpha;
+}

--- a/tunnelcave_sandbox_web/lib/config.ts
+++ b/tunnelcave_sandbox_web/lib/config.ts
@@ -1,0 +1,33 @@
+export interface SandboxParams {
+  worldSeed: number;
+  chunkLength: number;
+  ringStep: number;
+  tubeSides: number;
+  dirFreq: number;
+  dirBlend: number;
+  radiusBase: number;
+  radiusVar: number;
+  radiusFreq: number;
+  roughAmp: number;
+  roughFreq: number;
+  joltEveryMeters: number;
+  joltStrength: number;
+  maxTurnPerStepRad: number;
+}
+
+export const defaultParams: SandboxParams = {
+  worldSeed: 1337,
+  chunkLength: 80,
+  ringStep: 2.5,
+  tubeSides: 18,
+  dirFreq: 0.05,
+  dirBlend: 0.65,
+  radiusBase: 9,
+  radiusVar: 2.5,
+  radiusFreq: 0.017,
+  roughAmp: 0.65,
+  roughFreq: 0.18,
+  joltEveryMeters: 120,
+  joltStrength: 0.55,
+  maxTurnPerStepRad: Math.PI / 6
+};

--- a/tunnelcave_sandbox_web/lib/directionField.ts
+++ b/tunnelcave_sandbox_web/lib/directionField.ts
@@ -1,0 +1,111 @@
+import { curlNoise, fbmNoise } from "./noise";
+import { hashMix, randUnitVector } from "./prng";
+import { add, normalize, scale, Vec3 } from "./vector";
+import type { SandboxParams } from "./config";
+
+export interface DirectionSample {
+  forward: Vec3;
+  radius: number;
+  roughness: (theta: number) => number;
+}
+
+interface DirectionState {
+  forward: Vec3;
+  smoothForward: Vec3;
+  distance: number;
+  nextJolt: number;
+  chunkSeed: number;
+}
+
+export function createDirectionState(params: SandboxParams): DirectionState {
+  return {
+    forward: [0, 0, 1],
+    smoothForward: [0, 0, 1],
+    distance: 0,
+    nextJolt: params.joltEveryMeters,
+    chunkSeed: hashMix(params.worldSeed)
+  };
+}
+
+function sampleDirectionField(
+  params: SandboxParams,
+  state: DirectionState,
+  position: Vec3
+): Vec3 {
+  const scaled: Vec3 = [
+    position[0] * params.dirFreq,
+    position[1] * params.dirFreq,
+    position[2] * params.dirFreq
+  ];
+  const curl = curlNoise(state.chunkSeed, scaled);
+  return normalize(curl);
+}
+
+function applyJolts(
+  params: SandboxParams,
+  state: DirectionState,
+  rand: () => number
+): Vec3 {
+  let forward = state.forward;
+  state.distance += params.ringStep;
+  if (state.distance >= state.nextJolt) {
+    const impulse = randUnitVector(rand);
+    forward = normalize(add(forward, scale(impulse, params.joltStrength)));
+    state.nextJolt += params.joltEveryMeters * (0.4 + rand() * 1.2);
+  }
+  return forward;
+}
+
+export function stepDirection(
+  params: SandboxParams,
+  state: DirectionState,
+  position: Vec3,
+  rand: () => number
+): DirectionSample {
+  const fieldDir = sampleDirectionField(params, state, position);
+  const blended = normalize(
+    add(scale(state.smoothForward, params.dirBlend), scale(fieldDir, 1 - params.dirBlend))
+  );
+  let forward = blended;
+  const jolted = applyJolts(params, state, rand);
+  forward = normalize(add(scale(forward, 0.7), scale(jolted, 0.3)));
+  const turnAngle = Math.acos(
+    Math.min(
+      1,
+      Math.max(-1, state.forward[0] * forward[0] + state.forward[1] * forward[1] + state.forward[2] * forward[2])
+    )
+  );
+  if (turnAngle > params.maxTurnPerStepRad) {
+    const t = params.maxTurnPerStepRad / turnAngle;
+    forward = normalize(add(scale(state.forward, 1 - t), scale(forward, t)));
+  }
+  state.forward = forward;
+  state.smoothForward = forward;
+  const radiusNoise = fbmNoise(
+    state.chunkSeed + 211,
+    [
+      position[0] * params.radiusFreq,
+      position[1] * params.radiusFreq,
+      position[2] * params.radiusFreq
+    ],
+    4,
+    1,
+    0.5
+  );
+  const radius = params.radiusBase + radiusNoise * params.radiusVar;
+  const roughness = (theta: number) => {
+    const sample = fbmNoise(
+      state.chunkSeed + 997,
+      [
+        position[0] * params.roughFreq + Math.cos(theta) * 1.5,
+        position[1] * params.roughFreq + Math.sin(theta) * 1.5,
+        position[2] * params.roughFreq
+      ],
+      3,
+      1,
+      0.5
+    );
+    return sample * params.roughAmp;
+  };
+  return { forward, radius, roughness };
+}

--- a/tunnelcave_sandbox_web/lib/frame.ts
+++ b/tunnelcave_sandbox_web/lib/frame.ts
@@ -1,0 +1,49 @@
+import { angleBetween, cross, dot, length, normalize, scale, Vec3 } from "./vector";
+
+export interface OrthonormalFrame {
+  forward: Vec3;
+  right: Vec3;
+  up: Vec3;
+}
+
+export function createInitialFrame(direction: Vec3): OrthonormalFrame {
+  const forward = normalize(direction);
+  const hint: Vec3 = Math.abs(forward[1]) < 0.9 ? [0, 1, 0] : [1, 0, 0];
+  let right = normalize(cross(hint, forward));
+  if (length(right) === 0) {
+    right = [1, 0, 0];
+  }
+  const up = normalize(cross(forward, right));
+  return { forward, right, up };
+}
+
+export function transportFrame(
+  frame: OrthonormalFrame,
+  newForward: Vec3
+): OrthonormalFrame {
+  const fOld = frame.forward;
+  const fNew = normalize(newForward);
+  const angle = angleBetween(fOld, fNew);
+  if (angle < 1e-5) {
+    return { forward: fNew, right: frame.right, up: frame.up };
+  }
+  const axis = cross(fOld, fNew);
+  const axisLen = length(axis);
+  if (axisLen === 0) {
+    return { forward: fNew, right: frame.right, up: frame.up };
+  }
+  const k = [axis[0] / axisLen, axis[1] / axisLen, axis[2] / axisLen] as Vec3;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  const rotate = (v: Vec3): Vec3 => {
+    const term1 = scale(v, cos);
+    const term2 = scale(cross(k, v), sin);
+    const term3 = scale(k, dot(k, v) * (1 - cos));
+    return [term1[0] + term2[0] + term3[0], term1[1] + term2[1] + term3[1], term1[2] + term2[2] + term3[2]];
+  };
+
+  const right = normalize(rotate(frame.right));
+  const up = normalize(rotate(frame.up));
+  return { forward: fNew, right, up };
+}

--- a/tunnelcave_sandbox_web/lib/noise.ts
+++ b/tunnelcave_sandbox_web/lib/noise.ts
@@ -1,0 +1,90 @@
+import { hashMix, mulberry32 } from "./prng";
+import type { Vec3 } from "./vector";
+import { vec3 } from "./vector";
+
+function latticeValue(seed: number, x: number, y: number, z: number): number {
+  const h = hashMix([seed, Math.floor(x), Math.floor(y), Math.floor(z)]);
+  const rand = mulberry32(h);
+  return rand() * 2 - 1;
+}
+
+function smoothstep(t: number): number {
+  return t * t * (3 - 2 * t);
+}
+
+function trilinearInterpolation(seed: number, p: Vec3): number {
+  const [x, y, z] = p;
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const z0 = Math.floor(z);
+  const tx = smoothstep(x - x0);
+  const ty = smoothstep(y - y0);
+  const tz = smoothstep(z - z0);
+
+  let accum = 0;
+  for (let dx = 0; dx <= 1; dx += 1) {
+    for (let dy = 0; dy <= 1; dy += 1) {
+      for (let dz = 0; dz <= 1; dz += 1) {
+        const weight =
+          (dx ? tx : 1 - tx) * (dy ? ty : 1 - ty) * (dz ? tz : 1 - tz);
+        accum += weight * latticeValue(seed, x0 + dx, y0 + dy, z0 + dz);
+      }
+    }
+  }
+  return accum;
+}
+
+export function fbmNoise(
+  seed: number,
+  p: Vec3,
+  octaves: number,
+  frequency: number,
+  gain: number
+): number {
+  let amp = 1;
+  let freq = frequency;
+  let sum = 0;
+  let norm = 0;
+  for (let i = 0; i < octaves; i += 1) {
+    const sample = trilinearInterpolation(seed + i * 1013, [
+      p[0] * freq,
+      p[1] * freq,
+      p[2] * freq
+    ]);
+    sum += sample * amp;
+    norm += amp;
+    amp *= gain;
+    freq *= 2;
+  }
+  return norm === 0 ? 0 : sum / norm;
+}
+
+export function vectorPotential(seed: number, p: Vec3): Vec3 {
+  return vec3(
+    fbmNoise(seed + 17, p, 3, 0.7, 0.6),
+    fbmNoise(seed + 53, p, 3, 0.7, 0.6),
+    fbmNoise(seed + 97, p, 3, 0.7, 0.6)
+  );
+}
+
+export function curlNoise(seed: number, p: Vec3, eps = 0.25): Vec3 {
+  const px = [p[0] + eps, p[1], p[2]] as Vec3;
+  const mx = [p[0] - eps, p[1], p[2]] as Vec3;
+  const py = [p[0], p[1] + eps, p[2]] as Vec3;
+  const my = [p[0], p[1] - eps, p[2]] as Vec3;
+  const pz = [p[0], p[1], p[2] + eps] as Vec3;
+  const mz = [p[0], p[1], p[2] - eps] as Vec3;
+
+  const a = vectorPotential(seed, px);
+  const b = vectorPotential(seed, mx);
+  const c = vectorPotential(seed, py);
+  const d = vectorPotential(seed, my);
+  const e = vectorPotential(seed, pz);
+  const f = vectorPotential(seed, mz);
+
+  const dx = [(a[1] - b[1]) / (2 * eps), (a[2] - b[2]) / (2 * eps)];
+  const dy = [(c[0] - d[0]) / (2 * eps), (c[2] - d[2]) / (2 * eps)];
+  const dz = [(e[0] - f[0]) / (2 * eps), (e[1] - f[1]) / (2 * eps)];
+
+  return vec3(dy[1] - dz[1], dz[0] - dx[1], dx[0] - dy[0]);
+}

--- a/tunnelcave_sandbox_web/lib/prng.ts
+++ b/tunnelcave_sandbox_web/lib/prng.ts
@@ -1,0 +1,41 @@
+export type HashInput = number | readonly number[];
+
+export function hashMix(seed: HashInput): number {
+  const arr = Array.isArray(seed) ? seed : [seed];
+  let h = 1779033703 ^ arr.length;
+  for (let i = 0; i < arr.length; i += 1) {
+    let k = Math.imul(arr[i] | 0, 3432918353);
+    k = (k << 15) | (k >>> 17);
+    k = Math.imul(k, 461845907);
+    h ^= k;
+    h = (h << 13) | (h >>> 19);
+    h = Math.imul(h, 5) + 3864292196;
+  }
+  h ^= h >>> 16;
+  h = Math.imul(h, 2246822507);
+  h ^= h >>> 13;
+  h = Math.imul(h, 3266489909);
+  h ^= h >>> 16;
+  return h >>> 0;
+}
+
+export function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function randRange(rand: () => number, min: number, max: number): number {
+  return min + (max - min) * rand();
+}
+
+export function randUnitVector(rand: () => number): [number, number, number] {
+  const z = rand() * 2 - 1;
+  const theta = rand() * Math.PI * 2;
+  const r = Math.sqrt(Math.max(0, 1 - z * z));
+  return [r * Math.cos(theta), r * Math.sin(theta), z];
+}

--- a/tunnelcave_sandbox_web/lib/probe.ts
+++ b/tunnelcave_sandbox_web/lib/probe.ts
@@ -1,0 +1,76 @@
+import type { RingStation } from "./terrain";
+import { add, normalize, scale, Vec3 } from "./vector";
+
+function radialDistance(ring: RingStation, angle: number): number {
+  const radius = ring.radius + ring.roughness(angle);
+  return Math.max(0.5, radius);
+}
+
+export interface RingClearance {
+  minDiameter: number;
+  meanDiameter: number;
+  stdDiameter: number;
+  bestAngle: number;
+}
+
+export function analyzeRing(ring: RingStation, samples = 16): RingClearance {
+  const diameters: number[] = [];
+  let best = { diameter: 0, angle: 0 };
+  for (let i = 0; i < samples; i += 1) {
+    const theta = (i / samples) * Math.PI * 2;
+    const diameter = radialDistance(ring, theta) + radialDistance(ring, theta + Math.PI);
+    diameters.push(diameter);
+    if (diameter > best.diameter) {
+      best = { diameter, angle: theta };
+    }
+  }
+  const sum = diameters.reduce((acc, v) => acc + v, 0);
+  const mean = sum / diameters.length;
+  const variance = diameters.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) / diameters.length;
+  return {
+    minDiameter: Math.min(...diameters),
+    meanDiameter: mean,
+    stdDiameter: Math.sqrt(variance),
+    bestAngle: best.angle
+  };
+}
+
+export interface SpawnPose {
+  ringIndex: number;
+  position: Vec3;
+  forward: Vec3;
+  right: Vec3;
+  up: Vec3;
+  rollHint: number;
+}
+
+export function chooseSpawn(rings: RingStation[], craftRadius: number): SpawnPose | null {
+  let bestScore = -Infinity;
+  let best: { ring: RingStation; clearance: RingClearance } | null = null;
+  for (const ring of rings) {
+    const clearance = analyzeRing(ring);
+    const margin = clearance.minDiameter * 0.5 - craftRadius;
+    if (margin < 0.5) {
+      continue;
+    }
+    const score = clearance.meanDiameter - clearance.stdDiameter * 0.5 + margin * 2;
+    if (score > bestScore) {
+      bestScore = score;
+      best = { ring, clearance };
+    }
+  }
+  if (!best) {
+    return null;
+  }
+  const { ring, clearance } = best;
+  const angle = clearance.bestAngle;
+  const offset = add(
+    scale(ring.frame.right, Math.cos(angle) * (clearance.minDiameter * 0.25)),
+    scale(ring.frame.up, Math.sin(angle) * (clearance.minDiameter * 0.25))
+  );
+  const position = add(ring.position, offset);
+  const forward = ring.frame.forward;
+  const right = normalize(scale(ring.frame.right, Math.cos(angle)));
+  const up = normalize(scale(ring.frame.up, Math.sin(angle)));
+  return { ringIndex: ring.index, position, forward, right, up, rollHint: angle };
+}

--- a/tunnelcave_sandbox_web/lib/streaming.ts
+++ b/tunnelcave_sandbox_web/lib/streaming.ts
@@ -1,0 +1,29 @@
+import type { SandboxParams } from "./config";
+import { createTerrainGenerator, generateNextChunk, type ChunkData } from "./terrain";
+
+export interface ChunkBand {
+  chunks: Map<number, ChunkData>;
+  generatorState: ReturnType<typeof createTerrainGenerator>;
+}
+
+export function createChunkBand(params: SandboxParams): ChunkBand {
+  return {
+    chunks: new Map(),
+    generatorState: createTerrainGenerator(params)
+  };
+}
+
+export function ensureChunks(band: ChunkBand, centerChunk: number, keepBefore = 2, keepAfter = 3) {
+  const min = Math.max(0, centerChunk - keepBefore);
+  const max = centerChunk + keepAfter;
+  const { generatorState } = band;
+  while (generatorState.nextChunkIndex <= max) {
+    const chunk = generateNextChunk(generatorState);
+    band.chunks.set(chunk.chunkIndex, chunk);
+  }
+  for (const key of [...band.chunks.keys()]) {
+    if (key < min || key > max) {
+      band.chunks.delete(key);
+    }
+  }
+}

--- a/tunnelcave_sandbox_web/lib/terrain.ts
+++ b/tunnelcave_sandbox_web/lib/terrain.ts
@@ -1,0 +1,151 @@
+import type { SandboxParams } from "./config";
+import { createDirectionState, stepDirection } from "./directionField";
+import { mulberry32 } from "./prng";
+import { createInitialFrame, transportFrame, type OrthonormalFrame } from "./frame";
+import { add, normalize, scale, Vec3 } from "./vector";
+
+export interface RingStation {
+  index: number;
+  position: Vec3;
+  frame: OrthonormalFrame;
+  radius: number;
+  roughness: (theta: number) => number;
+}
+
+export interface ChunkData {
+  chunkIndex: number;
+  rings: RingStation[];
+  positions: Float32Array;
+  normals: Float32Array;
+  indices: Uint32Array;
+  bbox: { min: Vec3; max: Vec3 };
+}
+
+interface GeneratorState {
+  params: SandboxParams;
+  directionState: ReturnType<typeof createDirectionState>;
+  rand: () => number;
+  ringIndex: number;
+  position: Vec3;
+  frame: OrthonormalFrame;
+  nextChunkIndex: number;
+}
+
+export function createTerrainGenerator(params: SandboxParams): GeneratorState {
+  const rand = mulberry32(params.worldSeed);
+  const directionState = createDirectionState(params);
+  const position: Vec3 = [0, 0, 0];
+  const frame = createInitialFrame(directionState.forward);
+  return { params, directionState, rand, ringIndex: 0, position, frame, nextChunkIndex: 0 };
+}
+
+function integrateRing(state: GeneratorState): RingStation {
+  const { params, directionState, rand } = state;
+  const sample = stepDirection(params, directionState, state.position, rand);
+  const delta = scale(sample.forward, params.ringStep);
+  state.position = add(state.position, delta);
+  state.frame = transportFrame(state.frame, sample.forward);
+  const station: RingStation = {
+    index: state.ringIndex,
+    position: state.position,
+    frame: state.frame,
+    radius: sample.radius,
+    roughness: sample.roughness
+  };
+  state.ringIndex += 1;
+  return station;
+}
+
+function computeBbox(points: number[]): { min: Vec3; max: Vec3 } {
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+  for (let i = 0; i < points.length; i += 3) {
+    const x = points[i];
+    const y = points[i + 1];
+    const z = points[i + 2];
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    minZ = Math.min(minZ, z);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+    maxZ = Math.max(maxZ, z);
+  }
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+function buildRingVertices(ring: RingStation, params: SandboxParams): Vec3[] {
+  const vertices: Vec3[] = [];
+  const { frame } = ring;
+  for (let i = 0; i < params.tubeSides; i += 1) {
+    const theta = (i / params.tubeSides) * Math.PI * 2;
+    const radius = ring.radius + ring.roughness(theta);
+    const offset = add(scale(frame.right, Math.cos(theta) * radius), scale(frame.up, Math.sin(theta) * radius));
+    vertices.push(add(ring.position, offset));
+  }
+  return vertices;
+}
+
+function subtract(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function buildChunkGeometry(rings: RingStation[], params: SandboxParams) {
+  const vertices: number[] = [];
+  const normals: number[] = [];
+  const indices: number[] = [];
+  const ringVerts: Vec3[][] = rings.map((ring) => buildRingVertices(ring, params));
+  for (let r = 0; r < ringVerts.length; r += 1) {
+    const verts = ringVerts[r];
+    for (let v = 0; v < verts.length; v += 1) {
+      const p = verts[v];
+      vertices.push(p[0], p[1], p[2]);
+      const center = rings[r].position;
+      const normal = normalize(subtract(p, center));
+      normals.push(normal[0], normal[1], normal[2]);
+    }
+  }
+  const stride = params.tubeSides;
+  for (let r = 0; r < ringVerts.length - 1; r += 1) {
+    for (let v = 0; v < stride; v += 1) {
+      const nextV = (v + 1) % stride;
+      const a = r * stride + v;
+      const b = r * stride + nextV;
+      const c = (r + 1) * stride + v;
+      const d = (r + 1) * stride + nextV;
+      indices.push(a, c, b);
+      indices.push(b, c, d);
+    }
+  }
+  const bbox = computeBbox(vertices);
+  return {
+    positions: new Float32Array(vertices),
+    normals: new Float32Array(normals),
+    indices: new Uint32Array(indices),
+    bbox
+  };
+}
+
+export function generateNextChunk(state: GeneratorState): ChunkData {
+  const { params, nextChunkIndex } = state;
+  const rings: RingStation[] = [];
+  const targetCount = Math.round(params.chunkLength / params.ringStep) + 1;
+  for (let i = 0; i < targetCount; i += 1) {
+    const ring = integrateRing(state);
+    rings.push(ring);
+  }
+  const geometry = buildChunkGeometry(rings, params);
+  const chunk: ChunkData = {
+    chunkIndex: nextChunkIndex,
+    rings,
+    positions: geometry.positions,
+    normals: geometry.normals,
+    indices: geometry.indices,
+    bbox: geometry.bbox
+  };
+  state.nextChunkIndex += 1;
+  return chunk;
+}

--- a/tunnelcave_sandbox_web/lib/vector.ts
+++ b/tunnelcave_sandbox_web/lib/vector.ts
@@ -1,0 +1,77 @@
+export type Vec3 = [number, number, number];
+
+export function vec3(x = 0, y = 0, z = 0): Vec3 {
+  return [x, y, z];
+}
+
+export function copy(v: Vec3): Vec3 {
+  return [v[0], v[1], v[2]];
+}
+
+export function add(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+export function sub(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+export function scale(v: Vec3, s: number): Vec3 {
+  return [v[0] * s, v[1] * s, v[2] * s];
+}
+
+export function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+export function cross(a: Vec3, b: Vec3): Vec3 {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0]
+  ];
+}
+
+export function length(v: Vec3): number {
+  return Math.hypot(v[0], v[1], v[2]);
+}
+
+export function normalize(v: Vec3): Vec3 {
+  const len = length(v);
+  if (len === 0) {
+    return [0, 0, 0];
+  }
+  const inv = 1 / len;
+  return [v[0] * inv, v[1] * inv, v[2] * inv];
+}
+
+export function lerp(a: Vec3, b: Vec3, t: number): Vec3 {
+  return [
+    a[0] + (b[0] - a[0]) * t,
+    a[1] + (b[1] - a[1]) * t,
+    a[2] + (b[2] - a[2]) * t
+  ];
+}
+
+export function rotateAroundAxis(v: Vec3, axis: Vec3, angle: number): Vec3 {
+  const k = normalize(axis);
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const term1 = scale(v, cos);
+  const term2 = scale(cross(k, v), sin);
+  const term3 = scale(k, dot(k, v) * (1 - cos));
+  return add(add(term1, term2), term3);
+}
+
+export function projectOnPlane(v: Vec3, normal: Vec3): Vec3 {
+  const n = normalize(normal);
+  return sub(v, scale(n, dot(v, n)));
+}
+
+export function angleBetween(a: Vec3, b: Vec3): number {
+  const denom = length(a) * length(b);
+  if (denom === 0) {
+    return 0;
+  }
+  return Math.acos(Math.min(1, Math.max(-1, dot(a, b) / denom)));
+}

--- a/tunnelcave_sandbox_web/lib/world.ts
+++ b/tunnelcave_sandbox_web/lib/world.ts
@@ -1,0 +1,136 @@
+import type { SandboxParams } from "./config";
+import { createChunkBand, ensureChunks, type ChunkBand } from "./streaming";
+import { chooseSpawn, type SpawnPose } from "./probe";
+import type { RingStation } from "./terrain";
+import { createCameraRig, type CameraParams, type CameraRig, updateCameraRig } from "./camera";
+import { add, cross, length, normalize, scale, Vec3, lerp } from "./vector";
+
+export interface SimulationParams {
+  sandbox: SandboxParams;
+  camera: CameraParams;
+  craftRadius: number;
+}
+
+export interface CraftState {
+  arc: number;
+  speed: number;
+  targetSpeed: number;
+  roll: number;
+  rollRate: number;
+  position: Vec3;
+  forward: Vec3;
+  right: Vec3;
+  up: Vec3;
+}
+
+export interface SimulationState {
+  band: ChunkBand;
+  camera: CameraRig;
+  craft: CraftState;
+  spawn: SpawnPose;
+}
+
+export interface PlayerInput {
+  throttleDelta: number;
+  rollDelta: number;
+}
+
+function collectRings(band: ChunkBand): RingStation[] {
+  const rings: RingStation[] = [];
+  for (const chunk of band.chunks.values()) {
+    rings.push(...chunk.rings);
+  }
+  rings.sort((a, b) => a.index - b.index);
+  return rings;
+}
+
+function interpolateRing(rings: RingStation[], arc: number): {
+  position: Vec3;
+  forward: Vec3;
+  right: Vec3;
+  up: Vec3;
+} {
+  const ringIndex = Math.floor(arc);
+  const nextIndex = Math.min(rings[rings.length - 1].index, ringIndex + 1);
+  const base = rings.find((r) => r.index === ringIndex) ?? rings[0];
+  const next = rings.find((r) => r.index === nextIndex) ?? base;
+  const t = Math.min(1, Math.max(0, arc - ringIndex));
+  const position: Vec3 = lerp(base.position, next.position, t);
+  const forward = normalize(lerp(base.frame.forward, next.frame.forward, t));
+  let right = lerp(base.frame.right, next.frame.right, t);
+  right = normalize(right);
+  let up = cross(forward, right);
+  const upLen = length(up);
+  if (upLen === 0) {
+    up = base.frame.up;
+  } else {
+    up = scale(up, 1 / upLen);
+  }
+  right = cross(up, forward);
+  return { position, forward, right, up };
+}
+
+function applyRoll(right: Vec3, up: Vec3, forward: Vec3, roll: number) {
+  const cos = Math.cos(roll);
+  const sin = Math.sin(roll);
+  const newRight: Vec3 = [
+    right[0] * cos + up[0] * sin,
+    right[1] * cos + up[1] * sin,
+    right[2] * cos + up[2] * sin
+  ];
+  const newUp: Vec3 = [
+    up[0] * cos - right[0] * sin,
+    up[1] * cos - right[1] * sin,
+    up[2] * cos - right[2] * sin
+  ];
+  return { right: newRight, up: newUp, forward };
+}
+
+export function createSimulation(params: SimulationParams): SimulationState {
+  const band = createChunkBand(params.sandbox);
+  ensureChunks(band, 0);
+  const rings = collectRings(band);
+  const spawn = chooseSpawn(rings, params.craftRadius);
+  if (!spawn) {
+    throw new Error("Failed to find spawn ring");
+  }
+  const craft: CraftState = {
+    arc: spawn.ringIndex,
+    speed: 15,
+    targetSpeed: 15,
+    roll: spawn.rollHint,
+    rollRate: 0,
+    position: spawn.position,
+    forward: spawn.forward,
+    right: spawn.right,
+    up: spawn.up
+  };
+  const camera = createCameraRig(add(spawn.position, scale(spawn.forward, -10)));
+  return { band, camera, craft, spawn };
+}
+
+export function updateSimulation(
+  state: SimulationState,
+  params: SimulationParams,
+  input: PlayerInput,
+  dt: number
+) {
+  const { craft, band } = state;
+  craft.targetSpeed = Math.max(2, Math.min(80, craft.targetSpeed + input.throttleDelta * dt * 15));
+  craft.speed += (craft.targetSpeed - craft.speed) * Math.min(1, dt * 2);
+  craft.rollRate += input.rollDelta * dt * 2.5;
+  craft.rollRate *= Math.pow(0.4, dt);
+  craft.roll = Math.max(-Math.PI / 3, Math.min(Math.PI / 3, craft.roll + craft.rollRate * dt));
+  const deltaArc = (craft.speed * dt) / params.sandbox.ringStep;
+  craft.arc += deltaArc;
+  const centerChunk = Math.floor((craft.arc * params.sandbox.ringStep) / params.sandbox.chunkLength);
+  ensureChunks(band, centerChunk);
+  const rings = collectRings(band);
+  const sample = interpolateRing(rings, craft.arc);
+  const rolled = applyRoll(sample.right, sample.up, sample.forward, craft.roll);
+  craft.position = sample.position;
+  craft.forward = rolled.forward;
+  craft.right = rolled.right;
+  craft.up = rolled.up;
+  updateCameraRig(state.camera, craft.position, craft.forward, craft.right, craft.up, params.camera, dt);
+}

--- a/tunnelcave_sandbox_web/next-env.d.ts
+++ b/tunnelcave_sandbox_web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tunnelcave_sandbox_web/next.config.js
+++ b/tunnelcave_sandbox_web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/tunnelcave_sandbox_web/package.json
+++ b/tunnelcave_sandbox_web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "tunnelcave-sandbox-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "three": "0.155.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.8.6",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "typescript": "5.2.2"
+  }
+}

--- a/tunnelcave_sandbox_web/styles/globals.css
+++ b/tunnelcave_sandbox_web/styles/globals.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: dark;
+  background-color: #030712;
+  color: #f9fafb;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+}

--- a/tunnelcave_sandbox_web/tsconfig.json
+++ b/tunnelcave_sandbox_web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a standalone `tunnelcave_sandbox_web` Next.js app that renders the endless cave sandbox entirely in React + three.js
- port the deterministic noise, frame transport, spawn probing, and chunk streaming logic to TypeScript modules under the web sandbox
- document how to run the browser sandbox from the new Next.js project in the repository README

## Testing
- npm install *(fails in CI due to restricted access to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaef0414c8329b786dc65d38fecb8