### PR TITLE
Implement ack-aware event stream utilities

### DIFF
--- a/go-broker/internal/events/stream.go
+++ b/go-broker/internal/events/stream.go
@@ -1,0 +1,364 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// Kind enumerates the supported gameplay event payloads carried by the stream.
+type Kind string
+
+const (
+	KindCombat    Kind = "combat"
+	KindRadar     Kind = "radar"
+	KindRespawn   Kind = "respawn"
+	KindLifecycle Kind = "lifecycle"
+)
+
+// Envelope carries the concrete protobuf payload together with sequencing metadata.
+type Envelope struct {
+	Sequence uint64
+	Kind     Kind
+	Combat   *pb.CombatEvent
+	Radar    *pb.RadarContact
+	Game     *pb.GameEvent
+}
+
+// Clone duplicates the underlying protobuf payloads so tests can mutate their copy safely.
+func (e *Envelope) Clone() *Envelope {
+	if e == nil {
+		return nil
+	}
+	clone := *e
+	if e.Combat != nil {
+		if msg, ok := proto.Clone(e.Combat).(*pb.CombatEvent); ok {
+			clone.Combat = msg
+		}
+	}
+	if e.Radar != nil {
+		if msg, ok := proto.Clone(e.Radar).(*pb.RadarContact); ok {
+			clone.Radar = msg
+		}
+	}
+	if e.Game != nil {
+		if msg, ok := proto.Clone(e.Game).(*pb.GameEvent); ok {
+			clone.Game = msg
+		}
+	}
+	return &clone
+}
+
+// Config controls the retention policy for the stream log and subscriber buffers.
+type Config struct {
+	Retain int
+}
+
+// Default retention keeps the last 512 events if no explicit value is provided.
+const defaultRetention = 512
+
+// Stream coordinates ordered event delivery with at-least-once semantics per subscriber.
+type Stream struct {
+	mu          sync.Mutex
+	nextSeq     uint64
+	retention   int
+	logOrder    []uint64
+	logPayloads map[uint64]*Envelope
+	subscribers map[string]*subscriberState
+}
+
+// subscriberState persists acknowledgement state between transient connections.
+type subscriberState struct {
+	id      string
+	pending []uint64
+	lastAck uint64
+	ch      chan *Envelope
+	active  bool
+}
+
+// Subscription exposes the event channel and acknowledgement helpers for a subscriber.
+type Subscription struct {
+	id     string
+	stream *Stream
+	events <-chan *Envelope
+	once   sync.Once
+}
+
+// ErrOutOfOrderAck signals that a subscriber attempted to acknowledge future sequences.
+var ErrOutOfOrderAck = errors.New("ack sequence must match the next pending event")
+
+// NewStream constructs a stream using the provided configuration.
+func NewStream(cfg Config) *Stream {
+	retention := cfg.Retain
+	if retention <= 0 {
+		retention = defaultRetention
+	}
+	return &Stream{
+		retention:   retention,
+		logPayloads: make(map[uint64]*Envelope),
+		subscribers: make(map[string]*subscriberState),
+	}
+}
+
+// Subscribe attaches the logical subscriber to the stream and replays outstanding events.
+func (s *Stream) Subscribe(ctx context.Context, subscriberID string, buffer int) (*Subscription, error) {
+	if s == nil {
+		return nil, errors.New("nil stream")
+	}
+	if subscriberID == "" {
+		return nil, errors.New("subscriber id must be provided")
+	}
+	if buffer <= 0 {
+		buffer = 32
+	}
+
+	s.mu.Lock()
+	state := s.ensureSubscriberLocked(subscriberID)
+	replay := s.collectReplayLocked(state)
+	ch := make(chan *Envelope, buffer)
+	state.ch = ch
+	state.active = true
+	state.pending = append([]uint64(nil), replay...)
+	deliveries := s.prepareDeliveriesLocked(state, replay)
+	s.mu.Unlock()
+
+	go func() {
+		// 1.- Replay any outstanding events immediately after subscription.
+		for _, env := range deliveries {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- env:
+			}
+		}
+	}()
+
+	return &Subscription{id: subscriberID, stream: s, events: ch}, nil
+}
+
+// Events exposes the ordered delivery channel for the subscriber.
+func (s *Subscription) Events() <-chan *Envelope {
+	if s == nil {
+		return nil
+	}
+	return s.events
+}
+
+// Ack informs the stream that the subscriber processed the given sequence.
+func (s *Subscription) Ack(sequence uint64) error {
+	if s == nil || s.stream == nil {
+		return errors.New("subscription closed")
+	}
+	return s.stream.ack(s.id, sequence)
+}
+
+// Close marks the subscription as inactive while preserving acknowledgement state.
+func (s *Subscription) Close() {
+	if s == nil || s.stream == nil {
+		return
+	}
+	s.once.Do(func() {
+		s.stream.deactivateSubscriber(s.id)
+	})
+}
+
+func (s *Stream) ensureSubscriberLocked(subscriberID string) *subscriberState {
+	state, ok := s.subscribers[subscriberID]
+	if !ok {
+		state = &subscriberState{id: subscriberID}
+		s.subscribers[subscriberID] = state
+	}
+	return state
+}
+
+func (s *Stream) collectReplayLocked(state *subscriberState) []uint64 {
+	// 1.- When a subscriber reconnects we must replay any sequence greater than lastAck.
+	replay := state.pending[:0]
+	for _, seq := range s.logOrder {
+		if seq <= state.lastAck {
+			continue
+		}
+		replay = append(replay, seq)
+	}
+	return append([]uint64(nil), replay...)
+}
+
+func (s *Stream) prepareDeliveriesLocked(state *subscriberState, sequences []uint64) []*Envelope {
+	deliveries := make([]*Envelope, 0, len(sequences))
+	for _, seq := range sequences {
+		if payload, ok := s.logPayloads[seq]; ok {
+			deliveries = append(deliveries, payload.Clone())
+		}
+	}
+	return deliveries
+}
+
+// PublishCombat converts the telemetry and enqueues it for reliable delivery.
+func (s *Stream) PublishCombat(telemetry CombatTelemetry) (uint64, error) {
+	if s == nil {
+		return 0, errors.New("nil stream")
+	}
+	message := telemetry.ToProto()
+	return s.publishEnvelope(&Envelope{Kind: KindCombat, Combat: message})
+}
+
+// PublishRadar enqueues bundled radar contacts.
+func (s *Stream) PublishRadar(contact *pb.RadarContact) (uint64, error) {
+	if s == nil {
+		return 0, errors.New("nil stream")
+	}
+	if contact == nil {
+		return 0, errors.New("radar contact required")
+	}
+	clone, ok := proto.Clone(contact).(*pb.RadarContact)
+	if !ok {
+		return 0, errors.New("radar contact clone failed")
+	}
+	return s.publishEnvelope(&Envelope{Kind: KindRadar, Radar: clone})
+}
+
+// PublishRespawn emits respawn notifications which are modelled as spawn game events.
+func (s *Stream) PublishRespawn(event *pb.GameEvent) (uint64, error) {
+	if s == nil {
+		return 0, errors.New("nil stream")
+	}
+	if event == nil {
+		return 0, errors.New("respawn event required")
+	}
+	if event.GetType() != pb.EventType_EVENT_TYPE_SPAWNED {
+		return 0, fmt.Errorf("respawn must use SPAWNED type, got %v", event.GetType())
+	}
+	clone, ok := proto.Clone(event).(*pb.GameEvent)
+	if !ok {
+		return 0, errors.New("respawn clone failed")
+	}
+	return s.publishEnvelope(&Envelope{Kind: KindRespawn, Game: clone})
+}
+
+// PublishLifecycle captures other lifecycle transitions such as destruction or objective updates.
+func (s *Stream) PublishLifecycle(event *pb.GameEvent) (uint64, error) {
+	if s == nil {
+		return 0, errors.New("nil stream")
+	}
+	if event == nil {
+		return 0, errors.New("lifecycle event required")
+	}
+	switch event.GetType() {
+	case pb.EventType_EVENT_TYPE_DESTROYED, pb.EventType_EVENT_TYPE_OBJECTIVE_CAPTURED, pb.EventType_EVENT_TYPE_SCORE_UPDATE:
+	default:
+		return 0, fmt.Errorf("unsupported lifecycle event type %v", event.GetType())
+	}
+	clone, ok := proto.Clone(event).(*pb.GameEvent)
+	if !ok {
+		return 0, errors.New("lifecycle clone failed")
+	}
+	return s.publishEnvelope(&Envelope{Kind: KindLifecycle, Game: clone})
+}
+
+func (s *Stream) publishEnvelope(envelope *Envelope) (uint64, error) {
+	if envelope == nil {
+		return 0, errors.New("envelope required")
+	}
+
+	s.mu.Lock()
+	s.nextSeq++
+	seq := s.nextSeq
+	envelope.Sequence = seq
+	s.logPayloads[seq] = envelope
+	s.logOrder = append(s.logOrder, seq)
+
+	deliveries := make([]delivery, 0, len(s.subscribers))
+	for _, state := range s.subscribers {
+		state.pending = append(state.pending, seq)
+		if state.active && state.ch != nil {
+			deliveries = append(deliveries, delivery{ch: state.ch, payload: envelope.Clone()})
+		}
+	}
+	s.enforceRetentionLocked()
+	s.mu.Unlock()
+
+	for _, item := range deliveries {
+		// 1.- Deliver asynchronously to avoid blocking the publisher on slow subscribers.
+		select {
+		case item.ch <- item.payload:
+		default:
+		}
+	}
+
+	return seq, nil
+}
+
+type delivery struct {
+	ch      chan<- *Envelope
+	payload *Envelope
+}
+
+func (s *Stream) enforceRetentionLocked() {
+	// 1.- Determine the lowest acknowledgement across subscribers to retain necessary history.
+	if len(s.logOrder) <= s.retention {
+		return
+	}
+	minAck := s.nextSeq
+	for _, state := range s.subscribers {
+		if state.lastAck < minAck {
+			minAck = state.lastAck
+		}
+	}
+	cutoff := uint64(0)
+	if len(s.logOrder) > s.retention {
+		cutoff = s.logOrder[len(s.logOrder)-s.retention]
+	}
+	pruneBefore := minAck
+	if cutoff < pruneBefore {
+		pruneBefore = cutoff
+	}
+	if pruneBefore == 0 {
+		return
+	}
+	idx := sort.Search(len(s.logOrder), func(i int) bool { return s.logOrder[i] > pruneBefore })
+	for _, seq := range s.logOrder[:idx] {
+		delete(s.logPayloads, seq)
+	}
+	s.logOrder = append([]uint64(nil), s.logOrder[idx:]...)
+}
+
+func (s *Stream) ack(subscriberID string, sequence uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.subscribers[subscriberID]
+	if !ok {
+		return fmt.Errorf("unknown subscriber %q", subscriberID)
+	}
+	if len(state.pending) == 0 {
+		if sequence <= state.lastAck {
+			return nil
+		}
+		return ErrOutOfOrderAck
+	}
+	expected := state.pending[0]
+	if sequence != expected {
+		return ErrOutOfOrderAck
+	}
+	state.pending = state.pending[1:]
+	state.lastAck = sequence
+	s.enforceRetentionLocked()
+	return nil
+}
+
+func (s *Stream) deactivateSubscriber(subscriberID string) {
+	s.mu.Lock()
+	state, ok := s.subscribers[subscriberID]
+	if ok {
+		state.active = false
+		if state.ch != nil {
+			close(state.ch)
+			state.ch = nil
+		}
+	}
+	s.mu.Unlock()
+}

