### PR TITLE
Add cave path sampling API

### DIFF
--- a/docs/infinite-curved-cave-spec.md
+++ b/docs/infinite-curved-cave-spec.md
@@ -1,0 +1,43 @@
+# Infinite Curved Cave System Concept
+
+## Overview
+This document captures the conceptual requirements for an endless, noise-driven cave network designed for high-speed racing and atmospheric exploration. The emphasis is on a procedurally generated tunnel that never repeats obviously, while remaining navigable with responsive lighting driven by the player's vehicle.
+
+## 1. Cave Geometry
+- **Central spine**: The cave is defined around a continuous parametric curve \(\vec{C}(t) = (x(t), y(t), z(t))\) where \(t \in \mathbb{R}\). The functions \(x(t)\), \(y(t)\), and \(z(t)\) vary smoothly and are modulated by low-frequency noise so that curvature changes gradually.
+- **Tubular walls**: Points on the cave wall follow
+  \[
+  \vec{P}(\theta, r, t) = \vec{C}(t) + r \cos(\theta) \vec{N}(t) + r \sin(\theta) \vec{B}(t)
+  \]
+  where:
+  - \(\vec{N}(t)\) and \(\vec{B}(t)\) are the normal and binormal vectors from the Frenet frame of \(\vec{C}(t)\),
+  - \(\theta \in [0, 2\pi)\) sweeps around the tunnel,
+  - \(r \in [0, R(t)]\) controls radius from the centerline.
+- **Variable radius**: The local radius evolves as \(R(t) = R_0 + \Delta R \cdot f(t)\) where \(f(t)\) is band-limited noise. This introduces wide chambers and narrow squeezes while staying smooth enough for racing.
+
+## 2. Endless Progression
+- **Chunked generation**: The tunnel is generated in segments indexed by integer ranges of \(t\). Re-using periodic noise inputs allows seamless tiling without visible repetition.
+- **Player recentering**: Gameplay continuously re-centers the simulation around the player or vehicle, despawning far segments and spawning ahead, so the world feels infinite while only rendering a manageable window.
+
+## 3. Racing & Exploration Considerations
+- **Curvature balance**: Noise parameters should avoid perfect straightaways and overly tight bends, keeping the track thrilling but readable at speed.
+- **Traversal flow**: Radius modulation is synchronized with curvature so that tighter curves are often accompanied by slightly larger radii, giving players maneuvering room.
+
+## 4. Illumination Model
+- **Vehicle light source**: The vehicle at position \(\vec{V}\) emits light with intensity
+  \[
+  I(\vec{P}) = \frac{L}{\lVert \vec{P} - \vec{V} \rVert^2} \max(0, \cos \theta)
+  \]
+  where \(L\) is light strength and \(\theta\) is the angle between the light direction and the surface normal.
+- **Headlamp cones**: Using cone or spotlight attenuation reinforces the directional feel of headlights, heightening tension when traveling fast through darkness.
+
+## 5. Ambient Lighting Accents
+- **Secondary glow**: Subtle emissive materials (e.g., crystals, moisture) flicker based on noise fields to hint at depth and help orientation.
+- **Dynamic contrast**: Outside the primary beam remains largely dark, increasing reliance on vehicle lights and emphasizing speed.
+
+## 6. Implementation Notes
+- **Noise seeds**: Looping or tiled noise domains (e.g., 4D simplex noise with wrapped coordinates) prevent seams at chunk boundaries.
+- **Frame coherence**: Smooth derivatives of \(\vec{C}(t)\) are critical to avoid sudden twists in the Frenet frame. Consider parallel transport frames for added stability.
+- **Optimization**: Maintain a sliding window of generated mesh segments around the player to keep performance consistent during high-speed traversal.
+
+This specification should equip collaborators or procedural generation systems with the conceptual blueprint needed to realize an infinite, curved cave suited for racing experiences.

