### PR TITLE
Add structured replay capture and loader

### DIFF
--- a/go-broker/internal/replay/loader.go
+++ b/go-broker/internal/replay/loader.go
@@ -1,0 +1,159 @@
+package replay
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+)
+
+// TimelineEntry represents a single replay datum ready for deterministic iteration.
+type TimelineEntry struct {
+	Tick        uint64
+	SimulatedMs int64
+	CapturedAt  time.Time
+	Type        string
+	Payload     json.RawMessage
+}
+
+// Loader rehydrates compressed replay artefacts for validation workflows.
+type Loader struct {
+	entries []TimelineEntry
+}
+
+// Load constructs a loader from the provided replay file path.
+func Load(path string) (*Loader, error) {
+	if path == "" {
+		return nil, fmt.Errorf("replay path must be provided")
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope struct {
+		Frames []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"frames"`
+		WorldFrames []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"world_frames"`
+		Events []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, err
+	}
+
+	entries := make([]TimelineEntry, 0, len(envelope.Frames)+len(envelope.WorldFrames)+len(envelope.Events))
+
+	//1.- Rehydrate tick diffs so deterministic replays can include authoritative deltas.
+	for _, frame := range envelope.Frames {
+		captured, err := time.Parse(time.RFC3339Nano, frame.CapturedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse frame captured_at: %w", err)
+		}
+		entries = append(entries, TimelineEntry{
+			Tick:        frame.Tick,
+			SimulatedMs: frame.SimulatedMs,
+			CapturedAt:  captured,
+			Type:        "diff",
+			Payload:     append(json.RawMessage(nil), frame.Payload...),
+		})
+	}
+
+	//2.- Append world frames to feed deterministic validation runs.
+	for _, frame := range envelope.WorldFrames {
+		captured, err := time.Parse(time.RFC3339Nano, frame.CapturedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse world_frame captured_at: %w", err)
+		}
+		entries = append(entries, TimelineEntry{
+			Tick:        frame.Tick,
+			SimulatedMs: frame.SimulatedMs,
+			CapturedAt:  captured,
+			Type:        "world",
+			Payload:     append(json.RawMessage(nil), frame.Payload...),
+		})
+	}
+
+	//3.- Include gameplay events so match logs replay deterministically.
+	for _, event := range envelope.Events {
+		captured, err := time.Parse(time.RFC3339Nano, event.CapturedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse event captured_at: %w", err)
+		}
+		entries = append(entries, TimelineEntry{
+			Tick:        event.Tick,
+			SimulatedMs: event.SimulatedMs,
+			CapturedAt:  captured,
+			Type:        "event",
+			Payload:     append(json.RawMessage(nil), event.Payload...),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].SimulatedMs == entries[j].SimulatedMs {
+			if entries[i].Tick == entries[j].Tick {
+				return entries[i].Type < entries[j].Type
+			}
+			return entries[i].Tick < entries[j].Tick
+		}
+		return entries[i].SimulatedMs < entries[j].SimulatedMs
+	})
+
+	return &Loader{entries: entries}, nil
+}
+
+// Replay iterates over the loaded entries in deterministic order.
+func (l *Loader) Replay(apply func(TimelineEntry) error) error {
+	if l == nil {
+		return fmt.Errorf("loader not initialised")
+	}
+	if apply == nil {
+		return fmt.Errorf("replay callback must be provided")
+	}
+	for _, entry := range l.entries {
+		//1.- Invoke the callback for each timeline entry to drive the validation sim.
+		if err := apply(entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Entries exposes a defensive copy of the timeline for external assertions.
+func (l *Loader) Entries() []TimelineEntry {
+	if l == nil {
+		return nil
+	}
+	out := make([]TimelineEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}

--- a/go-broker/internal/replay/loader_test.go
+++ b/go-broker/internal/replay/loader_test.go
@@ -1,0 +1,71 @@
+package replay
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestLoaderReplayOrdering(t *testing.T) {
+	dir := t.TempDir()
+	current := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return current }
+
+	recorder, err := NewRecorder(dir, clock)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	recorder.RecordEvent(5, 900, []byte(`{"event":"late"}`))
+	recorder.RecordWorldFrame(3, 600, []byte(`{"frame":3}`))
+	recorder.RecordTick(1, 100, []byte(`{"tick":1}`))
+	recorder.RecordEvent(1, 100, []byte(`{"event":"start"}`))
+	recorder.RecordWorldFrame(2, 400, []byte(`{"frame":2}`))
+	recorder.RecordTick(2, 300, []byte(`{"tick":2}`))
+
+	path, err := recorder.Roll("beta")
+	if err != nil {
+		t.Fatalf("Roll: %v", err)
+	}
+
+	if filepath.Ext(path) != ".gz" {
+		t.Fatalf("expected gzip artefact, got %s", path)
+	}
+
+	loader, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	var sequence []string
+	err = loader.Replay(func(entry TimelineEntry) error {
+		//1.- Capture the ordered sequence for deterministic assertions.
+		sequence = append(sequence, fmt.Sprintf("%s:%d:%d", entry.Type, entry.Tick, entry.SimulatedMs))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+
+	expected := []string{
+		"diff:1:100",
+		"event:1:100",
+		"diff:2:300",
+		"world:2:400",
+		"world:3:600",
+		"event:5:900",
+	}
+	if !reflect.DeepEqual(sequence, expected) {
+		t.Fatalf("unexpected replay order: %v", sequence)
+	}
+
+	entries := loader.Entries()
+	if len(entries) != len(sequence) {
+		t.Fatalf("expected %d entries copy, got %d", len(sequence), len(entries))
+	}
+	if &entries[0] == &loader.entries[0] {
+		t.Fatalf("Entries must return a defensive copy")
+	}
+}

--- a/go-broker/internal/replay/recorder.go
+++ b/go-broker/internal/replay/recorder.go
@@ -1,6 +1,7 @@
 package replay
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -14,9 +15,26 @@ var matchIDCleaner = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 
 // TickFrame stores the payload for a single simulation tick.
 type TickFrame struct {
-	Tick       uint64
-	CapturedAt time.Time
-	Payload    []byte
+	Tick        uint64
+	CapturedAt  time.Time
+	SimulatedMs int64
+	Payload     []byte
+}
+
+// WorldFrame captures a full world snapshot suitable for deterministic replays.
+type WorldFrame struct {
+	Tick        uint64
+	CapturedAt  time.Time
+	SimulatedMs int64
+	Payload     []byte
+}
+
+// EventRecord stores a single gameplay event emitted during a match.
+type EventRecord struct {
+	Tick        uint64
+	CapturedAt  time.Time
+	SimulatedMs int64
+	Payload     []byte
 }
 
 // Recorder buffers authoritative tick deltas until they are flushed to disk.
@@ -25,6 +43,8 @@ type Recorder struct {
 	dir         string
 	now         func() time.Time
 	frames      []TickFrame
+	worldFrames []WorldFrame
+	events      []EventRecord
 	bytes       int64
 	dumps       int64
 	lastDump    time.Time
@@ -34,6 +54,8 @@ type Recorder struct {
 // Stats summarises recorder health for monitoring endpoints.
 type Stats struct {
 	BufferedFrames int
+	BufferedWorld  int
+	BufferedEvents int
 	BufferedBytes  int64
 	Dumps          int64
 	LastDumpURI    string
@@ -55,7 +77,7 @@ func NewRecorder(dir string, clock func() time.Time) (*Recorder, error) {
 }
 
 // RecordTick appends the encoded delta for the supplied tick to the buffer.
-func (r *Recorder) RecordTick(tick uint64, payload []byte) {
+func (r *Recorder) RecordTick(tick uint64, simulatedMs int64, payload []byte) {
 	if r == nil || len(payload) == 0 {
 		return
 	}
@@ -64,7 +86,37 @@ func (r *Recorder) RecordTick(tick uint64, payload []byte) {
 
 	r.mu.Lock()
 	//1.- Track buffered frames so future monitoring captures outstanding work.
-	r.frames = append(r.frames, TickFrame{Tick: tick, CapturedAt: captured, Payload: clone})
+	r.frames = append(r.frames, TickFrame{Tick: tick, CapturedAt: captured, SimulatedMs: simulatedMs, Payload: clone})
+	r.bytes += int64(len(clone))
+	r.mu.Unlock()
+}
+
+// RecordWorldFrame appends a full world snapshot captured at the configured cadence.
+func (r *Recorder) RecordWorldFrame(tick uint64, simulatedMs int64, payload []byte) {
+	if r == nil || len(payload) == 0 {
+		return
+	}
+	clone := append([]byte(nil), payload...)
+	captured := r.now().UTC()
+
+	r.mu.Lock()
+	//1.- Buffer the snapshot so match teardown can persist deterministic frames.
+	r.worldFrames = append(r.worldFrames, WorldFrame{Tick: tick, CapturedAt: captured, SimulatedMs: simulatedMs, Payload: clone})
+	r.bytes += int64(len(clone))
+	r.mu.Unlock()
+}
+
+// RecordEvent appends a single gameplay event payload for later persistence.
+func (r *Recorder) RecordEvent(tick uint64, simulatedMs int64, payload []byte) {
+	if r == nil || len(payload) == 0 {
+		return
+	}
+	clone := append([]byte(nil), payload...)
+	captured := r.now().UTC()
+
+	r.mu.Lock()
+	//1.- Buffer each event independently so the loader can reconstruct timelines.
+	r.events = append(r.events, EventRecord{Tick: tick, CapturedAt: captured, SimulatedMs: simulatedMs, Payload: clone})
 	r.bytes += int64(len(clone))
 	r.mu.Unlock()
 }
@@ -78,7 +130,7 @@ func (r *Recorder) Roll(matchID string) (string, error) {
 	defer r.mu.Unlock()
 
 	//1.- Bail out gracefully when nothing has been recorded yet.
-	if len(r.frames) == 0 {
+	if len(r.frames) == 0 && len(r.worldFrames) == 0 && len(r.events) == 0 {
 		return "", fmt.Errorf("no replay frames buffered")
 	}
 
@@ -87,40 +139,97 @@ func (r *Recorder) Roll(matchID string) (string, error) {
 		cleanedID = "match"
 	}
 	timestamp := r.now().UTC().Format("20060102T150405Z")
-	filename := fmt.Sprintf("%s-%s.json", cleanedID, timestamp)
+	filename := fmt.Sprintf("%s-%s.json.gz", cleanedID, timestamp)
 	path := filepath.Join(r.dir, filename)
 
 	//2.- Encode frames using JSON so downstream tooling can parse them easily.
 	envelope := struct {
 		SavedAt string `json:"saved_at"`
 		Frames  []struct {
-			Tick       uint64          `json:"tick"`
-			CapturedAt string          `json:"captured_at"`
-			Payload    json.RawMessage `json:"payload"`
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
 		} `json:"frames"`
+		WorldFrames []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"world_frames"`
+		Events []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"events"`
 	}{SavedAt: timestamp}
 	envelope.Frames = make([]struct {
-		Tick       uint64          `json:"tick"`
-		CapturedAt string          `json:"captured_at"`
-		Payload    json.RawMessage `json:"payload"`
+		Tick        uint64          `json:"tick"`
+		CapturedAt  string          `json:"captured_at"`
+		SimulatedMs int64           `json:"simulated_ms"`
+		Payload     json.RawMessage `json:"payload"`
 	}, len(r.frames))
+	envelope.WorldFrames = make([]struct {
+		Tick        uint64          `json:"tick"`
+		CapturedAt  string          `json:"captured_at"`
+		SimulatedMs int64           `json:"simulated_ms"`
+		Payload     json.RawMessage `json:"payload"`
+	}, len(r.worldFrames))
+	envelope.Events = make([]struct {
+		Tick        uint64          `json:"tick"`
+		CapturedAt  string          `json:"captured_at"`
+		SimulatedMs int64           `json:"simulated_ms"`
+		Payload     json.RawMessage `json:"payload"`
+	}, len(r.events))
 
 	for idx, frame := range r.frames {
 		envelope.Frames[idx].Tick = frame.Tick
 		envelope.Frames[idx].CapturedAt = frame.CapturedAt.Format(time.RFC3339Nano)
+		envelope.Frames[idx].SimulatedMs = frame.SimulatedMs
 		envelope.Frames[idx].Payload = json.RawMessage(frame.Payload)
+	}
+
+	for idx, frame := range r.worldFrames {
+		envelope.WorldFrames[idx].Tick = frame.Tick
+		envelope.WorldFrames[idx].CapturedAt = frame.CapturedAt.Format(time.RFC3339Nano)
+		envelope.WorldFrames[idx].SimulatedMs = frame.SimulatedMs
+		envelope.WorldFrames[idx].Payload = json.RawMessage(frame.Payload)
+	}
+
+	for idx, event := range r.events {
+		envelope.Events[idx].Tick = event.Tick
+		envelope.Events[idx].CapturedAt = event.CapturedAt.Format(time.RFC3339Nano)
+		envelope.Events[idx].SimulatedMs = event.SimulatedMs
+		envelope.Events[idx].Payload = json.RawMessage(event.Payload)
 	}
 
 	data, err := json.MarshalIndent(envelope, "", "  ")
 	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	file, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	writer := gzip.NewWriter(file)
+	if _, err := writer.Write(data); err != nil {
+		_ = writer.Close()
+		_ = file.Close()
+		return "", err
+	}
+	if err := writer.Close(); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
 		return "", err
 	}
 
 	//3.- Reset the buffer so a fresh match can begin immediately.
 	r.frames = nil
+	r.worldFrames = nil
+	r.events = nil
 	r.bytes = 0
 	r.dumps++
 	r.lastDump = r.now().UTC()
@@ -139,6 +248,8 @@ func (r *Recorder) Snapshot() Stats {
 	//1.- Copy the counters so monitoring endpoints avoid racing with the writer.
 	stats := Stats{
 		BufferedFrames: len(r.frames),
+		BufferedWorld:  len(r.worldFrames),
+		BufferedEvents: len(r.events),
 		BufferedBytes:  r.bytes,
 		Dumps:          r.dumps,
 		LastDumpURI:    r.lastDumpURI,

--- a/go-broker/internal/replay/recorder_test.go
+++ b/go-broker/internal/replay/recorder_test.go
@@ -1,7 +1,9 @@
 package replay
 
 import (
+	"compress/gzip"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,13 +20,22 @@ func TestRecorderRollsToDisk(t *testing.T) {
 		t.Fatalf("NewRecorder: %v", err)
 	}
 
-	recorder.RecordTick(1, []byte(`{"tick":1}`))
+	recorder.RecordTick(1, 0, []byte(`{"tick":1}`))
+	recorder.RecordWorldFrame(1, 0, []byte(`{"state":"frame"}`))
+	recorder.RecordEvent(1, 0, []byte(`{"event":"spawn"}`))
 	current = current.Add(10 * time.Millisecond)
-	recorder.RecordTick(2, []byte(`{"tick":2}`))
+	recorder.RecordTick(2, 10, []byte(`{"tick":2}`))
+	recorder.RecordEvent(2, 10, []byte(`{"event":"score"}`))
 
 	stats := recorder.Snapshot()
 	if stats.BufferedFrames != 2 {
 		t.Fatalf("expected 2 buffered frames, got %d", stats.BufferedFrames)
+	}
+	if stats.BufferedWorld != 1 {
+		t.Fatalf("expected 1 buffered world frame, got %d", stats.BufferedWorld)
+	}
+	if stats.BufferedEvents != 2 {
+		t.Fatalf("expected 2 buffered events, got %d", stats.BufferedEvents)
 	}
 	if stats.BufferedBytes == 0 {
 		t.Fatalf("expected buffered bytes to be tracked")
@@ -38,23 +49,53 @@ func TestRecorderRollsToDisk(t *testing.T) {
 		t.Fatalf("unexpected roll directory: %s", path)
 	}
 
-	data, err := os.ReadFile(path)
+	artifact, err := os.Open(path)
 	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
+		t.Fatalf("Open: %v", err)
 	}
-	var file struct {
+	defer artifact.Close()
+
+	gz, err := gzip.NewReader(artifact)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	defer gz.Close()
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	var dump struct {
 		SavedAt string `json:"saved_at"`
 		Frames  []struct {
-			Tick       uint64          `json:"tick"`
-			CapturedAt string          `json:"captured_at"`
-			Payload    json.RawMessage `json:"payload"`
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
 		} `json:"frames"`
+		WorldFrames []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"world_frames"`
+		Events []struct {
+			Tick        uint64          `json:"tick"`
+			CapturedAt  string          `json:"captured_at"`
+			SimulatedMs int64           `json:"simulated_ms"`
+			Payload     json.RawMessage `json:"payload"`
+		} `json:"events"`
 	}
-	if err := json.Unmarshal(data, &file); err != nil {
+	if err := json.Unmarshal(data, &dump); err != nil {
 		t.Fatalf("decode roll: %v", err)
 	}
-	if len(file.Frames) != 2 {
-		t.Fatalf("expected two frames, got %d", len(file.Frames))
+	if len(dump.Frames) != 2 {
+		t.Fatalf("expected two frames, got %d", len(dump.Frames))
+	}
+	if len(dump.WorldFrames) != 1 {
+		t.Fatalf("expected one world frame, got %d", len(dump.WorldFrames))
+	}
+	if len(dump.Events) != 2 {
+		t.Fatalf("expected two events, got %d", len(dump.Events))
 	}
 
 	stats = recorder.Snapshot()


### PR DESCRIPTION
## Summary
- capture tick diffs, periodic world snapshots, and events in the replay recorder and persist them as compressed artefacts
- add a replay loader utility for deterministic validation and expose default replay storage under storage/replays
- extend broker integration and unit tests to exercise the new recorder and loader behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68deed3f5c04832984719bcacea2ccd0