--- a/go-broker/internal/events/stream_test.go
+++ b/go-broker/internal/events/stream_test.go
@@ -1,0 +1,142 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+func TestStreamDeliverAndAck(t *testing.T) {
+	//1.- Arrange a stream and subscribe a test client.
+	stream := NewStream(Config{Retain: 8})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub, err := stream.Subscribe(ctx, "alpha", 4)
+	if err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	//2.- Publish a combat, radar, and respawn event for coverage.
+	telemetry := CombatTelemetry{EventID: "evt-1", OccurredAt: time.UnixMilli(42)}
+	if _, err := stream.PublishCombat(telemetry); err != nil {
+		t.Fatalf("publish combat failed: %v", err)
+	}
+
+	radar := &pb.RadarContact{SourceEntityId: "radar", Entries: []*pb.RadarContactEntry{{TargetEntityId: "bogey"}}}
+	if _, err := stream.PublishRadar(radar); err != nil {
+		t.Fatalf("publish radar failed: %v", err)
+	}
+
+	respawn := &pb.GameEvent{EventId: "evt-3", Type: pb.EventType_EVENT_TYPE_SPAWNED}
+	if _, err := stream.PublishRespawn(respawn); err != nil {
+		t.Fatalf("publish respawn failed: %v", err)
+	}
+
+	//3.- Assert sequential delivery and sequential acknowledgement.
+	for expected := uint64(1); expected <= 3; expected++ {
+		select {
+		case env := <-sub.Events():
+			if env.Sequence != expected {
+				t.Fatalf("expected sequence %d, got %d", expected, env.Sequence)
+			}
+			if err := sub.Ack(env.Sequence); err != nil {
+				t.Fatalf("ack failed: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for event %d", expected)
+		}
+	}
+}
+
+func TestStreamResendsUnackedEventsOnResubscribe(t *testing.T) {
+	//1.- Establish the stream and initial subscription.
+	stream := NewStream(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub, err := stream.Subscribe(ctx, "bravo", 2)
+	if err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	//2.- Publish two lifecycle events and ack only the first.
+	first := &pb.GameEvent{EventId: "first", Type: pb.EventType_EVENT_TYPE_DESTROYED}
+	second := &pb.GameEvent{EventId: "second", Type: pb.EventType_EVENT_TYPE_DESTROYED}
+	if _, err := stream.PublishLifecycle(first); err != nil {
+		t.Fatalf("publish first lifecycle failed: %v", err)
+	}
+	if _, err := stream.PublishLifecycle(second); err != nil {
+		t.Fatalf("publish second lifecycle failed: %v", err)
+	}
+
+	env := <-sub.Events()
+	if env.Game.GetEventId() != "first" {
+		t.Fatalf("expected first event, got %q", env.Game.GetEventId())
+	}
+	if err := sub.Ack(env.Sequence); err != nil {
+		t.Fatalf("ack first failed: %v", err)
+	}
+
+	//3.- Drop the second event to simulate packet loss and close the subscription.
+	<-sub.Events() // intentionally read without acking
+	sub.Close()
+
+	//4.- Re-subscribe and ensure the unacked event is replayed.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	replay, err := stream.Subscribe(ctx2, "bravo", 2)
+	if err != nil {
+		t.Fatalf("resubscribe failed: %v", err)
+	}
+
+	select {
+	case env := <-replay.Events():
+		if env.Game.GetEventId() != "second" {
+			t.Fatalf("expected replay of second event, got %q", env.Game.GetEventId())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for replayed event")
+	}
+}
+
+func TestStreamRejectsOutOfOrderAck(t *testing.T) {
+	//1.- Create the stream and publish a pair of events.
+	stream := NewStream(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub, err := stream.Subscribe(ctx, "charlie", 2)
+	if err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	lifecycle := &pb.GameEvent{EventId: "lifecycle", Type: pb.EventType_EVENT_TYPE_DESTROYED}
+	respawn := &pb.GameEvent{EventId: "respawn", Type: pb.EventType_EVENT_TYPE_SPAWNED}
+	if _, err := stream.PublishLifecycle(lifecycle); err != nil {
+		t.Fatalf("publish lifecycle failed: %v", err)
+	}
+	if _, err := stream.PublishRespawn(respawn); err != nil {
+		t.Fatalf("publish respawn failed: %v", err)
+	}
+
+	first := <-sub.Events()
+	second := <-sub.Events()
+
+	//2.- Attempt to ack the second sequence before the first and expect an error.
+	if err := sub.Ack(second.Sequence); !errors.Is(err, ErrOutOfOrderAck) {
+		t.Fatalf("expected out of order error, got %v", err)
+	}
+
+	//3.- Ack in the correct order to ensure recovery remains possible.
+	if err := sub.Ack(first.Sequence); err != nil {
+		t.Fatalf("ack first failed: %v", err)
+	}
+	if err := sub.Ack(second.Sequence); err != nil {
+		t.Fatalf("ack second failed: %v", err)
+	}
+}

--- a/python-sim/bots/event_stream.py
+++ b/python-sim/bots/event_stream.py
@@ -1,0 +1,111 @@
+"""In-memory acknowledgement tracker for reliable gameplay event delivery."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Iterable, List, Protocol
+
+
+class EventTransport(Protocol):
+    """Protocol describing the outbound acknowledgement sink."""
+
+    def send(self, payload: str) -> None:
+        """Send an encoded acknowledgement frame."""
+
+
+@dataclass
+class EventEnvelope:
+    """Mutable representation of an inbound gameplay event."""
+
+    sequence: int
+    kind: str
+    payload: object
+
+
+@dataclass
+class EventStreamState:
+    """Persisted cursor and backlog used to resume on reconnect."""
+
+    last_ack: int = 0
+    backlog: List[EventEnvelope] = field(default_factory=list)
+
+
+class EventStore(Protocol):
+    """Storage abstraction for persisting stream checkpoints."""
+
+    def load(self, subscriber: str) -> EventStreamState | None:
+        """Load the previously persisted state for the subscriber."""
+
+    def persist(self, subscriber: str, state: EventStreamState) -> None:
+        """Persist the latest acknowledgement cursor and backlog."""
+
+
+class MemoryEventStore:
+    """Simple dictionary-backed store suitable for tests."""
+
+    def __init__(self) -> None:
+        self._snapshots: dict[str, EventStreamState] = {}
+
+    def load(self, subscriber: str) -> EventStreamState | None:
+        #1.- Return a defensive copy so callers cannot mutate the stored instance.
+        snapshot = self._snapshots.get(subscriber)
+        if snapshot is None:
+            return None
+        return EventStreamState(snapshot.last_ack, [EventEnvelope(e.sequence, e.kind, e.payload) for e in snapshot.backlog])
+
+    def persist(self, subscriber: str, state: EventStreamState) -> None:
+        #2.- Clone the incoming state to decouple the store from caller mutations.
+        clone = EventStreamState(state.last_ack, [EventEnvelope(e.sequence, e.kind, e.payload) for e in state.backlog])
+        self._snapshots[subscriber] = clone
+
+
+class EventStreamClient:
+    """Client side buffer that enforces ordered acknowledgements."""
+
+    def __init__(self, subscriber: str, transport: EventTransport, store: EventStore | None = None) -> None:
+        #3.- Load the persisted state on construction so reconnects resume immediately.
+        self._subscriber = subscriber
+        self._transport = transport
+        self._store = store or MemoryEventStore()
+        snapshot = self._store.load(subscriber)
+        if snapshot:
+            self._last_ack = snapshot.last_ack
+            self._backlog = snapshot.backlog
+        else:
+            self._last_ack = 0
+            self._backlog: List[EventEnvelope] = []
+
+    def ingest(self, events: Iterable[EventEnvelope]) -> None:
+        #4.- Append strictly ordered events and raise on sequence gaps.
+        for event in events:
+            if event.sequence <= self._last_ack:
+                continue
+            expected = self._backlog[-1].sequence + 1 if self._backlog else self._last_ack + 1
+            if event.sequence != expected:
+                raise ValueError(f"event gap detected: expected {expected}, received {event.sequence}")
+            self._backlog.append(EventEnvelope(event.sequence, event.kind, event.payload))
+        self._store.persist(self._subscriber, EventStreamState(self._last_ack, list(self._backlog)))
+
+    def next_pending(self) -> EventEnvelope | None:
+        #5.- Expose the next unacknowledged event without mutating the queue.
+        return self._backlog[0] if self._backlog else None
+
+    def ack_next(self) -> None:
+        #6.- Pop the head event, notify the transport, and persist the cursor.
+        if not self._backlog:
+            return
+        event = self._backlog.pop(0)
+        self._last_ack = event.sequence
+        frame = {
+            "type": "event_ack",
+            "subscriber": self._subscriber,
+            "sequence": self._last_ack,
+        }
+        self._transport.send(json.dumps(frame))
+        self._store.persist(self._subscriber, EventStreamState(self._last_ack, list(self._backlog)))
+
+    @property
+    def state(self) -> EventStreamState:
+        #7.- Provide a snapshot for diagnostics and tests.
+        return EventStreamState(self._last_ack, list(self._backlog))

--- a/python-sim/tests/test_event_stream.py
+++ b/python-sim/tests/test_event_stream.py
@@ -1,0 +1,69 @@
+"""Tests for the bot-side reliable event stream helper."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from bots.event_stream import EventEnvelope, EventStreamClient, EventStreamState, MemoryEventStore
+
+
+class StubTransport:
+    """Capture outbound acknowledgements for assertions."""
+
+    def __init__(self) -> None:
+        self.sent: List[str] = []
+
+    def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+
+def test_acknowledgement_flow() -> None:
+    """Events should be acknowledged sequentially."""
+
+    #1.- Build the client with an empty store and inject two events.
+    transport = StubTransport()
+    store = MemoryEventStore()
+    client = EventStreamClient("alpha", transport, store)
+    client.ingest([EventEnvelope(1, "combat", {}), EventEnvelope(2, "radar", {})])
+
+    pending = client.next_pending()
+    assert pending is not None and pending.sequence == 1
+
+    client.ack_next()
+    client.ack_next()
+
+    assert len(transport.sent) == 2
+    assert json.loads(transport.sent[-1])["sequence"] == 2
+    assert client.state.backlog == []
+
+
+def test_state_restoration() -> None:
+    """Persisted backlog should be replayed on a new client instance."""
+
+    #2.- Prime the store with an existing backlog snapshot.
+    store = MemoryEventStore()
+    store.persist("bravo", EventStreamState(last_ack=2, backlog=[EventEnvelope(3, "respawn", {})]))
+
+    transport = StubTransport()
+    client = EventStreamClient("bravo", transport, store)
+
+    pending = client.next_pending()
+    assert pending is not None and pending.sequence == 3
+
+    client.ack_next()
+    assert json.loads(transport.sent[-1])["sequence"] == 3
+
+
+def test_detects_gaps() -> None:
+    """Missing events should surface as ValueError to request a replay."""
+
+    transport = StubTransport()
+    client = EventStreamClient("charlie", transport)
+
+    try:
+        client.ingest([EventEnvelope(5, "lifecycle", {})])
+    except ValueError as exc:  # pragma: no cover - exact message asserted below
+        assert "event gap detected" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected a gap detection error")

--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts"
+    "test": "ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/typescript-client/src/eventStream.test.ts
+++ b/typescript-client/src/eventStream.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert";
+import { EventEnvelope, EventStreamClient, MemoryEventStore } from "./eventStream";
+
+(async () => {
+  //1.- Capture outbound acknowledgements for verification.
+  const sent: string[] = [];
+  const transport = { send: (data: string) => sent.push(data) };
+  const store = new MemoryEventStore();
+  const client = new EventStreamClient("alpha", transport, store);
+
+  const events: EventEnvelope[] = [
+    { sequence: 1, kind: "combat", payload: { id: "evt-1" } },
+    { sequence: 2, kind: "radar", payload: { id: "evt-2" } },
+  ];
+
+  client.ingest(events);
+  assert.deepStrictEqual(client.nextPending(), events[0]);
+
+  client.ackLatest();
+  client.ackLatest();
+
+  assert.deepStrictEqual(sent, [
+    JSON.stringify({ type: "event_ack", subscriber: "alpha", sequence: 1 }),
+    JSON.stringify({ type: "event_ack", subscriber: "alpha", sequence: 2 }),
+  ]);
+  assert.strictEqual(client.snapshot().backlog.length, 0);
+
+  //2.- Persist a backlog and confirm the reconstructed client replays it.
+  const persisted = new MemoryEventStore();
+  const seedEvents: EventEnvelope[] = [
+    { sequence: 3, kind: "respawn", payload: { id: "evt-3" } },
+  ];
+  persisted.persist("bravo", { lastAck: 2, backlog: seedEvents });
+
+  const replaySent: string[] = [];
+  const replayClient = new EventStreamClient("bravo", { send: (data: string) => replaySent.push(data) }, persisted);
+  assert.deepStrictEqual(replayClient.nextPending(), seedEvents[0]);
+  replayClient.ackLatest();
+  assert.deepStrictEqual(replaySent, [
+    JSON.stringify({ type: "event_ack", subscriber: "bravo", sequence: 3 }),
+  ]);
+  assert.strictEqual(replayClient.snapshot().lastAck, 3);
+
+  //3.- Detect missing events so the caller can trigger a replay request.
+  const gapClient = new EventStreamClient("charlie", { send: () => undefined });
+  assert.throws(
+    () =>
+      gapClient.ingest([
+        { sequence: 2, kind: "lifecycle", payload: {} },
+      ]),
+    /event gap detected/,
+  );
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/typescript-client/src/eventStream.ts
+++ b/typescript-client/src/eventStream.ts
@@ -1,0 +1,118 @@
+export type EventKind = "combat" | "radar" | "respawn" | "lifecycle";
+
+export interface EventEnvelope {
+  sequence: number;
+  kind: EventKind;
+  payload: unknown;
+}
+
+export interface EventTransport {
+  //1.- Transport abstracts the outbound acknowledgement channel (e.g. WebSocket).
+  send(data: string): void;
+}
+
+export interface EventStoreSnapshot {
+  lastAck: number;
+  backlog: EventEnvelope[];
+}
+
+export interface EventStore {
+  //2.- Persist the acknowledgement cursor and backlog for reconnect safety.
+  load(subscriberId: string): EventStoreSnapshot | undefined;
+  persist(subscriberId: string, snapshot: EventStoreSnapshot): void;
+}
+
+export class MemoryEventStore implements EventStore {
+  private readonly snapshots = new Map<string, EventStoreSnapshot>();
+
+  load(subscriberId: string): EventStoreSnapshot | undefined {
+    //3.- Return a deep copy so callers cannot mutate the stored state.
+    const snapshot = this.snapshots.get(subscriberId);
+    if (!snapshot) {
+      return undefined;
+    }
+    return {
+      lastAck: snapshot.lastAck,
+      backlog: snapshot.backlog.map((event) => ({ ...event })),
+    };
+  }
+
+  persist(subscriberId: string, snapshot: EventStoreSnapshot): void {
+    this.snapshots.set(subscriberId, {
+      lastAck: snapshot.lastAck,
+      backlog: snapshot.backlog.map((event) => ({ ...event })),
+    });
+  }
+}
+
+export interface AckMessage {
+  type: "event_ack";
+  subscriber: string;
+  sequence: number;
+}
+
+export class EventStreamClient {
+  private backlog: EventEnvelope[] = [];
+  private lastAck = 0;
+
+  constructor(
+    private readonly subscriberId: string,
+    private readonly transport: EventTransport,
+    private readonly store: EventStore = new MemoryEventStore(),
+  ) {
+    //4.- Restore persisted state on construction so reconnects resume seamlessly.
+    const snapshot = this.store.load(subscriberId);
+    if (snapshot) {
+      this.lastAck = snapshot.lastAck;
+      this.backlog = snapshot.backlog.map((event) => ({ ...event }));
+    }
+  }
+
+  ingest(events: EventEnvelope[]): void {
+    //5.- Normalise and append events while preserving strict ordering guarantees.
+    const filtered = events
+      .filter((event) => event.sequence > this.lastAck)
+      .sort((a, b) => a.sequence - b.sequence);
+    if (filtered.length === 0) {
+      return;
+    }
+    const expected = this.backlog.length > 0 ? this.backlog[this.backlog.length - 1].sequence : this.lastAck;
+    filtered.forEach((event, index) => {
+      const nextSequence = expected + index + 1;
+      if (event.sequence !== nextSequence) {
+        throw new Error(`event gap detected: expected ${nextSequence}, received ${event.sequence}`);
+      }
+    });
+    this.backlog.push(...filtered.map((event) => ({ ...event })));
+    this.store.persist(this.subscriberId, { lastAck: this.lastAck, backlog: this.backlog });
+  }
+
+  nextPending(): EventEnvelope | undefined {
+    //6.- Provide the next event without removing it so callers can retry on failures.
+    return this.backlog[0];
+  }
+
+  ackLatest(): void {
+    //7.- Pop the head of the backlog and send an acknowledgement frame.
+    const event = this.backlog.shift();
+    if (!event) {
+      return;
+    }
+    this.lastAck = event.sequence;
+    const message: AckMessage = {
+      type: "event_ack",
+      subscriber: this.subscriberId,
+      sequence: this.lastAck,
+    };
+    this.transport.send(JSON.stringify(message));
+    this.store.persist(this.subscriberId, { lastAck: this.lastAck, backlog: this.backlog });
+  }
+
+  snapshot(): EventStoreSnapshot {
+    //8.- Expose a shallow copy for diagnostic inspection in tests.
+    return {
+      lastAck: this.lastAck,
+      backlog: this.backlog.map((event) => ({ ...event })),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a durable, ordered event stream manager with acknowledgements to the broker events package
- provide integration tests that exercise replay after packet loss and sequencing guarantees
- extend TypeScript and Python clients with persistent event journaling and acknowledgement helpers

## Testing
- go test ./...
- npm test
- PYTHONPATH=. pytest tests/test_event_stream.py

------
https://chatgpt.com/codex/tasks/task_e_68dee36ff4f483298375a73a4b10ed71