--- a/tests/test_cave_path.py
+++ b/tests/test_cave_path.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+
+from tunnelcave_sandbox.path import CavePath
+from tunnelcave_sandbox.terrain_generator import TunnelParams, TunnelTerrainGenerator
+
+
+def make_params(**overrides: object) -> TunnelParams:
+    base = dict(
+        world_seed=7,
+        chunk_length=6.0,
+        ring_step=3.0,
+        tube_sides=6,
+        dir_freq=0.05,
+        dir_blend=0.65,
+        radius_base=5.0,
+        radius_var=0.5,
+        radius_freq=0.01,
+        rough_amp=0.2,
+        rough_freq=0.1,
+        jolt_every_meters=200.0,
+        jolt_strength=0.1,
+        max_turn_per_step_rad=0.5,
+        mode="mesh",
+        field_type="divergence_free",
+        min_clearance_radius=0.0,
+    )
+    base.update(overrides)
+    return TunnelParams(**base)
+
+
+def test_sample_matches_first_ring_at_zero() -> None:
+    params = make_params()
+    generator = TunnelTerrainGenerator(params)
+    path = CavePath(generator)
+
+    sample = path.sample(0.0)
+    first_ring = generator.rings()[0]
+
+    assert sample.frame.origin == first_ring.center
+    assert sample.frame.forward == first_ring.forward
+    assert sample.radii == first_ring.roughness_profile
+
+
+def test_sample_interpolates_between_rings() -> None:
+    params = make_params()
+    generator = TunnelTerrainGenerator(params)
+    path = CavePath(generator)
+
+    generator.ensure_arc_length(params.ring_step)
+    arc_lengths = generator.arc_lengths()
+    assert len(arc_lengths) >= 2
+
+    t = arc_lengths[1] * 0.42
+    sample = path.sample(t)
+
+    ring0, ring1 = generator.rings()[:2]
+    s0, s1 = arc_lengths[:2]
+    blend = (t - s0) / (s1 - s0)
+
+    expected_origin = ring0.center.lerp(ring1.center, blend)
+    assert (sample.frame.origin - expected_origin).length() < 1e-6
+
+    theta = 1.234
+    sides = params.tube_sides
+    angle_index = (theta % math.tau) / math.tau * sides
+    radius0 = ring0.radius_at_angle(angle_index)
+    radius1 = ring1.radius_at_angle(angle_index)
+    expected_radius = radius0 * (1.0 - blend) + radius1 * blend
+    assert abs(sample.radius_at(theta) - expected_radius) < 1e-6
+
+    wall_point = path.wall_point(t, theta)
+    axis = sample.frame.right * math.cos(theta) + sample.frame.up * math.sin(theta)
+    assert (wall_point - (sample.frame.origin + axis * expected_radius)).length() < 1e-6
+
+
+def test_wall_point_allows_custom_radius() -> None:
+    params = make_params()
+    generator = TunnelTerrainGenerator(params)
+    path = CavePath(generator)
+
+    custom_radius = 1.5
+    theta = 0.5
+    point = path.wall_point(0.0, theta, custom_radius)
+    first_ring = generator.rings()[0]
+    axis = first_ring.frame.right * math.cos(theta) + first_ring.frame.up * math.sin(theta)
+    expected = first_ring.center + axis * custom_radius
+    assert (point - expected).length() < 1e-6

--- a/tunnelcave_sandbox/__init__.py
+++ b/tunnelcave_sandbox/__init__.py
@@ -13,6 +13,7 @@ from .frame import OrthonormalFrame
 from .geometry import RingSample, ChunkGeometry
 from .profile import CavernProfileParams, default_cavern_profile
 from .terrain_generator import TunnelTerrainGenerator, TunnelParams
+from .path import CavePath, CurveSample
 from .probe import RingProbe
 from .spawn import SpawnPlanner, SpawnRequest, SpawnResult
 from .streaming import ChunkStreamer
