### PR TITLE
Add tunnel quality regression tests and document follow-up tasks

### DIFF
--- a/docs/tunnel_quality_tasks.md
+++ b/docs/tunnel_quality_tasks.md
@@ -1,0 +1,24 @@
+# Tunnel Quality Follow-Up Tasks
+
+The new automated tests help guard against regressions in the tunnel geometry,
+but there are still several opportunities to raise overall quality:
+
+1. **Adaptive Filter Kernels** – Experiment with kernels that vary based on the
+   local curvature or turbulence of the direction field so that straight
+   segments stay crisp while high-curvature areas receive additional smoothing.
+2. **Dynamic Radius Floor** – The current fixed ``radius_base * 0.2`` floor is
+   conservative. Investigate adaptive rules that consider the profile’s base
+   scale and recent roughness variance to better preserve large chambers
+   without risking thin passages.
+3. **Path Quality Metrics** – Introduce metrics (e.g., integrated curvature,
+   jerk, or roll oscillation) and expose them to the tests so we can track the
+   impact of future generator tweaks quantitatively.
+4. **Chunk Boundary Blending** – Implement blending between neighboring chunk
+   meshes or roughness profiles to hide subtle seams when rendering with baked
+   lighting or high-contrast shaders.
+5. **Stress Testing** – Add soak tests that sweep extreme parameter values to
+   ensure the generator remains numerically stable and keeps the skiff inside
+   safe radii even during long procedural flights.
+
+These items can guide future improvements once the current safeguards are in
+place.

--- a/tests/test_terrain_generator.py
+++ b/tests/test_terrain_generator.py
@@ -1,7 +1,7 @@
 import math
 from pathlib import Path
 import sys
-from typing import Tuple
+from typing import Iterable, Tuple
 
 import pytest
 
@@ -46,6 +46,17 @@ def _avg_abs_diff(a: Tuple[float, ...], b: Tuple[float, ...]) -> float:
     return sum(abs(x - y) for x, y in zip(a, b)) / len(a)
 
 
+def _adjacent_variation(profile: Iterable[float]) -> float:
+    values = tuple(profile)
+    if not values:
+        return 0.0
+    diffs = []
+    for idx, value in enumerate(values):
+        next_value = values[(idx + 1) % len(values)]
+        diffs.append(abs(next_value - value))
+    return sum(diffs) / len(diffs)
+
+
 class TestTunnelTerrainGenerator:
     def test_roughness_smoothing_reduces_jump_between_rings(self) -> None:
         no_smoothing_params = _make_params(rough_smoothness=0.0)
@@ -72,4 +83,48 @@ class TestTunnelTerrainGenerator:
 
         with pytest.raises(ValueError):
             TunnelTerrainGenerator(_make_params(rough_smoothness=1.1))
+
+    def test_angular_filter_kernel_reduces_profile_variation(self) -> None:
+        baseline_params = _make_params(
+            rough_amp=1.2,
+            rough_freq=0.3,
+            rough_filter_kernel=None,
+            rough_smoothness=0.0,
+        )
+        baseline_gen = TunnelTerrainGenerator(baseline_params)
+        baseline_gen.generate_chunk(0)
+        baseline_profile = baseline_gen.rings()[1].roughness_profile
+        baseline_variation = _adjacent_variation(baseline_profile)
+
+        filtered_params = _make_params(
+            rough_amp=1.2,
+            rough_freq=0.3,
+            rough_filter_kernel=(1.0, 2.0, 1.0),
+            rough_smoothness=0.0,
+        )
+        filtered_gen = TunnelTerrainGenerator(filtered_params)
+        filtered_gen.generate_chunk(0)
+        filtered_profile = filtered_gen.rings()[1].roughness_profile
+        filtered_variation = _adjacent_variation(filtered_profile)
+
+        assert filtered_variation < baseline_variation
+
+    def test_forward_rotation_respects_turn_limit(self) -> None:
+        limit_rad = math.radians(3.0)
+        params = _make_params(max_turn_per_step_rad=limit_rad)
+        generator = TunnelTerrainGenerator(params)
+        generator.generate_chunk(1)
+        rings = generator.rings()
+        for prev, curr in zip(rings, rings[1:]):
+            dot = max(-1.0, min(1.0, prev.forward.dot(curr.forward)))
+            angle = math.acos(dot)
+            assert angle <= limit_rad + 1e-5
+
+    def test_minimum_radius_respected_across_rings(self) -> None:
+        params = _make_params(radius_base=6.0, rough_amp=5.5)
+        generator = TunnelTerrainGenerator(params)
+        generator.generate_chunk(2)
+        expected_floor = params.radius_base * 0.2 * params.profile.base_scale
+        for ring in generator.rings():
+            assert min(ring.roughness_profile) >= expected_floor
 


### PR DESCRIPTION
## Summary
- add coverage for tunnel angular filtering, turn limits, and radius floor safeguards
- document follow-up tasks to continue improving tunnel quality

## Testing
- pytest tests/test_terrain_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68dcddcfc41883299d61ca502567b0ed