### PR TITLE
Add broker operational endpoints and docs

### DIFF
--- a/docs/ops/endpoints.md
+++ b/docs/ops/endpoints.md
@@ -1,0 +1,64 @@
+# Broker operational endpoints
+
+The broker exposes a small set of HTTP endpoints for health checks, metrics
+collection, and operational replay management. All paths are served from the
+same host and port as the primary WebSocket listener.
+
+## `/livez`
+
+* **Method:** `GET`
+* **Purpose:** Liveness probe that confirms the HTTP listener is reachable.
+* **Response:** JSON payload containing an `alive` status and timestamp.
+* **Authentication:** Not required.
+
+Use this endpoint for container liveness checks. A non-`200 OK` response
+indicates the process should be restarted.
+
+## `/readyz`
+
+* **Method:** `GET`
+* **Purpose:** Readiness probe that verifies the broker finished startup and
+  reports current WebSocket client counts.
+* **Response:** JSON with readiness status, uptime in seconds, active clients,
+  and pending handshake counts. Returns `503 Service Unavailable` while startup
+  failures persist.
+* **Authentication:** Not required.
+
+## `/metrics`
+
+* **Method:** `GET`
+* **Purpose:** Prometheus-compatible text metrics describing broker state.
+* **Response:** `text/plain; version=0.0.4` document containing gauges for
+  uptime, connected clients, pending handshakes, and total broadcast payloads.
+* **Authentication:** Not required.
+
+Scrape this endpoint from Prometheus or curl it manually to verify live
+statistics:
+
+```bash
+curl -s http://broker-host:43127/metrics
+```
+
+## `/replay/dump`
+
+* **Method:** `POST`
+* **Purpose:** Triggers a replay dump broadcast to all connected clients.
+* **Response:** `202 Accepted` JSON with status and optional location once the
+  dumper acknowledges the request.
+* **Authentication:** Required. Include the configured admin token via either
+  an `Authorization: Bearer <token>` header or `X-Admin-Token: <token>` header.
+
+Replay triggers are rate limited. Configure the allowed burst and window with
+`BROKER_REPLAY_DUMP_BURST` and `BROKER_REPLAY_DUMP_WINDOW`. Exceeding the
+limit results in `429 Too Many Requests`.
+
+Example request:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $BROKER_ADMIN_TOKEN" \
+  http://broker-host:43127/replay/dump
+```
+
+A `403 Forbidden` response indicates the broker was started without an admin
+credential, while `401 Unauthorized` reflects a missing or invalid token.

--- a/go-broker/internal/http/handlers.go
+++ b/go-broker/internal/http/handlers.go
@@ -1,0 +1,255 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"driftpursuit/broker/internal/logging"
+)
+
+// ReadinessProvider exposes broker state required for readiness checks.
+type ReadinessProvider interface {
+	SnapshotClientCounts() (clients, pending int)
+	StartupError() error
+	Uptime() time.Duration
+}
+
+// StatsFunc returns cumulative broadcast and client statistics.
+type StatsFunc func() (broadcasts, clients int)
+
+// ReplayDumper triggers a replay dump and optionally returns the artifact location.
+type ReplayDumper interface {
+	DumpReplay(ctx context.Context) (string, error)
+}
+
+// ReplayDumperFunc adapts a function into a ReplayDumper.
+type ReplayDumperFunc func(ctx context.Context) (string, error)
+
+// DumpReplay implements ReplayDumper.
+func (f ReplayDumperFunc) DumpReplay(ctx context.Context) (string, error) { return f(ctx) }
+
+// RateLimiter gates how frequently sensitive operations may be invoked.
+type RateLimiter interface {
+	Allow() bool
+}
+
+// Options configures the HandlerSet.
+type Options struct {
+	Logger      *logging.Logger
+	Readiness   ReadinessProvider
+	Stats       StatsFunc
+	Replay      ReplayDumper
+	AdminToken  string
+	RateLimiter RateLimiter
+	TimeSource  func() time.Time
+}
+
+// HandlerSet bundles the broker operational handlers.
+type HandlerSet struct {
+	logger      *logging.Logger
+	readiness   ReadinessProvider
+	stats       StatsFunc
+	replay      ReplayDumper
+	adminToken  string
+	rateLimiter RateLimiter
+	now         func() time.Time
+}
+
+// NewHandlerSet constructs a HandlerSet using the provided options.
+func NewHandlerSet(opts Options) *HandlerSet {
+	logger := opts.Logger
+	if logger == nil {
+		logger = logging.L()
+	}
+	now := opts.TimeSource
+	if now == nil {
+		now = time.Now
+	}
+	return &HandlerSet{
+		logger:      logger,
+		readiness:   opts.Readiness,
+		stats:       opts.Stats,
+		replay:      opts.Replay,
+		adminToken:  strings.TrimSpace(opts.AdminToken),
+		rateLimiter: opts.RateLimiter,
+		now:         now,
+	}
+}
+
+// Register attaches all handlers to the provided mux.
+func (h *HandlerSet) Register(mux *http.ServeMux) {
+	if mux == nil {
+		return
+	}
+	mux.HandleFunc("/livez", h.LivenessHandler())
+	mux.HandleFunc("/readyz", h.ReadinessHandler())
+	mux.HandleFunc("/metrics", h.MetricsHandler())
+	mux.HandleFunc("/replay/dump", h.ReplayDumpHandler())
+}
+
+// LivenessHandler reports that the HTTP server is reachable.
+func (h *HandlerSet) LivenessHandler() http.HandlerFunc {
+	type response struct {
+		Status    string `json:"status"`
+		Timestamp string `json:"timestamp"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, response{
+			Status:    "alive",
+			Timestamp: h.now().UTC().Format(time.RFC3339Nano),
+		})
+	}
+}
+
+// ReadinessHandler reports broker readiness, including client counts and startup status.
+func (h *HandlerSet) ReadinessHandler() http.HandlerFunc {
+	type response struct {
+		Status         string  `json:"status"`
+		Message        string  `json:"message,omitempty"`
+		UptimeSeconds  float64 `json:"uptime_seconds"`
+		Clients        int     `json:"clients"`
+		PendingClients int     `json:"pending_clients"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		status := http.StatusOK
+		resp := response{Status: "ok"}
+		if h.readiness != nil {
+			clients, pending := h.readiness.SnapshotClientCounts()
+			resp.Clients = clients
+			resp.PendingClients = pending
+			resp.UptimeSeconds = h.readiness.Uptime().Seconds()
+			if err := h.readiness.StartupError(); err != nil {
+				status = http.StatusServiceUnavailable
+				resp.Status = "error"
+				resp.Message = err.Error()
+			}
+		}
+		writeJSON(w, status, resp)
+	}
+}
+
+// MetricsHandler emits Prometheus compatible text metrics.
+func (h *HandlerSet) MetricsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		broadcasts, clients := h.metricsStats()
+		pending, uptime := h.pendingAndUptime()
+
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprintf(w, "# HELP broker_uptime_seconds Broker uptime in seconds.\n")
+		fmt.Fprintf(w, "# TYPE broker_uptime_seconds gauge\n")
+		fmt.Fprintf(w, "broker_uptime_seconds %.0f\n", uptime)
+
+		fmt.Fprintf(w, "# HELP broker_clients Current connected WebSocket clients.\n")
+		fmt.Fprintf(w, "# TYPE broker_clients gauge\n")
+		fmt.Fprintf(w, "broker_clients %d\n", clients)
+
+		fmt.Fprintf(w, "# HELP broker_pending_clients Pending WebSocket handshakes awaiting upgrade.\n")
+		fmt.Fprintf(w, "# TYPE broker_pending_clients gauge\n")
+		fmt.Fprintf(w, "broker_pending_clients %d\n", pending)
+
+		fmt.Fprintf(w, "# HELP broker_broadcasts_total Total broadcast payloads delivered.\n")
+		fmt.Fprintf(w, "# TYPE broker_broadcasts_total counter\n")
+		fmt.Fprintf(w, "broker_broadcasts_total %d\n", broadcasts)
+	}
+}
+
+// ReplayDumpHandler authorises and triggers replay dump creation.
+func (h *HandlerSet) ReplayDumpHandler() http.HandlerFunc {
+	type response struct {
+		Status   string `json:"status"`
+		Location string `json:"location,omitempty"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		reqLogger := h.logger.With(
+			logging.String("handler", "replay_dump"),
+			logging.String("remote_addr", r.RemoteAddr),
+		)
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if h.adminToken == "" {
+			reqLogger.Warn("replay dump denied: admin auth disabled")
+			http.Error(w, "admin authentication not configured", http.StatusForbidden)
+			return
+		}
+		if !h.authorise(r) {
+			reqLogger.Warn("replay dump denied: unauthorized request")
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if h.rateLimiter != nil && !h.rateLimiter.Allow() {
+			reqLogger.Warn("replay dump denied: rate limit exceeded")
+			http.Error(w, "too many requests", http.StatusTooManyRequests)
+			return
+		}
+		if h.replay == nil {
+			reqLogger.Warn("replay dump denied: no dumper configured")
+			http.Error(w, "replay dumping is unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		location, err := h.replay.DumpReplay(r.Context())
+		if err != nil {
+			reqLogger.Error("replay dump trigger failed", logging.Error(err))
+			http.Error(w, "failed to trigger replay dump", http.StatusInternalServerError)
+			return
+		}
+		reqLogger.Info("replay dump triggered")
+		writeJSON(w, http.StatusAccepted, response{Status: "accepted", Location: location})
+	}
+}
+
+func (h *HandlerSet) metricsStats() (broadcasts, clients int) {
+	if h.stats != nil {
+		return h.stats()
+	}
+	if h.readiness != nil {
+		clients, _ = h.readiness.SnapshotClientCounts()
+	}
+	return
+}
+
+func (h *HandlerSet) pendingAndUptime() (pending int, uptime float64) {
+	if h.readiness == nil {
+		return 0, 0
+	}
+	_, pending = h.readiness.SnapshotClientCounts()
+	return pending, h.readiness.Uptime().Seconds()
+}
+
+func (h *HandlerSet) authorise(r *http.Request) bool {
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
+	var token string
+	if len(header) > 7 && strings.EqualFold(header[:7], "Bearer ") {
+		token = strings.TrimSpace(header[7:])
+	} else if header != "" {
+		token = header
+	}
+	if token == "" {
+		token = strings.TrimSpace(r.Header.Get("X-Admin-Token"))
+	}
+	if token == "" {
+		token = strings.TrimSpace(r.URL.Query().Get("token"))
+	}
+	if token == "" {
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(h.adminToken)) == 1 {
+		return true
+	}
+	return false
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+	}
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/go-broker/internal/http/handlers_test.go
+++ b/go-broker/internal/http/handlers_test.go
@@ -1,0 +1,172 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"driftpursuit/broker/internal/logging"
+)
+
+type stubReadiness struct {
+	clients int
+	pending int
+	uptime  time.Duration
+	err     error
+}
+
+func (s *stubReadiness) SnapshotClientCounts() (int, int) { return s.clients, s.pending }
+func (s *stubReadiness) StartupError() error              { return s.err }
+func (s *stubReadiness) Uptime() time.Duration            { return s.uptime }
+
+type stubLimiter struct {
+	remaining int
+}
+
+func (s *stubLimiter) Allow() bool {
+	if s.remaining <= 0 {
+		return false
+	}
+	s.remaining--
+	return true
+}
+
+type stubDumper struct {
+	location string
+	err      error
+	calls    int
+}
+
+func (s *stubDumper) DumpReplay(ctx context.Context) (string, error) {
+	s.calls++
+	return s.location, s.err
+}
+
+func TestLivenessHandlerReturnsJSON(t *testing.T) {
+	fixed := time.Date(2024, time.January, 2, 15, 4, 5, 0, time.UTC)
+	handlers := NewHandlerSet(Options{Logger: logging.NewTestLogger(), TimeSource: func() time.Time { return fixed }})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+
+	handlers.LivenessHandler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	var payload struct {
+		Status    string `json:"status"`
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "alive" {
+		t.Fatalf("unexpected status %q", payload.Status)
+	}
+	if payload.Timestamp != fixed.Format(time.RFC3339Nano) {
+		t.Fatalf("unexpected timestamp %q", payload.Timestamp)
+	}
+}
+
+func TestReadinessHandlerUnavailable(t *testing.T) {
+	readiness := &stubReadiness{clients: 3, pending: 1, uptime: 45 * time.Second, err: errors.New("boom")}
+	handlers := NewHandlerSet(Options{Logger: logging.NewTestLogger(), Readiness: readiness})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	handlers.ReadinessHandler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+	var payload struct {
+		Status         string  `json:"status"`
+		Message        string  `json:"message"`
+		UptimeSeconds  float64 `json:"uptime_seconds"`
+		Clients        int     `json:"clients"`
+		PendingClients int     `json:"pending_clients"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "error" || payload.Message != "boom" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Clients != 3 || payload.PendingClients != 1 {
+		t.Fatalf("unexpected client counts: %+v", payload)
+	}
+	if payload.UptimeSeconds != readiness.uptime.Seconds() {
+		t.Fatalf("unexpected uptime: got %f want %f", payload.UptimeSeconds, readiness.uptime.Seconds())
+	}
+}
+
+func TestMetricsHandlerOutputsPrometheusFormat(t *testing.T) {
+	readiness := &stubReadiness{clients: 2, pending: 1, uptime: 90 * time.Second}
+	handlers := NewHandlerSet(Options{
+		Logger:    logging.NewTestLogger(),
+		Readiness: readiness,
+		Stats: func() (int, int) {
+			return 4, 2
+		},
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	handlers.MetricsHandler().ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Content-Type"); got != "text/plain; version=0.0.4" {
+		t.Fatalf("unexpected content type %q", got)
+	}
+	body := rr.Body.String()
+	for _, substr := range []string{
+		"broker_broadcasts_total 4",
+		"broker_clients 2",
+		"broker_pending_clients 1",
+		"broker_uptime_seconds 90",
+	} {
+		if !strings.Contains(body, substr) {
+			t.Fatalf("metrics missing %q:\n%s", substr, body)
+		}
+	}
+}
+
+func TestReplayDumpHandlerAuthAndRateLimits(t *testing.T) {
+	dumper := &stubDumper{location: "/tmp/latest"}
+	limiter := &stubLimiter{remaining: 1}
+	handlers := NewHandlerSet(Options{
+		Logger:      logging.NewTestLogger(),
+		Replay:      dumper,
+		AdminToken:  "topsecret",
+		RateLimiter: limiter,
+	})
+
+	makeRequest := func(token string) *httptest.ResponseRecorder {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/replay/dump", nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		handlers.ReplayDumpHandler().ServeHTTP(rr, req)
+		return rr
+	}
+
+	if resp := makeRequest(""); resp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized for missing token, got %d", resp.Code)
+	}
+
+	if resp := makeRequest("topsecret"); resp.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for authorised request, got %d", resp.Code)
+	}
+	if dumper.calls != 1 {
+		t.Fatalf("expected dumper invoked once, got %d", dumper.calls)
+	}
+
+	if resp := makeRequest("topsecret"); resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected rate limit, got %d", resp.Code)
+	}
+}

--- a/go-broker/internal/http/ratelimiter.go
+++ b/go-broker/internal/http/ratelimiter.go
@@ -1,0 +1,55 @@
+package httpapi
+
+import (
+	"sync"
+	"time"
+)
+
+// SlidingWindowLimiter enforces a maximum number of events within a time window.
+type SlidingWindowLimiter struct {
+	window time.Duration
+	limit  int
+	now    func() time.Time
+
+	mu     sync.Mutex
+	events []time.Time
+}
+
+// NewSlidingWindowLimiter constructs a limiter allowing up to limit events per window.
+func NewSlidingWindowLimiter(window time.Duration, limit int, timeSource func() time.Time) *SlidingWindowLimiter {
+	if window <= 0 || limit <= 0 {
+		return &SlidingWindowLimiter{window: window, limit: limit}
+	}
+	if timeSource == nil {
+		timeSource = time.Now
+	}
+	return &SlidingWindowLimiter{
+		window: window,
+		limit:  limit,
+		now:    timeSource,
+	}
+}
+
+// Allow reports whether the caller may proceed under the current rate limits.
+func (l *SlidingWindowLimiter) Allow() bool {
+	if l == nil || l.limit <= 0 || l.window <= 0 {
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	cutoff := now.Add(-l.window)
+	kept := l.events[:0]
+	for _, ts := range l.events {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	l.events = kept
+	if len(l.events) >= l.limit {
+		return false
+	}
+	l.events = append(l.events, now)
+	return true
+}

--- a/go-broker/internal/http/ratelimiter_test.go
+++ b/go-broker/internal/http/ratelimiter_test.go
@@ -1,0 +1,34 @@
+package httpapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSlidingWindowLimiter(t *testing.T) {
+	now := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	limiter := NewSlidingWindowLimiter(time.Minute, 2, func() time.Time { return now })
+
+	if !limiter.Allow() || !limiter.Allow() {
+		t.Fatal("expected first two calls to be allowed")
+	}
+	if limiter.Allow() {
+		t.Fatal("expected third call to be denied")
+	}
+
+	now = now.Add(30 * time.Second)
+	if limiter.Allow() {
+		t.Fatal("expected call within window to still be denied")
+	}
+
+	now = now.Add(31 * time.Second)
+	if !limiter.Allow() {
+		t.Fatal("expected limiter to permit call after window passes")
+	}
+}
+
+func TestSlidingWindowLimiterDisabled(t *testing.T) {
+	if !NewSlidingWindowLimiter(0, 0, nil).Allow() {
+		t.Fatal("limiter with zero configuration should allow")
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal HTTP handler set that exposes /livez, /readyz, /metrics, and a secured /replay/dump trigger with rate limiting
- extend broker configuration to accept admin credentials and replay dump throttling, and wire the handlers into the main server
- document operational endpoint usage for on-call teams

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de06d7bc64832987c6e8f3f451ca0f