### PR TITLE
Add 60Hz simulation loop with state diff broadcasting

### DIFF
--- a/go-broker/internal/simulation/loop.go
+++ b/go-broker/internal/simulation/loop.go
@@ -1,0 +1,87 @@
+package simulation
+
+import (
+	"context"
+	"time"
+)
+
+// StepFunc advances the simulation by a fixed timestep and may emit side effects.
+type StepFunc func(step time.Duration)
+
+// Loop drives a fixed timestep simulation at the configured target frequency.
+type Loop struct {
+	step     time.Duration
+	stepFunc StepFunc
+	ticker   *time.Ticker
+	done     chan struct{}
+}
+
+// NewLoop configures a loop that targets the provided frames per second.
+func NewLoop(targetHz float64, step StepFunc) *Loop {
+	if targetHz <= 0 {
+		targetHz = 60
+	}
+	if step == nil {
+		step = func(time.Duration) {}
+	}
+	interval := time.Duration(float64(time.Second) / targetHz)
+	if interval <= 0 {
+		interval = time.Second / 60
+	}
+	return &Loop{
+		step:     interval,
+		stepFunc: step,
+	}
+}
+
+// Start begins ticking until the context is cancelled or Stop is invoked.
+func (l *Loop) Start(ctx context.Context) {
+	if l == nil || l.stepFunc == nil {
+		return
+	}
+
+	l.ticker = time.NewTicker(l.step)
+	l.done = make(chan struct{})
+	go func() {
+		defer close(l.done)
+		defer l.ticker.Stop()
+		last := time.Now()
+		accumulator := time.Duration(0)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-l.ticker.C:
+				//1.- Accumulate elapsed time and run fixed steps while catching up.
+				accumulator += now.Sub(last)
+				last = now
+				for accumulator >= l.step {
+					l.stepFunc(l.step)
+					accumulator -= l.step
+				}
+			}
+		}
+	}()
+}
+
+// Stop cancels the loop and waits for the goroutine to exit.
+func (l *Loop) Stop() {
+	if l == nil {
+		return
+	}
+	if l.ticker != nil {
+		l.ticker.Stop()
+	}
+	if l.done != nil {
+		<-l.done
+		l.done = nil
+	}
+}
+
+// StepDuration exposes the configured timestep for testing.
+func (l *Loop) StepDuration() time.Duration {
+	if l == nil {
+		return 0
+	}
+	return l.step
+}

