### PR TITLE
Add straight tunnel option to sandbox web generator

### DIFF
--- a/tunnelcave_sandbox_web/lib/config.ts
+++ b/tunnelcave_sandbox_web/lib/config.ts
@@ -14,6 +14,7 @@ export interface SandboxParams {
   chunkLength: number;
   ringStep: number;
   tubeSides: number;
+  fieldType: "straight" | "curl";
   dirFreq: number;
   dirBlend: number;
   radiusBase: number;
@@ -36,6 +37,7 @@ export const defaultParams: SandboxParams = {
   chunkLength: 90,
   ringStep: 3,
   tubeSides: 20,
+  fieldType: "straight",
   dirFreq: 0.05,
   dirBlend: 0.65,
   radiusBase: 11,


### PR DESCRIPTION
## Summary
- add a fieldType option to the web sandbox parameters and default it to "straight"
- update the direction field stepper to bypass curl noise and jolts when a straight tunnel is requested

## Testing
- not run (next lint prompts for interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68dd2d439be0832993acac28778df056