### PR TITLE
Add intent control validator with cooldown enforcement

### DIFF
--- a/go-broker/intent.go
+++ b/go-broker/intent.go
@@ -7,18 +7,6 @@ import (
 	"time"
 )
 
-const (
-	//1.- Define min/max ranges for analog control channels.
-	intentThrottleMin = -1.0
-	intentThrottleMax = 1.0
-	intentBrakeMin    = 0.0
-	intentBrakeMax    = 1.0
-	intentSteerMin    = -1.0
-	intentSteerMax    = 1.0
-	intentGearMin     = -1
-	intentGearMax     = 9
-)
-
 var (
 	errIntentEmptyPayload   = errors.New("empty intent payload")
 	errIntentMissingID      = errors.New("intent missing controller id")
@@ -64,18 +52,6 @@ func validateIntentPayload(payload *intentPayload) error {
 	}
 	if payload.SequenceID == 0 {
 		return fmt.Errorf("intent sequence id must be positive: %d", payload.SequenceID)
-	}
-	if payload.Throttle < intentThrottleMin || payload.Throttle > intentThrottleMax {
-		return fmt.Errorf("throttle %.2f out of range", payload.Throttle)
-	}
-	if payload.Brake < intentBrakeMin || payload.Brake > intentBrakeMax {
-		return fmt.Errorf("brake %.2f out of range", payload.Brake)
-	}
-	if payload.Steer < intentSteerMin || payload.Steer > intentSteerMax {
-		return fmt.Errorf("steer %.2f out of range", payload.Steer)
-	}
-	if payload.Gear < intentGearMin || payload.Gear > intentGearMax {
-		return fmt.Errorf("gear %d out of range", payload.Gear)
 	}
 	return nil
 }