@@ -32,6 +33,8 @@ __all__ = [
     "default_cavern_profile",
     "TunnelTerrainGenerator",
     "TunnelParams",
+    "CavePath",
+    "CurveSample",
     "RingProbe",
     "SpawnPlanner",
     "SpawnRequest",

--- a/tunnelcave_sandbox/path.py
+++ b/tunnelcave_sandbox/path.py
@@ -1,0 +1,112 @@
+"""Sampling helpers that expose the cave as a smooth parametric curve."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Tuple
+
+from .frame import OrthonormalFrame
+from .terrain_generator import TunnelTerrainGenerator
+from .vector import Vector3, orthonormalize
+
+
+@dataclass(frozen=True)
+class CurveSample:
+    """Interpolated Frenet-style frame and radius data at parameter ``t``."""
+
+    parameter: float
+    frame: OrthonormalFrame
+    radii: Tuple[float, ...]
+
+    @property
+    def min_radius(self) -> float:
+        return min(self.radii)
+
+    @property
+    def max_radius(self) -> float:
+        return max(self.radii)
+
+    def radius_at(self, theta: float) -> float:
+        """Return the tunnel radius along angle ``theta`` (radians)."""
+
+        sides = len(self.radii)
+        if sides == 0:
+            return 0.0
+        angle_index = (theta % math.tau) / math.tau * sides
+        base_index = int(math.floor(angle_index)) % sides
+        next_index = (base_index + 1) % sides
+        t = angle_index - math.floor(angle_index)
+        return self.radii[base_index] * (1.0 - t) + self.radii[next_index] * t
+
+    def point_on_wall(self, theta: float, radius: float | None = None) -> Vector3:
+        """Return a point on the cave wall."""
+
+        frame = self.frame
+        r = self.radius_at(theta) if radius is None else max(0.0, radius)
+        axis = frame.right * math.cos(theta) + frame.up * math.sin(theta)
+        return frame.origin + axis * r
+
+
+class CavePath:
+    """Utility exposing the generated tunnel as ``C(t)`` and ``P(θ, r, t)``."""
+
+    def __init__(self, generator: TunnelTerrainGenerator) -> None:
+        self._generator = generator
+
+    def sample(self, t: float) -> CurveSample:
+        if t < 0.0:
+            raise ValueError("Parameter t must be non-negative")
+        self._generator.ensure_arc_length(t)
+        rings = self._generator.rings()
+        if not rings:
+            raise RuntimeError("TunnelTerrainGenerator produced no rings")
+        arc_lengths = self._generator.arc_lengths()
+        if len(rings) != len(arc_lengths):
+            raise RuntimeError("Ring count does not match arc length count")
+
+        if t >= arc_lengths[-1]:
+            ring = rings[-1]
+            return CurveSample(parameter=arc_lengths[-1], frame=ring.frame, radii=ring.roughness_profile)
+
+        low = 0
+        high = len(arc_lengths) - 1
+        while low < high:
+            mid = (low + high) // 2
+            if arc_lengths[mid] <= t:
+                low = mid + 1
+            else:
+                high = mid
+        upper_index = max(1, low)
+        lower_index = upper_index - 1
+
+        lower_s = arc_lengths[lower_index]
+        upper_s = arc_lengths[upper_index]
+        denom = max(upper_s - lower_s, 1e-6)
+        blend = (t - lower_s) / denom
+
+        lower_ring = rings[lower_index]
+        upper_ring = rings[upper_index]
+
+        origin = lower_ring.center.lerp(upper_ring.center, blend)
+        forward = lower_ring.forward.lerp(upper_ring.forward, blend).normalized()
+        up_hint = lower_ring.frame.up.lerp(upper_ring.frame.up, blend)
+        fwd, up, right = orthonormalize(forward, up_hint)
+        frame = OrthonormalFrame(origin=origin, forward=fwd, right=right, up=up)
+
+        radii = tuple(
+            lower_ring.roughness_profile[i] * (1.0 - blend)
+            + upper_ring.roughness_profile[i] * blend
+            for i in range(len(lower_ring.roughness_profile))
+        )
+
+        return CurveSample(parameter=t, frame=frame, radii=radii)
+
+    def centerline(self, t: float) -> Vector3:
+        """Return the centerline point ``C(t)``."""
+
+        return self.sample(t).frame.origin
+
+    def wall_point(self, t: float, theta: float, radius: float | None = None) -> Vector3:
+        """Evaluate ``P(θ, r, t)`` at the provided parameters."""
+
+        return self.sample(t).point_on_wall(theta, radius)

--- a/tunnelcave_sandbox/terrain_generator.py
+++ b/tunnelcave_sandbox/terrain_generator.py
@@ -161,6 +161,22 @@ class TunnelTerrainGenerator:
 
         return tuple(self._global_rings)
 
+    def arc_lengths(self) -> Tuple[float, ...]:
+        """Return the cumulative arc length at each generated ring."""
+
+        return tuple(self._global_s_positions)
+
+    def ensure_arc_length(self, arc_length: float) -> None:
+        """Generate enough rings to cover ``arc_length`` meters of tunnel."""
+
+        if arc_length <= 0.0:
+            return
+        last_s = self._global_s_positions[-1] if self._global_s_positions else 0.0
+        if arc_length <= last_s:
+            return
+        steps_needed = int(math.ceil(arc_length / max(self._params.ring_step, 1e-6)))
+        self._ensure_ring(steps_needed + 1)
+
     def radius_floor_history(self) -> Tuple[float, ...]:
         """Return the per-ring minimum radius floor used during generation."""
 


### PR DESCRIPTION
## Summary
- add CavePath and CurveSample helpers to sample the tunnel centerline and walls as a smooth parametric curve
- expose arc-length accessors on TunnelTerrainGenerator and export the new helpers from the tunnelcave package
- cover the curve sampling behavior with dedicated tests

## Testing
- pytest tests/test_cave_path.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4d2ea96883299903bdd49274c596