### PR TITLE
Add deterministic pipe network module planning

### DIFF
--- a/docs/pipe-network-field.md
+++ b/docs/pipe-network-field.md
@@ -10,7 +10,12 @@ stays connected across long distances.
 Choose the field by setting `TunnelParams.field_type` to `"pipe_network"`. The
 field accepts an optional `PipeNetworkParams` structure that controls the basic
 module lengths and curvature. The defaults already produce a varied layout, but
-explicit configuration makes the sequence easier to reason about:
+explicit configuration makes the sequence easier to reason about. Internally the
+field builds a deterministic *module plan* whose length is driven by
+`module_count_hint`; the plan guarantees that each cycle contains straight runs,
+helixes, and both junction arc orientations so the path never degenerates into a
+single primitive. Tweaking the pipe parameters changes how each module behaves
+while the plan keeps them smoothly stitched together:
 
 ```python
 from tunnelcave_sandbox.direction_field import PipeNetworkParams

--- a/tests/test_pipe_network_field.py
+++ b/tests/test_pipe_network_field.py
@@ -78,6 +78,14 @@ def test_pipe_network_field_repeatable_and_smooth() -> None:
         assert ring.center.y == pytest.approx(expected.y, abs=1e-4)
         assert ring.center.z == pytest.approx(expected.z, abs=1e-4)
 
+    # The module plan should include each primitive type in a single cycle so the
+    # tunnel never degenerates into a straight or purely helical run.
+    field.position_at(pipe_params.straight_length * pipe_params.module_count_hint * 2.0)
+    seen = {type(segment).__name__ for segment, _ in field._segments[: pipe_params.module_count_hint]}
+    assert "_StraightSegment" in seen
+    assert "_HelixSegment" in seen
+    assert "_ArcSegment" in seen
+
     turn_angles = []
     for prev, curr in zip(rings_a, rings_a[1:]):
         dot = max(-1.0, min(1.0, prev.forward.dot(curr.forward)))


### PR DESCRIPTION
## Summary
- precompute a deterministic module plan for `PipeNetworkField` so each cycle includes straights, arcs, and helixes
- expose the module plan behavior in the pipe network documentation and assert on it in tests

## Testing
- `pytest tests/test_pipe_network_field.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd1c6a90a08329a309de56cba2df07