### PR TITLE
Implement adaptive tunnel radius floor with history tracking

### DIFF
--- a/tests/test_terrain_generator.py
+++ b/tests/test_terrain_generator.py
@@ -124,7 +124,11 @@ class TestTunnelTerrainGenerator:
         params = _make_params(radius_base=6.0, rough_amp=5.5)
         generator = TunnelTerrainGenerator(params)
         generator.generate_chunk(2)
-        expected_floor = params.radius_base * 0.2 * params.profile.base_scale
-        for ring in generator.rings():
-            assert min(ring.roughness_profile) >= expected_floor
+        floors = generator.radius_floor_history()
+        rings = generator.rings()
+        assert len(floors) == len(rings)
+        base_floor = params.radius_base * 0.12
+        for ring, floor in zip(rings, floors):
+            assert min(ring.roughness_profile) >= floor - 1e-6
+            assert floor >= base_floor
 


### PR DESCRIPTION
## Summary
- add adaptive minimum radius logic that blends base scale information with recent roughness statistics to avoid thin passages while preserving wide chambers
- persist per-ring radius floor history and expose it for tests together with moving roughness statistics
- update generator tests to assert against the adaptive floor instead of a fixed constant

## Testing
- `pytest` *(fails: integration test cannot launch Go broker in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdf45a2708329b53bbf2d296e9403