### PR TITLE
Improve tunnel curve smoothing

### DIFF
--- a/tunnelcave_sandbox/terrain_generator.py
+++ b/tunnelcave_sandbox/terrain_generator.py
@@ -71,6 +71,8 @@ class TunnelParams:
     rough_smoothness: float = 0.0
     rough_filter_kernel: Optional[Tuple[float, ...]] = None
     min_clearance_radius: float = 0.0
+    curve_smoothing_distance: float = 18.0
+    curve_smoothing_steps: int = 5
 
 
 class TunnelTerrainGenerator:
@@ -89,6 +91,10 @@ class TunnelTerrainGenerator:
             raise ValueError("min_clearance_radius must be non-negative")
         if params.min_clearance_radius >= params.radius_base:
             raise ValueError("min_clearance_radius must be smaller than radius_base")
+        if params.curve_smoothing_distance < 0.0:
+            raise ValueError("curve_smoothing_distance must be non-negative")
+        if params.curve_smoothing_steps < 1:
+            raise ValueError("curve_smoothing_steps must be at least 1")
 
         kernel = params.rough_filter_kernel
         if kernel is not None:
@@ -111,6 +117,8 @@ class TunnelTerrainGenerator:
             max_turn_per_step_rad=params.max_turn_per_step_rad,
             jolt_every_meters=params.jolt_every_meters,
             jolt_strength=params.jolt_strength,
+            curve_smoothing_distance=params.curve_smoothing_distance,
+            curve_smoothing_steps=params.curve_smoothing_steps,
         )
         if params.field_type == "divergence_free":
             self._field = DivergenceFreeField(field_params)


### PR DESCRIPTION
## Summary
- add curve-smoothing controls to the tunnel direction field and maintain a persistent blended heading for gentler turns
- surface curve smoothing distance/step parameters on `TunnelParams` and pass them into field construction

## Testing
- `python -m tunnelcave_sandbox.sandbox_demo`
- `pytest tests/test_terrain_generator.py tests/test_pipe_network_field.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd24a6dafc83299dc8e087d9072ce6