### PR TITLE
Add pipe network direction field option

### DIFF
--- a/docs/pipe-network-field.md
+++ b/docs/pipe-network-field.md
@@ -1,0 +1,60 @@
+# Pipe Network Direction Field
+
+The tunnel sandbox now supports a deterministic pipe-layout field in addition to
+its original divergence-free curl-noise field. The `PipeNetworkField` stitches
+straight runs, junction arcs, and smooth helixes into a repeatable sequence that
+stays connected across long distances.
+
+## Selecting the field
+
+Choose the field by setting `TunnelParams.field_type` to `"pipe_network"`. The
+field accepts an optional `PipeNetworkParams` structure that controls the basic
+module lengths and curvature. The defaults already produce a varied layout, but
+explicit configuration makes the sequence easier to reason about:
+
+```python
+from tunnelcave_sandbox.direction_field import PipeNetworkParams
+from tunnelcave_sandbox.terrain_generator import TunnelParams
+
+params = TunnelParams(
+    world_seed=2024,
+    chunk_length=24.0,
+    ring_step=3.0,
+    tube_sides=8,
+    dir_freq=0.05,
+    dir_blend=0.5,
+    radius_base=5.0,
+    radius_var=0.6,
+    radius_freq=0.02,
+    rough_amp=0.25,
+    rough_freq=0.12,
+    jolt_every_meters=0.0,
+    jolt_strength=0.0,
+    max_turn_per_step_rad=0.85,
+    mode="mesh+sdf",
+    field_type="pipe_network",
+    pipe_network=PipeNetworkParams(
+        straight_length=10.0,
+        helix_turns=1.5,
+        helix_pitch=2.5,
+        helix_radius=7.5,
+        junction_angle_deg=60.0,
+        junction_radius=8.0,
+    ),
+)
+```
+
+With this configuration the `TunnelTerrainGenerator` follows the deterministic
+pipe network and emits rings exactly on the analytic path.
+
+## Expected characteristics
+
+* **Repeatable** – The path only depends on `world_seed` and the
+  `PipeNetworkParams`, so re-instantiating the generator recreates the same
+  topology.
+* **Smoothly connected** – Straight segments, helical coils, and junction arcs
+  share tangents at their boundaries to avoid kinks, which keeps ring frames
+  aligned chunk-to-chunk.
+* **Position hints** – `PipeNetworkField` exposes `position_at(arc_length)` so
+  the terrain generator places each ring directly on the analytic curve rather
+  than integrating the direction numerically.

--- a/tests/test_pipe_network_field.py
+++ b/tests/test_pipe_network_field.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tunnelcave_sandbox.direction_field import FieldParams, PipeNetworkField, PipeNetworkParams
+from tunnelcave_sandbox.terrain_generator import TunnelParams, TunnelTerrainGenerator
+
+
+def make_params(pipe_params: PipeNetworkParams) -> TunnelParams:
+    return TunnelParams(
+        world_seed=1337,
+        chunk_length=18.0,
+        ring_step=3.0,
+        tube_sides=6,
+        dir_freq=0.05,
+        dir_blend=0.5,
+        radius_base=4.0,
+        radius_var=0.5,
+        radius_freq=0.02,
+        rough_amp=0.2,
+        rough_freq=0.15,
+        jolt_every_meters=0.0,
+        jolt_strength=0.0,
+        max_turn_per_step_rad=0.75,
+        mode="mesh",
+        field_type="pipe_network",
+        pipe_network=pipe_params,
+    )
+
+
+def _collect_rings(generator: TunnelTerrainGenerator, chunk_count: int) -> list:
+    for idx in range(chunk_count):
+        generator.generate_chunk(idx)
+    return list(generator.rings())
+
+
+def test_pipe_network_field_repeatable_and_smooth() -> None:
+    pipe_params = PipeNetworkParams(
+        module_count_hint=16,
+        straight_length=9.0,
+        helix_turns=1.25,
+        helix_pitch=2.75,
+        helix_radius=6.5,
+        junction_angle_deg=55.0,
+        junction_radius=7.5,
+    )
+    params = make_params(pipe_params)
+    generator_a = TunnelTerrainGenerator(params)
+    generator_b = TunnelTerrainGenerator(params)
+
+    rings_a = _collect_rings(generator_a, chunk_count=4)
+    rings_b = _collect_rings(generator_b, chunk_count=4)
+
+    assert len(rings_a) == len(rings_b) > 0
+
+    for a, b in zip(rings_a, rings_b):
+        assert a.center.x == pytest.approx(b.center.x, abs=1e-6)
+        assert a.center.y == pytest.approx(b.center.y, abs=1e-6)
+        assert a.center.z == pytest.approx(b.center.z, abs=1e-6)
+        forward_dot = max(-1.0, min(1.0, a.forward.dot(b.forward)))
+        assert math.acos(forward_dot) < 1e-6
+
+    field_params = FieldParams(
+        world_seed=params.world_seed,
+        dir_freq=params.dir_freq,
+        dir_blend=params.dir_blend,
+        max_turn_per_step_rad=params.max_turn_per_step_rad,
+        jolt_every_meters=params.jolt_every_meters,
+        jolt_strength=params.jolt_strength,
+    )
+    field = PipeNetworkField(field_params, pipe_params)
+    for index, ring in enumerate(rings_a[:16]):
+        arc_length = index * params.ring_step
+        expected = field.position_at(arc_length)
+        assert ring.center.x == pytest.approx(expected.x, abs=1e-4)
+        assert ring.center.y == pytest.approx(expected.y, abs=1e-4)
+        assert ring.center.z == pytest.approx(expected.z, abs=1e-4)
+
+    turn_angles = []
+    for prev, curr in zip(rings_a, rings_a[1:]):
+        dot = max(-1.0, min(1.0, prev.forward.dot(curr.forward)))
+        turn_angles.append(math.acos(dot))
+    assert max(turn_angles) < 0.75

