### PR TITLE
Retune cavern profile to reconnect twin tunnels

### DIFF
--- a/tunnelcave_sandbox/profile.py
+++ b/tunnelcave_sandbox/profile.py
@@ -24,18 +24,18 @@ class CavernProfileParams:
 
 
 def default_cavern_profile() -> CavernProfileParams:
-    """Return a profile that yields three interlinked caverns."""
+    """Return a profile that yields two caverns that braid together."""
 
     return CavernProfileParams(
         base_scale=1.35,
-        lobe_centers=(math.pi / 2.0, 3.0 * math.pi / 2.0, 0.0),
-        lobe_strengths=(0.85, 0.85, 0.55),
-        lobe_width=0.9,
-        fractal_octaves=4,
-        fractal_gain=0.55,
+        lobe_centers=(math.pi / 2.0, 3.0 * math.pi / 2.0),
+        lobe_strengths=(0.95, 0.95),
+        lobe_width=1.15,
+        fractal_octaves=0,
+        fractal_gain=0.0,
         fractal_lacunarity=2.1,
-        twist_frequency=0.018,
-        twist_strength=0.65,
+        twist_frequency=0.03,
+        twist_strength=0.72,
     )
 
 

--- a/tunnelcave_sandbox_web/lib/config.ts
+++ b/tunnelcave_sandbox_web/lib/config.ts
@@ -44,14 +44,14 @@ export const defaultParams: SandboxParams = {
   joltStrength: 0.45,
   maxTurnPerStepRad: Math.PI / 6,
   profile: {
-    baseScale: 1.4,
-    lobeCenters: [Math.PI / 2, (3 * Math.PI) / 2, 0],
-    lobeStrengths: [0.85, 0.85, 0.6],
-    lobeWidth: 0.9,
-    fractalOctaves: 4,
-    fractalGain: 0.55,
+    baseScale: 1.35,
+    lobeCenters: [Math.PI / 2, (3 * Math.PI) / 2],
+    lobeStrengths: [0.95, 0.95],
+    lobeWidth: 1.15,
+    fractalOctaves: 0,
+    fractalGain: 0,
     fractalLacunarity: 2.1,
-    twistFrequency: 0.02,
-    twistStrength: 0.6
+    twistFrequency: 0.03,
+    twistStrength: 0.72
   }
 };


### PR DESCRIPTION
## Summary
- drop the third lobe from the cavern profile so only the original pair of tunnels remain
- widen and strengthen the two lobes while increasing twist to let them overlap into a shared connector
- mirror the updated two-lobe parameters in the web sandbox configuration for visual parity
- disable the fractal roughness parameters in both simulators so the tunnel interior renders without noisy protrusions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc88d99c883298570c6dce6c1fce3