### PR TITLE
Gate tunnel mouth egress and refresh control docs

### DIFF
--- a/go-broker/control_docs.go
+++ b/go-broker/control_docs.go
@@ -24,28 +24,53 @@ type ControlDoc struct {
 //     keep documentation in sync.
 var defaultControlDocs = []ControlDoc{
 	{
-		ID:          "manual-toggle",
-		Label:       "Manual Control",
-		Description: "Engage viewer-driven manual control so keyboard movement is applied on top of telemetry.",
-		Shortcut:    "Button / keyboard M",
+		ID:          "assist-toggle",
+		Label:       "Flight Assist",
+		Description: "Toggle between guided tunnel-follow assist and unrestricted free-flight.",
+		Shortcut:    "Keyboard F",
 	},
-        {
-                ID:          "accelerate-forward",
-                Label:       "Forward Acceleration",
-                Description: "Toggle a scripted thrust curve that pushes the aircraft down the runway.",
-                Shortcut:    "Button / keyboard T",
-        },
-        {
-                ID:          "reroute-waypoints",
-                Label:       "Cycle Autopilot Route",
-                Description: "Send preset waypoint loops to the simulator using the set_waypoints command.",
-                Shortcut:    "Button",
-        },
-        {
-                ID:          "keyboard",
-                Label:       "Flight Keys",
-                Description: "WASD for planar movement, RF/Space/Shift for altitude, QE for yaw, arrow keys for pitch and roll.",
-        },
+	{
+		ID:          "throttle",
+		Label:       "Throttle",
+		Description: "Adjust forward thrust to climb the cave stream or slow to a hover.",
+		Shortcut:    "W / S, Arrow Up / Arrow Down",
+	},
+	{
+		ID:          "yaw",
+		Label:       "Yaw",
+		Description: "Twist around the vertical axis for tight corridor turns.",
+		Shortcut:    "J / L, Arrow Left / Arrow Right",
+	},
+	{
+		ID:          "pitch",
+		Label:       "Pitch",
+		Description: "Tilt the nose to dive deeper or level back toward the horizon.",
+		Shortcut:    "I / K, Arrow Up / Arrow Down",
+	},
+	{
+		ID:          "roll",
+		Label:       "Roll",
+		Description: "Bank the craft with precision tunnel banking inputs.",
+		Shortcut:    "A / D, Q / E",
+	},
+	{
+		ID:          "vertical-thrust",
+		Label:       "Vertical Thrust",
+		Description: "Slide up or down along world-up to thread vertical shafts.",
+		Shortcut:    "N / M, PageUp / PageDown",
+	},
+	{
+		ID:          "boost",
+		Label:       "Boost",
+		Description: "Hold for an auxiliary thruster burst when you need extra speed.",
+		Shortcut:    "Shift / Space",
+	},
+	{
+		ID:          "reset",
+		Label:       "Reset Craft",
+		Description: "Respawn at the last safe ring if you clip the cave mouth.",
+		Shortcut:    "Keyboard R",
+	},
 }
 
 // registerControlDocEndpoints registers the HTTP handlers used by the viewer to

--- a/tunnelcave_sandbox_web/components/ControlsOverlay.tsx
+++ b/tunnelcave_sandbox_web/components/ControlsOverlay.tsx
@@ -3,9 +3,10 @@ import styles from "./ControlsOverlay.module.css";
 interface OverlayProps {
   speed: number;
   targetSpeed: number;
+  assistEnabled: boolean;
 }
 
-export function ControlsOverlay({ speed, targetSpeed }: OverlayProps) {
+export function ControlsOverlay({ speed, targetSpeed, assistEnabled }: OverlayProps) {
   return (
     <div className={styles.overlay}>
       <div>
@@ -19,14 +20,21 @@ export function ControlsOverlay({ speed, targetSpeed }: OverlayProps) {
         <span>
           Target: <strong>{targetSpeed.toFixed(1)} m/s</strong>
         </span>
+        <span>
+          Assist: <strong>{assistEnabled ? "Guided" : "Free flight"}</strong>
+        </span>
       </div>
       <div className={styles.instructions}>
         <p>Controls</p>
         <ul>
-          <li>W / S – Increase or decrease throttle</li>
-          <li>A / D – Bank craft left / right</li>
-          <li>Space – Reset roll</li>
-          <li>Shift – Boost follow camera tightness</li>
+          <li>F – Toggle guided assist ({assistEnabled ? "on" : "off"})</li>
+          <li>W / S or ↑ / ↓ – Throttle forward / reverse</li>
+          <li>A / D (Q / E) – Roll left / right</li>
+          <li>I / K – Pitch up / down</li>
+          <li>← / → – Yaw left / right</li>
+          <li>J / L or PgDn / PgUp – Vertical thrust down / up</li>
+          <li>Shift / Space – Boost</li>
+          <li>R – Reset to spawn, B – Beam, M – Missile</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- derive a mouth constraint from the earliest tunnel ring and store it on the simulation state
- clamp craft motion against the cave mouth plane and aperture so interior pilots cannot exit while still allowing outside entry
- update the Go broker control documentation to describe the tunnel flight bindings and assist toggle

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ddd83a358c8329bf3509cb752590ed