--- a/tests/test_tunnel_mesh.py
+++ b/tests/test_tunnel_mesh.py
@@ -20,6 +20,7 @@ def make_params(**overrides: object) -> TunnelParams:
         jolt_strength=0.25,
         max_turn_per_step_rad=0.5,
         mode="mesh",
+        field_type="divergence_free",
     )
     base.update(overrides)
     return TunnelParams(**base)

--- a/tunnelcave_sandbox/__init__.py
+++ b/tunnelcave_sandbox/__init__.py
@@ -8,7 +8,7 @@ modules are intentionally small so every file stays well below the
 
 from .vector import Vector3
 from .noise import NoiseConfig, noise3
-from .direction_field import DivergenceFreeField
+from .direction_field import DivergenceFreeField, PipeNetworkField, PipeNetworkParams
 from .frame import OrthonormalFrame
 from .geometry import RingSample, ChunkGeometry
 from .profile import CavernProfileParams, default_cavern_profile
@@ -23,6 +23,8 @@ __all__ = [
     "NoiseConfig",
     "noise3",
     "DivergenceFreeField",
+    "PipeNetworkField",
+    "PipeNetworkParams",
     "OrthonormalFrame",
     "RingSample",
     "ChunkGeometry",

--- a/tunnelcave_sandbox/terrain_generator.py
+++ b/tunnelcave_sandbox/terrain_generator.py
@@ -5,7 +5,12 @@ import math
 from dataclasses import dataclass, field
 from typing import List, Tuple
 
-from .direction_field import DivergenceFreeField, FieldParams
+from .direction_field import (
+    DivergenceFreeField,
+    FieldParams,
+    PipeNetworkField,
+    PipeNetworkParams,
+)
 from .frame import OrthonormalFrame
 from .geometry import ChunkGeometry, MeshChunk, RingSample, SDFChunk
 from .noise import noise3
@@ -37,6 +42,8 @@ class TunnelParams:
     jolt_strength: float
     max_turn_per_step_rad: float
     mode: str
+    field_type: str = "divergence_free"
+    pipe_network: PipeNetworkParams | None = None
     add_end_caps: bool = True
     profile: CavernProfileParams = field(default_factory=default_cavern_profile)
 
@@ -61,7 +68,13 @@ class TunnelTerrainGenerator:
             jolt_every_meters=params.jolt_every_meters,
             jolt_strength=params.jolt_strength,
         )
-        self._field = DivergenceFreeField(field_params)
+        if params.field_type == "divergence_free":
+            self._field = DivergenceFreeField(field_params)
+        elif params.field_type == "pipe_network":
+            pipe_params = params.pipe_network or PipeNetworkParams()
+            self._field = PipeNetworkField(field_params, pipe_params)
+        else:
+            raise ValueError(f"Unknown field_type '{params.field_type}'")
         self._global_rings: List[RingSample] = []
         self._global_s_positions: List[float] = []
         self._rings_per_chunk = int(round(params.chunk_length / params.ring_step)) + 1
@@ -114,6 +127,11 @@ class TunnelTerrainGenerator:
         arc_length = prev_s + params.ring_step
         direction = self._field.next_direction(prev_ring.center, prev_ring.forward, index, arc_length)
         origin = prev_ring.center + direction * params.ring_step
+        if hasattr(self._field, "position_at"):
+            origin = getattr(self._field, "position_at")(arc_length)
+            delta = origin - prev_ring.center
+            if delta.length() > 1e-6:
+                direction = delta.normalized()
         frame = prev_ring.frame.transport(origin, direction)
 
         base_radius = params.radius_base + params.radius_var * noise3(


### PR DESCRIPTION
## Summary
- add a deterministic pipe-network direction field composed of straight runs, arcs, and helixes
- allow tunnel generation parameters to switch between divergence-free and pipe network fields and honour analytic positions
- document the new selector and cover it with repeatability/smoothness tests

## Testing
- pytest tests/test_pipe_network_field.py tests/test_tunnel_mesh.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd9d779788329a2c5ba54f2a83dc3