--- a/go-broker/internal/simulation/loop_test.go
+++ b/go-broker/internal/simulation/loop_test.go
@@ -1,0 +1,32 @@
+package simulation
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLoopRunsAtLeastTargetTicks(t *testing.T) {
+	var ticks int32
+	loop := NewLoop(60, func(time.Duration) {
+		atomic.AddInt32(&ticks, 1)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	loop.Start(ctx)
+	time.Sleep(55 * time.Millisecond)
+	cancel()
+	loop.Stop()
+	if atomic.LoadInt32(&ticks) == 0 {
+		t.Fatalf("expected loop to tick at least once")
+	}
+}
+
+func TestLoopStepDuration(t *testing.T) {
+	loop := NewLoop(120, func(time.Duration) {})
+	step := loop.StepDuration()
+	expected := time.Second / 120
+	if step != expected {
+		t.Fatalf("unexpected step duration %v", step)
+	}
+}

--- a/go-broker/internal/state/events.go
+++ b/go-broker/internal/state/events.go
@@ -1,0 +1,78 @@
+package state
+
+import (
+	"sync"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+// EventDiff contains the batch of gameplay events ready for broadcast.
+type EventDiff struct {
+	Events []*pb.GameEvent
+}
+
+// EventStore buffers gameplay events until the next tick publishes them.
+type EventStore struct {
+	mu     sync.Mutex
+	events []*pb.GameEvent
+}
+
+// NewEventStore constructs an event buffer.
+func NewEventStore() *EventStore {
+	return &EventStore{}
+}
+
+// Add enqueues a gameplay event for the next diff.
+func (s *EventStore) Add(event *pb.GameEvent) {
+	if s == nil || event == nil {
+		return
+	}
+
+	clone := protoClone(event)
+	s.mu.Lock()
+	//1.- Append the cloned event while holding the mutex to ensure ordering.
+	s.events = append(s.events, clone)
+	s.mu.Unlock()
+}
+
+// ConsumeDiff flushes and returns the queued events.
+func (s *EventStore) ConsumeDiff() EventDiff {
+	if s == nil {
+		return EventDiff{}
+	}
+
+	s.mu.Lock()
+	//1.- Swap out the current slice with a fresh buffer for the next tick.
+	events := s.events
+	s.events = nil
+	s.mu.Unlock()
+
+	if len(events) == 0 {
+		return EventDiff{}
+	}
+
+	//2.- Clone each event to prevent callers mutating the stored pointers.
+	diff := make([]*pb.GameEvent, 0, len(events))
+	for _, event := range events {
+		diff = append(diff, protoClone(event))
+	}
+	return EventDiff{Events: diff}
+}
+
+// protoClone provides a minimal protobuf clone helper without importing proto in every file.
+func protoClone(event *pb.GameEvent) *pb.GameEvent {
+	if event == nil {
+		return nil
+	}
+	clone := *event
+	if event.Metadata != nil {
+		clone.Metadata = make(map[string]string, len(event.Metadata))
+		for key, value := range event.Metadata {
+			clone.Metadata[key] = value
+		}
+	}
+	if event.RelatedEntityIds != nil {
+		clone.RelatedEntityIds = append([]string(nil), event.RelatedEntityIds...)
+	}
+	return &clone
+}

--- a/go-broker/internal/state/projectiles.go
+++ b/go-broker/internal/state/projectiles.go
@@ -1,0 +1,148 @@
+package state
+
+import "sync"
+
+// ProjectileState tracks simplified projectile kinematics for broadcasting diffs.
+type ProjectileState struct {
+	ID        string  `json:"id"`
+	Position  Vector3 `json:"position"`
+	Velocity  Vector3 `json:"velocity"`
+	Active    bool    `json:"active"`
+	UpdatedAt int64   `json:"updated_at_ms"`
+}
+
+// Vector3 mirrors the protobuf vector definition for JSON serialization.
+type Vector3 struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+	Z float64 `json:"z"`
+}
+
+// ProjectileDiff aggregates updates and removals for projectiles.
+type ProjectileDiff struct {
+	Updated []*ProjectileState
+	Removed []string
+}
+
+// ProjectileStore maintains projectile states with dirty tracking similar to vehicles.
+type ProjectileStore struct {
+	mu      sync.RWMutex
+	states  map[string]*ProjectileState
+	dirty   map[string]struct{}
+	removed map[string]struct{}
+}
+
+// NewProjectileStore constructs a projectile container with initialized maps.
+func NewProjectileStore() *ProjectileStore {
+	return &ProjectileStore{
+		states:  make(map[string]*ProjectileState),
+		dirty:   make(map[string]struct{}),
+		removed: make(map[string]struct{}),
+	}
+}
+
+// Upsert records or updates a projectile state and schedules it for the next diff.
+func (s *ProjectileStore) Upsert(state *ProjectileState) {
+	if s == nil || state == nil || state.ID == "" {
+		return
+	}
+
+	clone := *state
+
+	s.mu.Lock()
+	//1.- Store the cloned projectile and mark it dirty while clearing removal markers.
+	s.states[clone.ID] = &clone
+	delete(s.removed, clone.ID)
+	s.dirty[clone.ID] = struct{}{}
+	s.mu.Unlock()
+}
+
+// Remove deletes a projectile and queues its ID for removal broadcasting.
+func (s *ProjectileStore) Remove(projectileID string) {
+	if s == nil || projectileID == "" {
+		return
+	}
+
+	s.mu.Lock()
+	//1.- Remove any stored projectile, clear dirty flag, and track the removal.
+	delete(s.states, projectileID)
+	delete(s.dirty, projectileID)
+	s.removed[projectileID] = struct{}{}
+	s.mu.Unlock()
+}
+
+// Advance integrates projectile motion for a fixed timestep.
+func (s *ProjectileStore) Advance(stepSeconds float64) {
+	if s == nil || stepSeconds <= 0 {
+		return
+	}
+
+	s.mu.Lock()
+	//1.- Update projectile positions using simple Euler integration.
+	for id, projectile := range s.states {
+		if projectile == nil {
+			continue
+		}
+		projectile.Position.X += projectile.Velocity.X * stepSeconds
+		projectile.Position.Y += projectile.Velocity.Y * stepSeconds
+		projectile.Position.Z += projectile.Velocity.Z * stepSeconds
+		//2.- Mark projectile as dirty for diff emission.
+		s.dirty[id] = struct{}{}
+	}
+	s.mu.Unlock()
+}
+
+// ConsumeDiff retrieves and clears pending projectile updates.
+func (s *ProjectileStore) ConsumeDiff() ProjectileDiff {
+	if s == nil {
+		return ProjectileDiff{}
+	}
+
+	s.mu.Lock()
+	//1.- Capture dirty IDs and removals before resetting trackers.
+	dirtyIDs := make([]string, 0, len(s.dirty))
+	for id := range s.dirty {
+		dirtyIDs = append(dirtyIDs, id)
+	}
+	removedIDs := make([]string, 0, len(s.removed))
+	for id := range s.removed {
+		removedIDs = append(removedIDs, id)
+	}
+
+	s.dirty = make(map[string]struct{})
+	s.removed = make(map[string]struct{})
+
+	//2.- Clone the projectile states referenced by the dirty identifiers.
+	updated := make([]*ProjectileState, 0, len(dirtyIDs))
+	for _, id := range dirtyIDs {
+		projectile, ok := s.states[id]
+		if !ok || projectile == nil {
+			continue
+		}
+		clone := *projectile
+		updated = append(updated, &clone)
+	}
+	s.mu.Unlock()
+
+	return ProjectileDiff{Updated: updated, Removed: removedIDs}
+}
+
+// Snapshot clones and returns every projectile state currently tracked.
+func (s *ProjectileStore) Snapshot() []*ProjectileState {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	//1.- Clone each projectile under the read lock to preserve isolation.
+	snapshot := make([]*ProjectileState, 0, len(s.states))
+	for _, projectile := range s.states {
+		if projectile == nil {
+			continue
+		}
+		clone := *projectile
+		snapshot = append(snapshot, &clone)
+	}
+	s.mu.RUnlock()
+	return snapshot
+}

--- a/go-broker/internal/state/projectiles_test.go
+++ b/go-broker/internal/state/projectiles_test.go
@@ -1,0 +1,47 @@
+package state
+
+import (
+	"testing"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+func TestProjectileStoreDiff(t *testing.T) {
+	store := NewProjectileStore()
+	store.Upsert(&ProjectileState{ID: "proj-1", Velocity: Vector3{X: 3}})
+	diff := store.ConsumeDiff()
+	if len(diff.Updated) != 1 {
+		t.Fatalf("expected updated projectile")
+	}
+	store.ConsumeDiff()
+	store.Advance(1)
+	diff = store.ConsumeDiff()
+	if diff.Updated[0].Position.X != 3 {
+		t.Fatalf("unexpected position %.2f", diff.Updated[0].Position.X)
+	}
+}
+
+func TestProjectileStoreRemove(t *testing.T) {
+	store := NewProjectileStore()
+	store.Upsert(&ProjectileState{ID: "proj-2"})
+	store.Remove("proj-2")
+	diff := store.ConsumeDiff()
+	if len(diff.Removed) != 1 || diff.Removed[0] != "proj-2" {
+		t.Fatalf("expected removal diff")
+	}
+}
+
+func TestEventStoreConsume(t *testing.T) {
+	store := NewEventStore()
+	store.Add(&pb.GameEvent{EventId: "evt-1"})
+	diff := store.ConsumeDiff()
+	if len(diff.Events) != 1 {
+		t.Fatalf("expected one event")
+	}
+	if diff.Events[0].EventId != "evt-1" {
+		t.Fatalf("unexpected event id")
+	}
+	if len(store.ConsumeDiff().Events) != 0 {
+		t.Fatalf("expected empty after consume")
+	}
+}

--- a/go-broker/internal/state/vehicles.go
+++ b/go-broker/internal/state/vehicles.go
@@ -1,0 +1,175 @@
+package state
+
+import (
+	"sync"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// VehicleDiff groups updated and removed vehicle identifiers for a tick.
+type VehicleDiff struct {
+	Updated []*pb.VehicleState
+	Removed []string
+}
+
+// VehicleStore maintains the current authoritative vehicle states with dirty tracking.
+type VehicleStore struct {
+	mu      sync.RWMutex
+	states  map[string]*pb.VehicleState
+	dirty   map[string]struct{}
+	removed map[string]struct{}
+}
+
+// NewVehicleStore constructs a thread-safe vehicle state container.
+func NewVehicleStore() *VehicleStore {
+	return &VehicleStore{
+		states:  make(map[string]*pb.VehicleState),
+		dirty:   make(map[string]struct{}),
+		removed: make(map[string]struct{}),
+	}
+}
+
+// Upsert records or updates the vehicle state and flags it for the next diff.
+func (s *VehicleStore) Upsert(state *pb.VehicleState) {
+	if s == nil || state == nil || state.VehicleId == "" {
+		return
+	}
+
+	//1.- Clone the protobuf to avoid concurrent mutation from callers.
+	clone, ok := proto.Clone(state).(*pb.VehicleState)
+	if !ok {
+		return
+	}
+
+	s.mu.Lock()
+	//2.- Replace the stored state and mark it dirty for the diff collector.
+	s.states[clone.VehicleId] = clone
+	delete(s.removed, clone.VehicleId)
+	s.dirty[clone.VehicleId] = struct{}{}
+	s.mu.Unlock()
+}
+
+// Remove deletes the vehicle state and marks its identifier for removal in the diff.
+func (s *VehicleStore) Remove(vehicleID string) {
+	if s == nil || vehicleID == "" {
+		return
+	}
+
+	s.mu.Lock()
+	//1.- Delete any stored state and tag the identifier as removed.
+	delete(s.states, vehicleID)
+	delete(s.dirty, vehicleID)
+	s.removed[vehicleID] = struct{}{}
+	s.mu.Unlock()
+}
+
+// Get returns a defensive clone of the stored vehicle state if present.
+func (s *VehicleStore) Get(vehicleID string) *pb.VehicleState {
+	if s == nil || vehicleID == "" {
+		return nil
+	}
+
+	s.mu.RLock()
+	//1.- Retrieve the stored pointer while holding the read lock.
+	state, ok := s.states[vehicleID]
+	s.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+
+	//2.- Clone the protobuf so callers cannot mutate the store directly.
+	clone, ok := proto.Clone(state).(*pb.VehicleState)
+	if !ok {
+		return nil
+	}
+	return clone
+}
+
+// Advance integrates vehicle motion for the fixed timestep and marks them dirty.
+func (s *VehicleStore) Advance(stepSeconds float64) {
+	if s == nil || stepSeconds <= 0 {
+		return
+	}
+
+	s.mu.Lock()
+	//1.- Iterate over each vehicle and update positions using velocity * dt.
+	for id, vehicle := range s.states {
+		if vehicle == nil {
+			continue
+		}
+		pos := vehicle.Position
+		vel := vehicle.Velocity
+		if pos == nil || vel == nil {
+			continue
+		}
+		pos.X += vel.X * stepSeconds
+		pos.Y += vel.Y * stepSeconds
+		pos.Z += vel.Z * stepSeconds
+		//2.- Mark the vehicle as dirty so the diff includes the new position.
+		s.dirty[id] = struct{}{}
+	}
+	s.mu.Unlock()
+}
+
+// ConsumeDiff collects and clears the pending vehicle updates and removals.
+func (s *VehicleStore) ConsumeDiff() VehicleDiff {
+	if s == nil {
+		return VehicleDiff{}
+	}
+
+	s.mu.Lock()
+	//1.- Snapshot the dirty and removed identifiers under lock.
+	dirtyIDs := make([]string, 0, len(s.dirty))
+	for id := range s.dirty {
+		dirtyIDs = append(dirtyIDs, id)
+	}
+	removedIDs := make([]string, 0, len(s.removed))
+	for id := range s.removed {
+		removedIDs = append(removedIDs, id)
+	}
+
+	//2.- Reset the dirty/removed trackers before releasing the lock.
+	s.dirty = make(map[string]struct{})
+	s.removed = make(map[string]struct{})
+
+	//3.- Clone the vehicle states corresponding to the dirty identifiers.
+	updated := make([]*pb.VehicleState, 0, len(dirtyIDs))
+	for _, id := range dirtyIDs {
+		vehicle, ok := s.states[id]
+		if !ok {
+			continue
+		}
+		clone, ok := proto.Clone(vehicle).(*pb.VehicleState)
+		if !ok {
+			continue
+		}
+		updated = append(updated, clone)
+	}
+	s.mu.Unlock()
+
+	return VehicleDiff{Updated: updated, Removed: removedIDs}
+}
+
+// Snapshot returns all stored vehicles as defensive clones.
+func (s *VehicleStore) Snapshot() []*pb.VehicleState {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	//1.- Allocate the slice large enough for all vehicles under the read lock.
+	snapshot := make([]*pb.VehicleState, 0, len(s.states))
+	for _, vehicle := range s.states {
+		if vehicle == nil {
+			continue
+		}
+		clone, ok := proto.Clone(vehicle).(*pb.VehicleState)
+		if !ok {
+			continue
+		}
+		snapshot = append(snapshot, clone)
+	}
+	s.mu.RUnlock()
+	return snapshot
+}

--- a/go-broker/internal/state/vehicles_test.go
+++ b/go-broker/internal/state/vehicles_test.go
@@ -1,0 +1,84 @@
+package state
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+func TestVehicleStoreUpsertAndDiff(t *testing.T) {
+	store := NewVehicleStore()
+	vehicle := &pb.VehicleState{VehicleId: "veh-1", Position: &pb.Vector3{}, Velocity: &pb.Vector3{X: 10}}
+
+	store.Upsert(vehicle)
+	diff := store.ConsumeDiff()
+	if len(diff.Updated) != 1 {
+		t.Fatalf("expected 1 updated vehicle, got %d", len(diff.Updated))
+	}
+	if diff.Updated[0].VehicleId != "veh-1" {
+		t.Fatalf("unexpected vehicle id %q", diff.Updated[0].VehicleId)
+	}
+
+	if len(store.ConsumeDiff().Updated) != 0 {
+		t.Fatalf("expected diff to be empty after consume")
+	}
+}
+
+func TestVehicleStoreAdvanceMarksDirty(t *testing.T) {
+	store := NewVehicleStore()
+	store.Upsert(&pb.VehicleState{VehicleId: "veh-2", Position: &pb.Vector3{}, Velocity: &pb.Vector3{Y: 5}})
+	store.ConsumeDiff()
+
+	store.Advance(0.5)
+	diff := store.ConsumeDiff()
+	if len(diff.Updated) != 1 {
+		t.Fatalf("expected 1 updated vehicle after advance, got %d", len(diff.Updated))
+	}
+	if diff.Updated[0].Position.Y != 2.5 {
+		t.Fatalf("unexpected Y position %.2f", diff.Updated[0].Position.Y)
+	}
+}
+
+func TestVehicleStoreConcurrentAccess(t *testing.T) {
+	store := NewVehicleStore()
+	wg := sync.WaitGroup{}
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			store.Upsert(&pb.VehicleState{VehicleId: fmt.Sprintf("veh-%d", idx)})
+		}(i)
+	}
+	wg.Wait()
+	if len(store.Snapshot()) != 32 {
+		t.Fatalf("snapshot mismatch")
+	}
+}
+
+func TestVehicleStoreGetClones(t *testing.T) {
+	store := NewVehicleStore()
+	store.Upsert(&pb.VehicleState{VehicleId: "veh-3", Position: &pb.Vector3{X: 1}})
+	got := store.Get("veh-3")
+	if got == nil {
+		t.Fatalf("expected vehicle state")
+	}
+	got.Position.X = 999
+	if store.Get("veh-3").Position.X == 999 {
+		t.Fatalf("store should not reflect external mutation")
+	}
+}
+
+func TestWorldStateAdvanceTick(t *testing.T) {
+	world := NewWorldState()
+	world.Vehicles.Upsert(&pb.VehicleState{VehicleId: "veh-4", Position: &pb.Vector3{}, Velocity: &pb.Vector3{Z: 2}})
+	diff := world.AdvanceTick(500 * time.Millisecond)
+	if len(diff.Vehicles.Updated) != 1 {
+		t.Fatalf("expected vehicle diff")
+	}
+	if diff.Vehicles.Updated[0].Position.Z != 1 {
+		t.Fatalf("unexpected Z position %.2f", diff.Vehicles.Updated[0].Position.Z)
+	}
+}

--- a/go-broker/internal/state/world.go
+++ b/go-broker/internal/state/world.go
@@ -1,0 +1,82 @@
+package state
+
+import "time"
+
+// TickDiff collates all state deltas emitted for a simulation tick.
+type TickDiff struct {
+	Vehicles    VehicleDiff
+	Projectiles ProjectileDiff
+	Events      EventDiff
+}
+
+// HasChanges reports whether the diff contains any modifications worth broadcasting.
+func (d TickDiff) HasChanges() bool {
+	//1.- Check each sub diff for non-empty updates or removals.
+	if len(d.Vehicles.Updated) > 0 || len(d.Vehicles.Removed) > 0 {
+		return true
+	}
+	if len(d.Projectiles.Updated) > 0 || len(d.Projectiles.Removed) > 0 {
+		return true
+	}
+	if len(d.Events.Events) > 0 {
+		return true
+	}
+	return false
+}
+
+// WorldState holds the authoritative state containers for the simulation.
+type WorldState struct {
+	Vehicles    *VehicleStore
+	Projectiles *ProjectileStore
+	Events      *EventStore
+}
+
+// NewWorldState constructs the world containers with default implementations.
+func NewWorldState() *WorldState {
+	return &WorldState{
+		Vehicles:    NewVehicleStore(),
+		Projectiles: NewProjectileStore(),
+		Events:      NewEventStore(),
+	}
+}
+
+// AdvanceTick integrates motion for the provided step and collects the diff.
+func (w *WorldState) AdvanceTick(step time.Duration) TickDiff {
+	if w == nil {
+		return TickDiff{}
+	}
+
+	//1.- Convert the duration to seconds for the integration helpers.
+	stepSeconds := step.Seconds()
+	//2.- Advance each store's state using the fixed timestep.
+	w.Vehicles.Advance(stepSeconds)
+	w.Projectiles.Advance(stepSeconds)
+	//3.- Gather the diff from each store to broadcast downstream.
+	return TickDiff{
+		Vehicles:    w.Vehicles.ConsumeDiff(),
+		Projectiles: w.Projectiles.ConsumeDiff(),
+		Events:      w.Events.ConsumeDiff(),
+	}
+}
+
+// Snapshot captures the entire world state for recovery or debugging.
+func (w *WorldState) Snapshot() TickDiff {
+	if w == nil {
+		return TickDiff{}
+	}
+
+	//1.- Collect full snapshots from each store for a comprehensive diff.
+	vehicles := w.Vehicles.Snapshot()
+	projectiles := w.Projectiles.Snapshot()
+	events := w.Events.ConsumeDiff()
+
+	return TickDiff{
+		Vehicles: VehicleDiff{
+			Updated: vehicles,
+		},
+		Projectiles: ProjectileDiff{
+			Updated: projectiles,
+		},
+		Events: events,
+	}
+}


### PR DESCRIPTION
## Summary
- add world state containers for vehicles, projectiles, and events with diff tracking
- introduce a fixed-timestep simulation loop that publishes world diffs to clients when state changes
- extend structured message handling and tests to cover the new simulation-driven updates

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de2690ffb8832994929e04186d90f3