### PR TITLE
Reset roll input on KeyD release

### DIFF
--- a/tunnelcave_sandbox_web/components/SandboxCanvas.tsx
+++ b/tunnelcave_sandbox_web/components/SandboxCanvas.tsx
@@ -705,8 +705,12 @@ export function SandboxCanvas() {
     const keyUp = (event: KeyboardEvent) => {
       if (event.code === "KeyW" && inputRef.current.throttle > 0) inputRef.current.throttle = 0;
       if (event.code === "KeyS" && inputRef.current.throttle < 0) inputRef.current.throttle = 0;
-      if (event.code === "KeyA" && inputRef.current.roll < 0) inputRef.current.roll = 0;
-      if (event.code === "KeyD" && inputRef.current.roll > 0) inputRef.current.roll = 0;
+      if (event.code === "KeyA") {
+        inputRef.current.roll = 0;
+      }
+      if (event.code === "KeyD") {
+        inputRef.current.roll = 0;
+      }
       if (event.code === "ArrowUp" && inputRef.current.pitch > 0) inputRef.current.pitch = 0;
       if (event.code === "ArrowDown" && inputRef.current.pitch < 0) inputRef.current.pitch = 0;
       if (event.code === "ArrowLeft" && inputRef.current.yaw < 0) inputRef.current.yaw = 0;


### PR DESCRIPTION
## Summary
- ensure the roll input resets to zero when releasing either roll key to avoid stale input values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddc8063e9c8329ad6a3f6e96aba2a1