--- a/go-broker/internal/input/validation.go
+++ b/go-broker/internal/input/validation.go
@@ -1,0 +1,393 @@
+package input
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"driftpursuit/broker/internal/logging"
+)
+
+// ValidationReason identifies why a control frame was rejected by the validator.
+type ValidationReason string
+
+const (
+	ValidationReasonNone           ValidationReason = ""
+	ValidationReasonThrottleRange  ValidationReason = "throttle_range"
+	ValidationReasonBrakeRange     ValidationReason = "brake_range"
+	ValidationReasonSteerRange     ValidationReason = "steer_range"
+	ValidationReasonGearRange      ValidationReason = "gear_range"
+	ValidationReasonThrottleDelta  ValidationReason = "throttle_delta"
+	ValidationReasonBrakeDelta     ValidationReason = "brake_delta"
+	ValidationReasonSteerDelta     ValidationReason = "steer_delta"
+	ValidationReasonGearDelta      ValidationReason = "gear_delta"
+	ValidationReasonCooldownActive ValidationReason = "cooldown_active"
+)
+
+// ControlRanges groups the inclusive ranges for each analog control channel.
+type ControlRanges struct {
+	Throttle Range
+	Brake    Range
+	Steer    Range
+	Gear     IntRange
+}
+
+// Range defines the inclusive min/max for a floating point channel.
+type Range struct {
+	Min float64
+	Max float64
+}
+
+// IntRange defines the inclusive min/max for an integer channel.
+type IntRange struct {
+	Min int32
+	Max int32
+}
+
+// ControlDeltas groups the maximum per-frame deltas for each control channel.
+type ControlDeltas struct {
+	Throttle float64
+	Brake    float64
+	Steer    float64
+	Gear     int32
+}
+
+// Controls captures the subset of intent payload required for validation.
+type Controls struct {
+	Throttle float64
+	Brake    float64
+	Steer    float64
+	Gear     int32
+}
+
+// ControlConstraints configures the validator's range, delta, and cooldown policies.
+type ControlConstraints struct {
+	Ranges             ControlRanges
+	Deltas             ControlDeltas
+	InvalidBurstLimit  int
+	InvalidBurstWindow time.Duration
+	CooldownDuration   time.Duration
+	MaxCooldownStrikes int
+}
+
+// ValidationDecision summarises the result of a Validate call.
+type ValidationDecision struct {
+	Accepted   bool
+	Reason     ValidationReason
+	Warn       bool
+	Disconnect bool
+	Cooldown   time.Duration
+	Details    string
+}
+
+// ValidationCounters aggregates per-client violation statistics.
+type ValidationCounters struct {
+	Violations  map[ValidationReason]uint64 `json:"violations,omitempty"`
+	Cooldowns   uint64                      `json:"cooldowns"`
+	Disconnects uint64                      `json:"disconnects"`
+}
+
+// ValidatorOption customises validator construction.
+type ValidatorOption func(*Validator)
+
+// Validator enforces control ranges, delta limits, and cooldown behaviour.
+type Validator struct {
+	mu      sync.Mutex
+	cfg     ControlConstraints
+	clock   Clock
+	logger  *logging.Logger
+	clients map[string]*validatorClientState
+	metrics map[string]ValidationCounters
+}
+
+type validatorClientState struct {
+	lastControls  Controls
+	hasLast       bool
+	firstInvalid  time.Time
+	invalidCount  int
+	cooldownUntil time.Time
+	strikes       int
+}
+
+// DefaultControlConstraints provides the tuned baseline for production traffic.
+var DefaultControlConstraints = ControlConstraints{
+	Ranges: ControlRanges{
+		Throttle: Range{Min: -1.0, Max: 1.0},
+		Brake:    Range{Min: 0.0, Max: 1.0},
+		Steer:    Range{Min: -1.0, Max: 1.0},
+		Gear:     IntRange{Min: -1, Max: 9},
+	},
+	Deltas: ControlDeltas{
+		Throttle: 0.35,
+		Brake:    0.50,
+		Steer:    0.45,
+		Gear:     1,
+	},
+	InvalidBurstLimit:  5,
+	InvalidBurstWindow: time.Second,
+	CooldownDuration:   500 * time.Millisecond,
+	MaxCooldownStrikes: 3,
+}
+
+// WithValidatorClock overrides the clock used to determine cooldown windows.
+func WithValidatorClock(clock Clock) ValidatorOption {
+	return func(v *Validator) {
+		if clock != nil {
+			v.clock = clock
+		}
+	}
+}
+
+// WithValidatorLogger injects a logger for diagnostics.
+func WithValidatorLogger(logger *logging.Logger) ValidatorOption {
+	return func(v *Validator) {
+		if logger != nil {
+			v.logger = logger
+		}
+	}
+}
+
+// NewValidator builds a validator with the supplied constraints and logger.
+func NewValidator(cfg ControlConstraints, logger *logging.Logger, opts ...ValidatorOption) *Validator {
+	//1.- Copy the configuration so we can safely mutate defaults.
+	if cfg.InvalidBurstLimit <= 0 {
+		cfg.InvalidBurstLimit = DefaultControlConstraints.InvalidBurstLimit
+	}
+	if cfg.InvalidBurstWindow <= 0 {
+		cfg.InvalidBurstWindow = DefaultControlConstraints.InvalidBurstWindow
+	}
+	if cfg.CooldownDuration <= 0 {
+		cfg.CooldownDuration = DefaultControlConstraints.CooldownDuration
+	}
+	if cfg.MaxCooldownStrikes <= 0 {
+		cfg.MaxCooldownStrikes = DefaultControlConstraints.MaxCooldownStrikes
+	}
+	if cfg.Ranges == (ControlRanges{}) {
+		cfg.Ranges = DefaultControlConstraints.Ranges
+	}
+	if cfg.Deltas == (ControlDeltas{}) {
+		cfg.Deltas = DefaultControlConstraints.Deltas
+	}
+	validator := &Validator{
+		cfg:     cfg,
+		clock:   systemClock{},
+		logger:  logger,
+		clients: make(map[string]*validatorClientState),
+		metrics: make(map[string]ValidationCounters),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(validator)
+		}
+	}
+	if validator.clock == nil {
+		validator.clock = systemClock{}
+	}
+	return validator
+}
+
+// Validate checks the supplied controls and records any violations.
+func (v *Validator) Validate(clientID, controllerID string, controls Controls) ValidationDecision {
+	//2.- Assume acceptance when the validator is absent to reduce call sites.
+	if v == nil {
+		return ValidationDecision{Accepted: true}
+	}
+	key := v.key(clientID, controllerID)
+	now := v.clock.Now()
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	state := v.ensureStateLocked(key)
+
+	if !state.cooldownUntil.IsZero() && now.Before(state.cooldownUntil) {
+		remaining := state.cooldownUntil.Sub(now)
+		return ValidationDecision{Accepted: false, Reason: ValidationReasonCooldownActive, Cooldown: remaining}
+	}
+
+	if reason := v.checkRangesLocked(controls); reason != ValidationReasonNone {
+		return v.registerViolationLocked(key, state, now, reason)
+	}
+	if state.hasLast {
+		if reason := v.checkDeltasLocked(state.lastControls, controls); reason != ValidationReasonNone {
+			return v.registerViolationLocked(key, state, now, reason)
+		}
+	}
+
+	return ValidationDecision{Accepted: true}
+}
+
+// Commit marks the supplied controls as accepted, resetting invalid counters.
+func (v *Validator) Commit(clientID, controllerID string, controls Controls) {
+	if v == nil {
+		return
+	}
+	key := v.key(clientID, controllerID)
+	v.mu.Lock()
+	state := v.ensureStateLocked(key)
+	state.lastControls = controls
+	state.hasLast = true
+	state.invalidCount = 0
+	state.firstInvalid = time.Time{}
+	v.mu.Unlock()
+}
+
+// Forget clears all state for the specified client.
+func (v *Validator) Forget(clientID string) {
+	if v == nil || clientID == "" {
+		return
+	}
+	v.mu.Lock()
+	for key := range v.clients {
+		if v.belongsToClient(key, clientID) {
+			delete(v.clients, key)
+			delete(v.metrics, key)
+		}
+	}
+	v.mu.Unlock()
+}
+
+// Metrics returns a snapshot of per-client counters for diagnostics.
+func (v *Validator) Metrics() map[string]ValidationCounters {
+	if v == nil {
+		return nil
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(v.metrics) == 0 {
+		return nil
+	}
+	snapshot := make(map[string]ValidationCounters, len(v.metrics))
+	for key, counters := range v.metrics {
+		clone := ValidationCounters{Cooldowns: counters.Cooldowns, Disconnects: counters.Disconnects}
+		if len(counters.Violations) > 0 {
+			clone.Violations = make(map[ValidationReason]uint64, len(counters.Violations))
+			for reason, count := range counters.Violations {
+				clone.Violations[reason] = count
+			}
+		}
+		snapshot[key] = clone
+	}
+	return snapshot
+}
+
+func (v *Validator) ensureStateLocked(key string) *validatorClientState {
+	state := v.clients[key]
+	if state == nil {
+		state = &validatorClientState{}
+		v.clients[key] = state
+	}
+	return state
+}
+
+func (v *Validator) registerViolationLocked(key string, state *validatorClientState, now time.Time, reason ValidationReason) ValidationDecision {
+	counters := v.metrics[key]
+	if counters.Violations == nil {
+		counters.Violations = make(map[ValidationReason]uint64)
+	}
+	counters.Violations[reason]++
+	v.metrics[key] = counters
+
+	decision := ValidationDecision{Accepted: false, Reason: reason}
+
+	window := v.cfg.InvalidBurstWindow
+	limit := v.cfg.InvalidBurstLimit
+	if limit > 0 {
+		if state.invalidCount == 0 || now.Sub(state.firstInvalid) > window {
+			state.firstInvalid = now
+			state.invalidCount = 1
+		} else {
+			state.invalidCount++
+		}
+		remaining := limit - state.invalidCount
+		if remaining <= 1 {
+			decision.Warn = remaining == 1
+		}
+		if state.invalidCount >= limit {
+			state.cooldownUntil = now.Add(v.cfg.CooldownDuration)
+			state.invalidCount = 0
+			state.firstInvalid = time.Time{}
+			state.strikes++
+			counters = v.metrics[key]
+			counters.Cooldowns++
+			if state.strikes >= v.cfg.MaxCooldownStrikes {
+				decision.Disconnect = true
+				counters.Disconnects++
+			}
+			v.metrics[key] = counters
+			decision.Cooldown = v.cfg.CooldownDuration
+			if v.logger != nil {
+				v.logger.Debug("intent validator cooldown",
+					logging.String("key", key),
+					logging.String("reason", string(reason)),
+					logging.Field{Key: "cooldown_ms", Value: v.cfg.CooldownDuration.Milliseconds()},
+				)
+			}
+		}
+	}
+	return decision
+}
+
+func (v *Validator) checkRangesLocked(controls Controls) ValidationReason {
+	//4.- Compare each channel individually to provide actionable feedback.
+	if r := v.cfg.Ranges.Throttle; controls.Throttle < r.Min || controls.Throttle > r.Max {
+		return ValidationReasonThrottleRange
+	}
+	if r := v.cfg.Ranges.Brake; controls.Brake < r.Min || controls.Brake > r.Max {
+		return ValidationReasonBrakeRange
+	}
+	if r := v.cfg.Ranges.Steer; controls.Steer < r.Min || controls.Steer > r.Max {
+		return ValidationReasonSteerRange
+	}
+	if r := v.cfg.Ranges.Gear; controls.Gear < r.Min || controls.Gear > r.Max {
+		return ValidationReasonGearRange
+	}
+	return ValidationReasonNone
+}
+
+func (v *Validator) checkDeltasLocked(prev, next Controls) ValidationReason {
+	//5.- Evaluate delta magnitudes in floating point space with tolerance for rounding.
+	if limit := v.cfg.Deltas.Throttle; limit > 0 {
+		if math.Abs(next.Throttle-prev.Throttle) > limit+1e-9 {
+			return ValidationReasonThrottleDelta
+		}
+	}
+	if limit := v.cfg.Deltas.Brake; limit > 0 {
+		if math.Abs(next.Brake-prev.Brake) > limit+1e-9 {
+			return ValidationReasonBrakeDelta
+		}
+	}
+	if limit := v.cfg.Deltas.Steer; limit > 0 {
+		if math.Abs(next.Steer-prev.Steer) > limit+1e-9 {
+			return ValidationReasonSteerDelta
+		}
+	}
+	if limit := v.cfg.Deltas.Gear; limit > 0 {
+		if int32(math.Abs(float64(next.Gear-prev.Gear))) > limit {
+			return ValidationReasonGearDelta
+		}
+	}
+	return ValidationReasonNone
+}
+
+func (v *Validator) key(clientID, controllerID string) string {
+	//6.- Build a stable key so multiple controllers on the same websocket stay independent.
+	if clientID == "" {
+		return controllerID
+	}
+	if controllerID == "" {
+		return clientID
+	}
+	return fmt.Sprintf("%s|%s", clientID, controllerID)
+}
+
+func (v *Validator) belongsToClient(key, clientID string) bool {
+	if key == clientID {
+		return true
+	}
+	if len(key) <= len(clientID) || key[:len(clientID)] != clientID {
+		return false
+	}
+	return len(key) > len(clientID) && key[len(clientID)] == '|'
+}

--- a/go-broker/internal/input/validation_test.go
+++ b/go-broker/internal/input/validation_test.go
@@ -1,0 +1,116 @@
+package input
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"driftpursuit/broker/internal/logging"
+)
+
+type validatorClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// 1.- Now returns the synthetic time used to drive cooldown calculations deterministically.
+func (c *validatorClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// 2.- Advance moves the synthetic clock forward so tests can simulate elapsed time.
+func (c *validatorClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func TestValidatorAcceptsWithinConstraints(t *testing.T) {
+	clock := &validatorClock{now: time.UnixMilli(0)}
+	validator := NewValidator(DefaultControlConstraints, logging.NewTestLogger(), WithValidatorClock(clock))
+
+	controls := Controls{Throttle: 0.3, Brake: 0.2, Steer: -0.1, Gear: 2}
+	decision := validator.Validate("client-A", "controller-A", controls)
+	if !decision.Accepted {
+		t.Fatalf("expected acceptance, got %+v", decision)
+	}
+
+	validator.Commit("client-A", "controller-A", controls)
+
+	controls2 := Controls{Throttle: 0.4, Brake: 0.3, Steer: -0.2, Gear: 3}
+	decision = validator.Validate("client-A", "controller-A", controls2)
+	if !decision.Accepted {
+		t.Fatalf("expected acceptance on second frame, got %+v", decision)
+	}
+}
+
+func TestValidatorRejectsOutOfRange(t *testing.T) {
+	clock := &validatorClock{now: time.UnixMilli(0)}
+	validator := NewValidator(DefaultControlConstraints, logging.NewTestLogger(), WithValidatorClock(clock))
+
+	controls := Controls{Throttle: 1.5, Brake: 0.2, Steer: 0.1, Gear: 2}
+	decision := validator.Validate("client-B", "controller-B", controls)
+	if decision.Accepted {
+		t.Fatalf("expected rejection for throttle overflow")
+	}
+	if decision.Reason != ValidationReasonThrottleRange {
+		t.Fatalf("unexpected reason %s", decision.Reason)
+	}
+}
+
+func TestValidatorRejectsDeltaSpike(t *testing.T) {
+	clock := &validatorClock{now: time.UnixMilli(0)}
+	validator := NewValidator(DefaultControlConstraints, logging.NewTestLogger(), WithValidatorClock(clock))
+
+	baseline := Controls{Throttle: 0.0, Brake: 0.0, Steer: 0.0, Gear: 1}
+	if decision := validator.Validate("client-C", "controller-C", baseline); !decision.Accepted {
+		t.Fatalf("baseline rejected: %+v", decision)
+	}
+	validator.Commit("client-C", "controller-C", baseline)
+
+	spike := Controls{Throttle: 0.9, Brake: 0.0, Steer: 0.0, Gear: 1}
+	decision := validator.Validate("client-C", "controller-C", spike)
+	if decision.Accepted {
+		t.Fatalf("expected rejection for throttle delta")
+	}
+	if decision.Reason != ValidationReasonThrottleDelta {
+		t.Fatalf("unexpected reason %s", decision.Reason)
+	}
+}
+
+func TestValidatorAppliesCooldownAfterBurst(t *testing.T) {
+	clock := &validatorClock{now: time.UnixMilli(0)}
+	cfg := DefaultControlConstraints
+	cfg.InvalidBurstLimit = 3
+	cfg.CooldownDuration = 300 * time.Millisecond
+	validator := NewValidator(cfg, logging.NewTestLogger(), WithValidatorClock(clock))
+
+	bad := Controls{Throttle: 2.0, Brake: 0.0, Steer: 0.0, Gear: 1}
+	var lastDecision ValidationDecision
+	for i := 0; i < cfg.InvalidBurstLimit; i++ {
+		decision := validator.Validate("client-D", "controller-D", bad)
+		if decision.Accepted {
+			t.Fatalf("expected rejection at iteration %d", i)
+		}
+		lastDecision = decision
+	}
+	if lastDecision.Cooldown != cfg.CooldownDuration {
+		t.Fatalf("expected cooldown duration %s, got %s", cfg.CooldownDuration, lastDecision.Cooldown)
+	}
+
+	decision := validator.Validate("client-D", "controller-D", Controls{Throttle: 0.0, Brake: 0.0, Steer: 0.0, Gear: 1})
+	if decision.Accepted {
+		t.Fatalf("expected cooldown to reject valid frame")
+	}
+	if decision.Reason != ValidationReasonCooldownActive {
+		t.Fatalf("expected cooldown active reason, got %s", decision.Reason)
+	}
+
+	clock.Advance(cfg.CooldownDuration)
+	decision = validator.Validate("client-D", "controller-D", Controls{Throttle: 0.0, Brake: 0.0, Steer: 0.0, Gear: 1})
+	if !decision.Accepted {
+		t.Fatalf("expected acceptance after cooldown, got %+v", decision)
+	}
+}


### PR DESCRIPTION
## Summary
- add an intent control validator that enforces range, delta, and cooldown limits while tracking per-client violations
- wire the validator into broker stats and intent handling so invalid frames are rejected and cooldown penalties trigger disconnects when needed
- expand intent-focused tests to cover range, delta, and cooldown behaviour alongside unit tests for the validator

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dec523409c83298de7266631ed5166