### PR TITLE
Stream straight tunnel geometry continuously

### DIFF
--- a/tunnelcave_sandbox_web/lib/config.ts
+++ b/tunnelcave_sandbox_web/lib/config.ts
@@ -14,6 +14,7 @@ export interface SandboxParams {
   chunkLength: number;
   ringStep: number;
   tubeSides: number;
+  fieldType: "straight" | "curl";
   dirFreq: number;
   dirBlend: number;
   radiusBase: number;
@@ -36,6 +37,7 @@ export const defaultParams: SandboxParams = {
   chunkLength: 90,
   ringStep: 3,
   tubeSides: 20,
+  fieldType: "straight",
   dirFreq: 0.05,
   dirBlend: 0.65,
   radiusBase: 11,
@@ -48,7 +50,7 @@ export const defaultParams: SandboxParams = {
   joltEveryMeters: 140,
   joltStrength: 0.45,
   maxTurnPerStepRad: Math.PI / 6,
-  addEndCaps: true,
+  addEndCaps: false,
   profile: {
 
     baseScale: 1.3,

--- a/tunnelcave_sandbox_web/lib/world.ts
+++ b/tunnelcave_sandbox_web/lib/world.ts
@@ -59,10 +59,13 @@ export interface PlayerInput {
 }
 
 function collectRings(band: ChunkBand): RingStation[] {
-  const rings: RingStation[] = [];
+  const dedup = new Map<number, RingStation>();
   for (const chunk of band.chunks.values()) {
-    rings.push(...chunk.rings);
+    for (const ring of chunk.rings) {
+      dedup.set(ring.index, ring);
+    }
   }
+  const rings = Array.from(dedup.values());
   rings.sort((a, b) => a.index - b.index);
   return rings;
 }


### PR DESCRIPTION
## Summary
- carry the previous ring into each generated chunk so adjacent meshes stitch together for endless streaming
- disable end caps by default and only allow the first chunk to add a cap when explicitly enabled
- deduplicate collected rings so navigation uses the most recent geometry when chunks overlap

## Testing
- npm run lint *(fails: Next.js lint command prompts for interactive setup in this environment)*
- npx tsc --noEmit *(fails: existing missing type definitions and tsconfig target requirements for Map iteration)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2d439be0832993acac28778df056