### PR TITLE
Add smoothing controls to tunnel roughness

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm run dev
 
 By default the dev server listens on [`http://localhost:3000`](http://localhost:3000). Open the page to load the sandbox, then use **W/S** to adjust throttle, **A/D** to bank, **Shift** to tighten the follow camera, and **Space** to level the craft. The entire pipeline lives within the Next.js app, so it can be deployed to any static Next-friendly host without referencing the Python or Go stacks.
 
-The latest generator revamps the cave cross-section into a triple-lobe cavern: stacked north–south chambers stitched together by a twisting connector tunnel, with multi-octave rock noise layering fractal boulders onto every wall. The base radius is scaled up and streamed chunks remain deterministic, so existing spawn planning and occlusion-aware camera logic continue to function while the world feels more expansive.
+The latest generator revamps the cave cross-section into a triple-lobe cavern: stacked north–south chambers stitched together by a twisting connector tunnel, with multi-octave rock noise layering fractal boulders onto every wall. The base radius is scaled up and streamed chunks remain deterministic, so existing spawn planning and occlusion-aware camera logic continue to function while the world feels more expansive. Roughness now reuses the previous ring’s profile via an exponential smoother (`rough_smoothness`) and an optional angular filter, keeping neighboring frames coherent without sacrificing determinism.
 
 
 ## Viewer connection banner

--- a/tests/test_terrain_generator.py
+++ b/tests/test_terrain_generator.py
@@ -1,0 +1,75 @@
+import math
+from pathlib import Path
+import sys
+from typing import Tuple
+
+import pytest
+
+# Ensure the tunnelcave package is importable when running tests from repo root.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tunnelcave_sandbox.profile import default_cavern_profile  # noqa: E402
+from tunnelcave_sandbox.terrain_generator import (  # noqa: E402
+    TunnelParams,
+    TunnelTerrainGenerator,
+)
+
+
+def _make_params(**overrides: object) -> TunnelParams:
+    base = dict(
+        world_seed=1234,
+        chunk_length=30.0,
+        ring_step=3.0,
+        tube_sides=16,
+        dir_freq=0.05,
+        dir_blend=0.65,
+        radius_base=8.0,
+        radius_var=0.0,
+        radius_freq=0.0,
+        rough_amp=0.9,
+        rough_freq=0.1,
+        rough_smoothness=0.0,
+        rough_filter_kernel=None,
+        jolt_every_meters=10_000.0,
+        jolt_strength=0.0,
+        max_turn_per_step_rad=math.radians(5.0),
+        mode="mesh",
+        profile=default_cavern_profile(),
+    )
+    base.update(overrides)
+    return TunnelParams(**base)
+
+
+def _avg_abs_diff(a: Tuple[float, ...], b: Tuple[float, ...]) -> float:
+    return sum(abs(x - y) for x, y in zip(a, b)) / len(a)
+
+
+class TestTunnelTerrainGenerator:
+    def test_roughness_smoothing_reduces_jump_between_rings(self) -> None:
+        no_smoothing_params = _make_params(rough_smoothness=0.0)
+        no_smoothing_gen = TunnelTerrainGenerator(no_smoothing_params)
+        no_smoothing_gen.generate_chunk(0)
+        raw_rings = no_smoothing_gen.rings()
+        baseline_diff = _avg_abs_diff(
+            raw_rings[0].roughness_profile, raw_rings[1].roughness_profile
+        )
+
+        smoothed_params = _make_params(rough_smoothness=0.85)
+        smoothed_gen = TunnelTerrainGenerator(smoothed_params)
+        smoothed_gen.generate_chunk(0)
+        smoothed_rings = smoothed_gen.rings()
+        smoothed_diff = _avg_abs_diff(
+            smoothed_rings[0].roughness_profile, smoothed_rings[1].roughness_profile
+        )
+
+        assert smoothed_diff < baseline_diff
+
+    def test_invalid_smoothness_range_is_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            TunnelTerrainGenerator(_make_params(rough_smoothness=-0.1))
+
+        with pytest.raises(ValueError):
+            TunnelTerrainGenerator(_make_params(rough_smoothness=1.1))
+

--- a/tunnelcave_sandbox/sandbox_demo.py
+++ b/tunnelcave_sandbox/sandbox_demo.py
@@ -24,6 +24,8 @@ def build_default_params() -> TunnelParams:
         radius_freq=0.008,
         rough_amp=1.1,
         rough_freq=0.1,
+        rough_smoothness=0.45,
+        rough_filter_kernel=(0.2, 0.6, 0.2),
         jolt_every_meters=140.0,
         jolt_strength=0.3,
         max_turn_per_step_rad=0.7,

--- a/tunnelcave_sandbox/terrain_generator.py
+++ b/tunnelcave_sandbox/terrain_generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from .direction_field import DivergenceFreeField, FieldParams
 from .frame import OrthonormalFrame
@@ -31,6 +31,8 @@ class TunnelParams:
     max_turn_per_step_rad: float
     mode: str
     profile: CavernProfileParams = field(default_factory=default_cavern_profile)
+    rough_smoothness: float = 0.0
+    rough_filter_kernel: Optional[Tuple[float, ...]] = None
 
 
 class TunnelTerrainGenerator:
@@ -43,6 +45,18 @@ class TunnelTerrainGenerator:
             raise ValueError("roughness amplitude must be smaller than base radius")
         if len(params.profile.lobe_centers) != len(params.profile.lobe_strengths):
             raise ValueError("lobe_centers and lobe_strengths must have the same length")
+        if not 0.0 <= params.rough_smoothness <= 1.0:
+            raise ValueError("rough_smoothness must be between 0 and 1")
+
+        kernel = params.rough_filter_kernel
+        if kernel is not None:
+            if len(kernel) == 0:
+                raise ValueError("rough_filter_kernel must not be empty when provided")
+            if all(weight == 0.0 for weight in kernel):
+                raise ValueError("rough_filter_kernel must contain a non-zero weight")
+            self._rough_filter_kernel: Optional[Tuple[float, ...]] = tuple(kernel)
+        else:
+            self._rough_filter_kernel = None
 
         self._params = params
         field_params = FieldParams(
@@ -57,6 +71,7 @@ class TunnelTerrainGenerator:
         self._global_rings: List[RingSample] = []
         self._global_s_positions: List[float] = []
         self._rings_per_chunk = int(round(params.chunk_length / params.ring_step)) + 1
+        self._prev_roughness_profile: Optional[Tuple[float, ...]] = None
         self._ensure_ring(0)
 
     def generate_chunk(self, chunk_index: int) -> ChunkGeometry:
@@ -129,6 +144,7 @@ class TunnelTerrainGenerator:
         twist = twist_angle(params.world_seed + 5000, profile, arc_length)
         values: List[float] = []
         max_radius = scaled_radius
+        min_radius = scaled_radius * 0.8
         for side in range(sides):
             angle = (side / sides) * math.tau
             shifted_angle = angle + twist
@@ -143,10 +159,42 @@ class TunnelTerrainGenerator:
                 params.rough_freq,
             )
             radius = cavern_radius + params.rough_amp * rock_detail
-            radius = max(radius, scaled_radius * 0.8)
+            radius = max(radius, min_radius)
             values.append(radius)
             max_radius = max(max_radius, radius)
-        return tuple(values), max_radius
+
+        previous_profile = self._prev_roughness_profile
+        smoothness = params.rough_smoothness
+        if previous_profile is not None and smoothness > 0.0:
+            blend = 1.0 - smoothness
+            smoothed: List[float] = []
+            for idx, raw_value in enumerate(values):
+                prev_value = previous_profile[idx % len(previous_profile)]
+                blended = prev_value * smoothness + raw_value * blend
+                smoothed.append(max(blended, min_radius))
+            values = smoothed
+
+        if self._rough_filter_kernel is not None:
+            kernel = self._rough_filter_kernel
+            assert kernel is not None  # for type checkers
+            kernel_sum = sum(kernel)
+            if kernel_sum == 0.0:
+                filtered = values
+            else:
+                center = len(kernel) // 2
+                filtered = []
+                for idx in range(sides):
+                    acc = 0.0
+                    for offset, weight in enumerate(kernel):
+                        neighbor = (idx + offset - center) % sides
+                        acc += values[neighbor] * weight
+                    filtered.append(max(acc / kernel_sum, min_radius))
+            values = filtered
+
+        final_max = max(values, default=min_radius)
+        result = tuple(values)
+        self._prev_roughness_profile = result
+        return result, max(final_max, scaled_radius)
 
     def _build_mesh(self, rings: Tuple[RingSample, ...]) -> MeshChunk:
         vertices: List[Vector3] = []


### PR DESCRIPTION
## Summary
- cache the previous ring roughness profile and blend new samples using a configurable smoother
- add an optional angular filter and thread the rough_smoothness parameter through demo defaults and docs
- cover the new smoothing behavior with targeted unit tests

## Testing
- pytest tests/test_terrain_generator.py
- PYTHONPATH=python-sim pytest python-sim/tests

------
https://chatgpt.com/codex/tasks/task_e_68dcd95461208329abf54396f2ce3a6d