### PR TITLE
Refactor sandbox craft physics integration

### DIFF
--- a/tunnelcave_sandbox_web/lib/world.ts
+++ b/tunnelcave_sandbox_web/lib/world.ts
@@ -3,7 +3,18 @@ import { createChunkBand, ensureChunks, type ChunkBand } from "./streaming";
 import { chooseSpawn, type SpawnPose } from "./probe";
 import type { RingStation } from "./terrain";
 import { createCameraRig, type CameraParams, type CameraRig, updateCameraRig } from "./camera";
-import { add, cross, length, normalize, scale, Vec3, lerp } from "./vector";
+import {
+  add,
+  cross,
+  dot,
+  length,
+  normalize,
+  rotateAroundAxis,
+  scale,
+  sub,
+  Vec3,
+  lerp
+} from "./vector";
 
 export interface SimulationParams {
   sandbox: SandboxParams;
@@ -12,15 +23,15 @@ export interface SimulationParams {
 }
 
 export interface CraftState {
-  arc: number;
   speed: number;
   targetSpeed: number;
-  roll: number;
-  rollRate: number;
   position: Vec3;
+  velocity: Vec3;
   forward: Vec3;
   right: Vec3;
   up: Vec3;
+  angularVelocity: Vec3;
+  crashed: boolean;
 }
 
 export interface SimulationState {
@@ -30,7 +41,7 @@ export interface SimulationState {
     tangentAt?: (sMeters: number) => Vec3;
     closestS?: (p: Vec3 | { x: number; y: number; z: number }) => number;
     length?: number; // getter (meters) over currently loaded rings
-    sample?: (sMeters: number) => { position: Vec3; tangent: Vec3 };
+    sample?: (sMeters: number) => { position: Vec3; tangent: Vec3; right: Vec3; up: Vec3 };
   };
   camera: CameraRig;
   craft: CraftState;
@@ -40,6 +51,8 @@ export interface SimulationState {
 export interface PlayerInput {
   throttleDelta: number;
   rollDelta: number;
+  pitchDelta: number;
+  yawDelta: number;
 }
 
 function collectRings(band: ChunkBand): RingStation[] {
@@ -77,22 +90,6 @@ function interpolateRing(rings: RingStation[], arc: number): {
   return { position, forward, right, up };
 }
 
-function applyRoll(right: Vec3, up: Vec3, forward: Vec3, roll: number) {
-  const cos = Math.cos(roll);
-  const sin = Math.sin(roll);
-  const newRight: Vec3 = [
-    right[0] * cos + up[0] * sin,
-    right[1] * cos + up[1] * sin,
-    right[2] * cos + up[2] * sin
-  ];
-  const newUp: Vec3 = [
-    up[0] * cos - right[0] * sin,
-    up[1] * cos - right[1] * sin,
-    up[2] * cos - right[2] * sin
-  ];
-  return { right: newRight, up: newUp, forward };
-}
-
 /* ------------------------ Centerline helpers (meters <-> arc) ------------------------ */
 
 /** Convert {x,y,z} or Vec3-like into Vec3 tuple */
@@ -109,6 +106,116 @@ function metersToArc(sMeters: number, ringStep: number): number {
 /** Map arc units -> meters using ringStep */
 function arcToMeters(arc: number, ringStep: number): number {
   return arc * ringStep;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+const MASS = 1;
+const GRAVITY: Vec3 = [0, -9.81 * MASS, 0];
+const MIN_SPEED = 2;
+const MAX_SPEED = 80;
+const BASE_THRUST = 12;
+const THRUST_GAIN = 6;
+const LIFT_COEF = 0.12;
+const DRAG_COEF = 0.05;
+const RADIAL_SPRING = 8;
+const RADIAL_DAMPING = 4;
+const CONTROL_DAMPING = 0.35;
+const ROLL_CONTROL = 3.5;
+const PITCH_CONTROL = 2.5;
+const YAW_CONTROL = 2.8;
+const ALIGNMENT_GAIN = 1.2;
+const RESTITUTION = 0.25;
+
+function orthonormalize(forward: Vec3, up: Vec3): { forward: Vec3; right: Vec3; up: Vec3 } {
+  const f = normalize(forward);
+  let r = cross(f, up);
+  let rLen = length(r);
+  if (rLen < 1e-5) {
+    const fallback: Vec3 = Math.abs(f[1]) < 0.99 ? [0, 1, 0] : [1, 0, 0];
+    r = cross(f, fallback);
+    rLen = length(r);
+  }
+  const invR = rLen > 0 ? 1 / rLen : 0;
+  r = scale(r, invR);
+  const u = normalize(cross(r, f));
+  return { forward: f, right: r, up: u };
+}
+
+function resolveTerrainCollision(
+  craft: CraftState,
+  rings: RingStation[],
+  craftRadius: number,
+  arc: number,
+  ringStep: number
+) {
+  if (rings.length === 0) return;
+
+  const approxIndex = Math.floor(arc);
+  let bestPenetration = 0;
+  let bestRing: RingStation | null = null;
+  let bestNormal: Vec3 | null = null;
+  let bestAlong = 0;
+  let bestClearance = 0;
+
+  for (const ring of rings) {
+    if (Math.abs(ring.index - approxIndex) > 6) continue;
+    const toCraft = sub(craft.position, ring.position);
+    const along = dot(toCraft, ring.frame.forward);
+    if (Math.abs(along) > ringStep * 3) continue;
+    const axial = scale(ring.frame.forward, along);
+    let radial = sub(toCraft, axial);
+    const radialLen = length(radial);
+    const rightComp = dot(radial, ring.frame.right);
+    const upComp = dot(radial, ring.frame.up);
+    const theta = Math.atan2(upComp, rightComp);
+    const surfaceRadius = ring.radius + ring.roughness(theta);
+    const clearance = surfaceRadius + craftRadius;
+    const penetration = clearance - radialLen;
+    if (penetration > bestPenetration) {
+      let normal: Vec3;
+      if (radialLen > 1e-4) {
+        normal = scale(radial, 1 / radialLen);
+      } else {
+        const cosT = Math.cos(theta);
+        const sinT = Math.sin(theta);
+        normal = normalize(
+          add(scale(ring.frame.right, cosT), scale(ring.frame.up, sinT))
+        );
+      }
+      bestPenetration = penetration;
+      bestRing = ring;
+      bestNormal = normal;
+      bestAlong = along;
+      bestClearance = clearance;
+    }
+  }
+
+  if (!bestRing || !bestNormal || bestPenetration <= 0) return;
+
+  const alongOffset = scale(bestRing.frame.forward, bestAlong);
+  const surfacePoint = add(
+    bestRing.position,
+    add(alongOffset, scale(bestNormal, bestClearance))
+  );
+  craft.position = surfacePoint;
+
+  const vn = dot(craft.velocity, bestNormal);
+  if (vn < 0) {
+    craft.velocity = sub(craft.velocity, scale(bestNormal, (1 + RESTITUTION) * vn));
+  }
+
+  craft.speed = length(craft.velocity);
+
+  if (bestPenetration > craftRadius * 0.6) {
+    craft.crashed = true;
+    craft.velocity = [0, 0, 0] as Vec3;
+    craft.speed = 0;
+    craft.targetSpeed = 0;
+    craft.angularVelocity = [0, 0, 0] as Vec3;
+  }
 }
 
 /* ----------------------------------- Simulation ----------------------------------- */
@@ -157,7 +264,7 @@ export function createSimulation(params: SimulationParams): SimulationState {
     const r = currentRings();
     const arc = metersToArc(sMeters, ringStep);
     const s = interpolateRing(r, arc);
-    return { position: s.position, tangent: s.forward };
+    return { position: s.position, tangent: s.forward, right: s.right, up: s.up };
   };
 
   // Closest arc-length (meters) to world point p
@@ -215,16 +322,17 @@ export function createSimulation(params: SimulationParams): SimulationState {
 
   /* --- End centerline API ------------------------------------------------------ */
 
+  const initialSpeed = 15;
   const craft: CraftState = {
-    arc: spawn.ringIndex,
-    speed: 15,
-    targetSpeed: 15,
-    roll: spawn.rollHint,
-    rollRate: 0,
-    position: spawn.position,
-    forward: spawn.forward,
-    right: spawn.right,
-    up: spawn.up
+    speed: initialSpeed,
+    targetSpeed: initialSpeed,
+    position: [...spawn.position] as Vec3,
+    velocity: scale(spawn.forward, initialSpeed),
+    forward: [...spawn.forward] as Vec3,
+    right: [...spawn.right] as Vec3,
+    up: [...spawn.up] as Vec3,
+    angularVelocity: [0, 0, 0],
+    crashed: false
   };
 
   const camera = createCameraRig(add(spawn.position, scale(spawn.forward, -10)));
@@ -238,27 +346,108 @@ export function updateSimulation(
   dt: number
 ) {
   const { craft, band } = state;
+  if (craft.crashed) {
+    updateCameraRig(state.camera, craft.position, craft.forward, craft.right, craft.up, params.camera, dt);
+    return;
+  }
 
-  craft.targetSpeed = Math.max(2, Math.min(80, craft.targetSpeed + input.throttleDelta * dt * 15));
-  craft.speed += (craft.targetSpeed - craft.speed) * Math.min(1, dt * 2);
-  craft.rollRate += input.rollDelta * dt * 2.5;
-  craft.rollRate *= Math.pow(0.4, dt);
-  craft.roll = Math.max(-Math.PI / 3, Math.min(Math.PI / 3, craft.roll + craft.rollRate * dt));
-
-  const deltaArc = (craft.speed * dt) / params.sandbox.ringStep;
-  craft.arc += deltaArc;
-
-  const centerChunk = Math.floor((craft.arc * params.sandbox.ringStep) / params.sandbox.chunkLength);
+  const closestS = band.closestS;
+  const ringStep = params.sandbox.ringStep;
+  const chunkLength = params.sandbox.chunkLength;
+  const sMeters = typeof closestS === "function" ? closestS(craft.position) : 0;
+  let centerChunk = Math.floor(sMeters / chunkLength);
   ensureChunks(band, centerChunk);
 
-  const rings = collectRings(band);
-  const sample = interpolateRing(rings, craft.arc);
-  const rolled = applyRoll(sample.right, sample.up, sample.forward, craft.roll);
+  let rings = collectRings(band);
+  if (rings.length === 0) {
+    updateCameraRig(state.camera, craft.position, craft.forward, craft.right, craft.up, params.camera, dt);
+    return;
+  }
 
-  craft.position = sample.position;
-  craft.forward = rolled.forward;
-  craft.right = rolled.right;
-  craft.up = rolled.up;
+  const arc = metersToArc(sMeters, ringStep);
+  const sample = interpolateRing(rings, arc);
+
+  craft.targetSpeed = clamp(
+    craft.targetSpeed + input.throttleDelta * dt * 25,
+    MIN_SPEED,
+    MAX_SPEED
+  );
+
+  // Stability towards the guide spline
+  const forwardError = cross(craft.forward, sample.forward);
+  const yawCorrection = dot(forwardError, craft.up) * ALIGNMENT_GAIN;
+  const pitchCorrection = -dot(forwardError, craft.right) * ALIGNMENT_GAIN;
+  const rollError = dot(cross(craft.up, sample.up), craft.forward) * ALIGNMENT_GAIN;
+
+  craft.angularVelocity[0] += (input.rollDelta - rollError) * ROLL_CONTROL * dt;
+  craft.angularVelocity[1] += (input.pitchDelta + pitchCorrection) * PITCH_CONTROL * dt;
+  craft.angularVelocity[2] += (input.yawDelta - yawCorrection) * YAW_CONTROL * dt;
+
+  const damping = Math.pow(CONTROL_DAMPING, dt);
+  craft.angularVelocity[0] *= damping;
+  craft.angularVelocity[1] *= damping;
+  craft.angularVelocity[2] *= damping;
+
+  const rollStep = craft.angularVelocity[0] * dt;
+  const pitchStep = craft.angularVelocity[1] * dt;
+  const yawStep = craft.angularVelocity[2] * dt;
+
+  if (Math.abs(yawStep) > 1e-5) {
+    craft.forward = rotateAroundAxis(craft.forward, craft.up, yawStep);
+    craft.right = rotateAroundAxis(craft.right, craft.up, yawStep);
+  }
+  if (Math.abs(pitchStep) > 1e-5) {
+    craft.forward = rotateAroundAxis(craft.forward, craft.right, pitchStep);
+    craft.up = rotateAroundAxis(craft.up, craft.right, pitchStep);
+  }
+  if (Math.abs(rollStep) > 1e-5) {
+    craft.right = rotateAroundAxis(craft.right, craft.forward, rollStep);
+    craft.up = rotateAroundAxis(craft.up, craft.forward, rollStep);
+  }
+
+  const basis = orthonormalize(craft.forward, craft.up);
+  craft.forward = basis.forward;
+  craft.right = basis.right;
+  craft.up = basis.up;
+
+  const speed = length(craft.velocity);
+  craft.speed = speed;
+  const speedError = craft.targetSpeed - speed;
+  const thrustMagnitude = Math.max(0, BASE_THRUST + speedError * THRUST_GAIN);
+  const thrust = scale(craft.forward, thrustMagnitude);
+  const lift = scale(craft.up, LIFT_COEF * speed * speed);
+  const drag: Vec3 = speed > 0 ? scale(craft.velocity, -DRAG_COEF * speed) : [0, 0, 0];
+
+  const toCenter = sub(craft.position, sample.position);
+  const axialOffset = dot(toCenter, sample.forward);
+  const axialComponent = scale(sample.forward, axialOffset);
+  const radial = sub(toCenter, axialComponent);
+  const radialForce = scale(radial, -RADIAL_SPRING);
+  const velAxial = dot(craft.velocity, sample.forward);
+  const radialVelocity = sub(craft.velocity, scale(sample.forward, velAxial));
+  const radialDampingForce = scale(radialVelocity, -RADIAL_DAMPING);
+
+  let totalForce = add(thrust, lift);
+  totalForce = add(totalForce, drag);
+  totalForce = add(totalForce, GRAVITY);
+  totalForce = add(totalForce, radialForce);
+  totalForce = add(totalForce, radialDampingForce);
+
+  const acceleration = scale(totalForce, 1 / MASS);
+  craft.velocity = add(craft.velocity, scale(acceleration, dt));
+  craft.position = add(craft.position, scale(craft.velocity, dt));
+  craft.speed = length(craft.velocity);
+
+  const sAfter = typeof closestS === "function" ? closestS(craft.position) : sMeters;
+  const newCenterChunk = Math.floor(sAfter / chunkLength);
+  if (newCenterChunk !== centerChunk) {
+    centerChunk = newCenterChunk;
+    ensureChunks(band, centerChunk);
+  }
+
+  rings = collectRings(band);
+  const arcAfter = metersToArc(sAfter, ringStep);
+  resolveTerrainCollision(craft, rings, params.craftRadius, arcAfter, ringStep);
 
   updateCameraRig(state.camera, craft.position, craft.forward, craft.right, craft.up, params.camera, dt);
 }


### PR DESCRIPTION
## Summary
- evolve the craft pose directly by integrating thrust, lift, gravity, and control torques instead of sampling the spline
- add pitch and yaw inputs to the sandbox canvas and align the reset control with the simulated craft basis
- detect tunnel collisions against streamed rings, clamp penetration, and keep camera and chunk streaming centered on the craft

## Testing
- npm run build *(fails: missing @types/three in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc5743fb08329ad950406ac2b09ad