### PR TITLE
Add divergence-free field generation and swept tube utilities

### DIFF
--- a/tunnelcave_sandbox/src/__init__.py
+++ b/tunnelcave_sandbox/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules for tunnel cave sandbox generation utilities."""

--- a/tunnelcave_sandbox/src/generation/__init__.py
+++ b/tunnelcave_sandbox/src/generation/__init__.py
@@ -1,0 +1,26 @@
+"""Generation utilities for tunnel cave sandbox."""
+from .config import GenerationSeeds, load_generation_config
+from .divergence_free import (
+    DivergenceFreeField,
+    CurlHarmonic,
+    finite_difference_divergence,
+    integrate_streamline,
+)
+from .swept_tube import SweptTube, TubeSegment, build_swept_tube, generate_seeded_tube
+from .visualization import ContinuitySample, export_continuity_csv, sample_tube_clearance
+
+__all__ = [
+    "GenerationSeeds",
+    "load_generation_config",
+    "DivergenceFreeField",
+    "CurlHarmonic",
+    "finite_difference_divergence",
+    "integrate_streamline",
+    "SweptTube",
+    "TubeSegment",
+    "build_swept_tube",
+    "generate_seeded_tube",
+    "ContinuitySample",
+    "export_continuity_csv",
+    "sample_tube_clearance",
+]

--- a/tunnelcave_sandbox/src/generation/config.py
+++ b/tunnelcave_sandbox/src/generation/config.py
@@ -1,0 +1,55 @@
+"""Configuration helpers for deterministic tunnel cave generation."""
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+# //1.- Define dataclass to encapsulate generation seeds for reproducibility.
+@dataclass(frozen=True)
+class GenerationSeeds:
+    """Seeds driving the stochastic parts of cave generation."""
+
+    divergence_seed: int = 0
+    path_seed: int = 0
+
+    # //2.- Provide helper to mutate seeds from mapping when available.
+    @classmethod
+    def from_mapping(cls, payload: Optional[Dict[str, int]] = None) -> "GenerationSeeds":
+        if not payload:
+            return cls()
+        return cls(
+            divergence_seed=int(payload.get("divergence_seed", 0)),
+            path_seed=int(payload.get("path_seed", 0)),
+        )
+
+    # //3.- Allow overriding seeds through environment variables for integration tests.
+    @classmethod
+    def from_environment(cls, prefix: str = "TUNNELCAVE") -> "GenerationSeeds":
+        divergence = os.getenv(f"{prefix}_DIVERGENCE_SEED")
+        path = os.getenv(f"{prefix}_PATH_SEED")
+        mapping: Dict[str, int] = {}
+        if divergence is not None:
+            mapping["divergence_seed"] = int(divergence)
+        if path is not None:
+            mapping["path_seed"] = int(path)
+        return cls.from_mapping(mapping)
+
+    # //4.- Utility returning numpy RNG objects for each subsystem.
+    def create_generators(self) -> Dict[str, random.Random]:
+        return {
+            "divergence": random.Random(self.divergence_seed),
+            "path": random.Random(self.path_seed),
+        }
+
+
+# //5.- Provide canonical configuration accessor used across modules.
+def load_generation_config(
+    mapping: Optional[Dict[str, int]] = None,
+    *,
+    env_prefix: str = "TUNNELCAVE",
+) -> GenerationSeeds:
+    if mapping is not None:
+        return GenerationSeeds.from_mapping(mapping)
+    return GenerationSeeds.from_environment(prefix=env_prefix)

--- a/tunnelcave_sandbox/src/generation/divergence_free.py
+++ b/tunnelcave_sandbox/src/generation/divergence_free.py
@@ -1,0 +1,159 @@
+"""Divergence-free noise utilities for cave generation."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+from .config import GenerationSeeds
+
+
+# //1.- Describe a harmonic component used to assemble curl noise.
+@dataclass
+class CurlHarmonic:
+    wave_vector: Tuple[float, float, float]
+    generator_vector: Tuple[float, float, float]
+    phase: float
+    weight: float
+
+    # //2.- Precompute the curl direction ensuring divergence-free contributions.
+    def curl_direction(self) -> Tuple[float, float, float]:
+        direction = _cross(self.wave_vector, self.generator_vector)
+        norm = _norm(direction)
+        if norm == 0:
+            # //3.- Degenerate case fallback by rotating generator vector.
+            axis = (
+                self.wave_vector[1],
+                -self.wave_vector[0],
+                self.wave_vector[2],
+            )
+            direction = _cross(self.wave_vector, axis)
+            norm = _norm(direction)
+        return _scale(direction, self.weight / max(norm, 1e-9))
+
+
+# //4.- Helper generating harmonics from seeded random state.
+def _create_harmonics(
+    rng,
+    count: int,
+    frequency_range: Sequence[float] = (0.3, 2.5),
+) -> List[CurlHarmonic]:
+    harmonics: List[CurlHarmonic] = []
+    low, high = frequency_range
+    for _ in range(count):
+        wave = tuple(rng.uniform(low, high) for _ in range(3))
+        orient = tuple(rng.uniform(-1.0, 1.0) for _ in range(3))
+        phase = rng.uniform(0, 2 * math.pi)
+        weight = rng.uniform(0.4, 1.0)
+        harmonics.append(
+            CurlHarmonic(
+                wave_vector=wave,
+                generator_vector=orient,
+                phase=phase,
+                weight=weight,
+            )
+        )
+    return harmonics
+
+
+# //5.- Divergence-free field assembled as a sum of curl harmonics.
+@dataclass
+class DivergenceFreeField:
+    harmonics: Sequence[CurlHarmonic]
+
+    # //6.- Sample the vector field at a single 3D position.
+    def sample(self, position: Sequence[float]) -> Tuple[float, float, float]:
+        pos = _vector(position)
+        total = (0.0, 0.0, 0.0)
+        for harmonic in self.harmonics:
+            curl_dir = harmonic.curl_direction()
+            argument = _dot(harmonic.wave_vector, pos) + harmonic.phase
+            total = _add(total, _scale(curl_dir, math.cos(argument)))
+        return total
+
+    # //7.- Vectorized sampling across multiple positions for efficiency.
+    def batch_sample(self, positions: Sequence[Sequence[float]]) -> List[Tuple[float, float, float]]:
+        return [self.sample(pos) for pos in positions]
+
+    # //8.- Derive deterministic field from configured seeds.
+    @classmethod
+    def from_seeds(cls, seeds: GenerationSeeds, harmonic_count: int = 6) -> "DivergenceFreeField":
+        generators = seeds.create_generators()
+        harmonics = _create_harmonics(generators["divergence"], harmonic_count)
+        return cls(harmonics=harmonics)
+
+
+# //9.- Utility approximating divergence using central differences for validation.
+def finite_difference_divergence(
+    field: DivergenceFreeField,
+    position: Sequence[float],
+    epsilon: float = 1e-3,
+) -> float:
+    pos = _vector(position)
+    offsets = (
+        (epsilon, 0.0, 0.0),
+        (0.0, epsilon, 0.0),
+        (0.0, 0.0, epsilon),
+    )
+    divergence = 0.0
+    for axis in range(3):
+        forward = field.sample(_add(pos, offsets[axis]))
+        backward = field.sample(_subtract(pos, offsets[axis]))
+        divergence += (forward[axis] - backward[axis]) / (2 * epsilon)
+    return float(divergence)
+
+
+# //10.- Convenience method generating field trajectories for seeded paths.
+def integrate_streamline(
+    field: DivergenceFreeField,
+    *,
+    seed: Sequence[float],
+    steps: int,
+    step_size: float,
+) -> List[Tuple[float, float, float]]:
+    pos = list(_vector(seed))
+    points: List[Tuple[float, float, float]] = [tuple(pos)]
+    for _ in range(steps):
+        direction = field.sample(pos)
+        norm = _norm(direction)
+        if norm < 1e-6:
+            direction = (1.0, 0.0, 0.0)
+            norm = 1.0
+        step_vec = _scale(direction, step_size / norm)
+        pos = list(_add(pos, step_vec))
+        points.append(tuple(pos))
+    return points
+
+
+# //11.- Vector helper operations replacing NumPy dependencies.
+def _vector(values: Sequence[float]) -> Tuple[float, float, float]:
+    a, b, c = values
+    return float(a), float(b), float(c)
+
+
+def _add(a: Sequence[float], b: Sequence[float]) -> Tuple[float, float, float]:
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def _subtract(a: Sequence[float], b: Sequence[float]) -> Tuple[float, float, float]:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _scale(a: Sequence[float], scalar: float) -> Tuple[float, float, float]:
+    return (a[0] * scalar, a[1] * scalar, a[2] * scalar)
+
+
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _cross(a: Sequence[float], b: Sequence[float]) -> Tuple[float, float, float]:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def _norm(a: Sequence[float]) -> float:
+    return math.sqrt(_dot(a, a))

--- a/tunnelcave_sandbox/src/generation/swept_tube.py
+++ b/tunnelcave_sandbox/src/generation/swept_tube.py
@@ -1,0 +1,126 @@
+"""Swept tube construction around divergence-free streamlines."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Sequence, Tuple
+
+from .divergence_free import DivergenceFreeField, integrate_streamline
+
+
+# //1.- Basic vector helpers for arithmetic without external dependencies.
+def _vec_add(a: Sequence[float], b: Sequence[float]) -> Tuple[float, float, float]:
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def _vec_sub(a: Sequence[float], b: Sequence[float]) -> Tuple[float, float, float]:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _vec_scale(a: Sequence[float], scalar: float) -> Tuple[float, float, float]:
+    return (a[0] * scalar, a[1] * scalar, a[2] * scalar)
+
+
+def _vec_dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _vec_norm(a: Sequence[float]) -> float:
+    return (_vec_dot(a, a)) ** 0.5
+
+
+# //2.- Represent a single tube segment storing analytic SDF evaluation.
+@dataclass
+class TubeSegment:
+    start: Tuple[float, float, float]
+    end: Tuple[float, float, float]
+    radius_start: float
+    radius_end: float
+
+    # //3.- Compute minimum distance from point to the segment centerline.
+    def distance_to_point(self, point: Tuple[float, float, float]) -> float:
+        segment = _vec_sub(self.end, self.start)
+        length_sq = _vec_dot(segment, segment)
+        if length_sq == 0:
+            return _vec_norm(_vec_sub(point, self.start))
+        t = _vec_dot(_vec_sub(point, self.start), segment) / length_sq
+        t_clamped = max(0.0, min(1.0, t))
+        projection = _vec_add(self.start, _vec_scale(segment, t_clamped))
+        return _vec_norm(_vec_sub(point, projection))
+
+    # //4.- Interpolate radius along the segment for varying thickness.
+    def radius_at(self, point: Tuple[float, float, float]) -> float:
+        segment = _vec_sub(self.end, self.start)
+        length_sq = _vec_dot(segment, segment)
+        if length_sq == 0:
+            return self.radius_start
+        t = _vec_dot(_vec_sub(point, self.start), segment) / length_sq
+        t_clamped = max(0.0, min(1.0, t))
+        return self.radius_start + (self.radius_end - self.radius_start) * t_clamped
+
+    # //5.- Signed distance function using analytic closest point evaluation.
+    def sdf(self, point: Sequence[float]) -> float:
+        pos = tuple(float(v) for v in point)
+        distance = self.distance_to_point(pos)
+        radius = self.radius_at(pos)
+        return distance - radius
+
+
+# //6.- Complete swept tube storing ordered segments with evaluation utilities.
+@dataclass
+class SweptTube:
+    segments: Sequence[TubeSegment]
+
+    # //7.- Signed distance function defined as minimum distance across segments.
+    def sdf(self, point: Sequence[float]) -> float:
+        pos = tuple(float(v) for v in point)
+        return min(segment.sdf(pos) for segment in self.segments)
+
+    # //8.- Expose analytic SDF definition for sampling functions.
+    def analytic_sdf(self) -> Callable[[Sequence[float]], float]:
+        return lambda p: self.sdf(p)
+
+    # //9.- Generate dense sampling for visualization or testing.
+    def sample_along_path(self, resolution: int) -> List[Tuple[float, float, float]]:
+        samples: List[Tuple[float, float, float]] = []
+        for segment in self.segments:
+            for step in range(resolution):
+                ratio = step / max(1, resolution)
+                point = _vec_add(segment.start, _vec_scale(_vec_sub(segment.end, segment.start), ratio))
+                samples.append(point)
+        samples.append(self.segments[-1].end)
+        return samples
+
+
+# //10.- Build swept tube from path points and radius definition.
+def build_swept_tube(path: Sequence[Sequence[float]], radius: Callable[[int, int], float]) -> SweptTube:
+    segments: List[TubeSegment] = []
+    for idx in range(len(path) - 1):
+        start = tuple(float(v) for v in path[idx])
+        end = tuple(float(v) for v in path[idx + 1])
+        radius_start = float(radius(idx, len(path)))
+        radius_end = float(radius(idx + 1, len(path)))
+        segments.append(
+            TubeSegment(start=start, end=end, radius_start=radius_start, radius_end=radius_end)
+        )
+    return SweptTube(segments=segments)
+
+
+# //11.- Helper synthesizing swept tube directly from divergence-free field seeds.
+def generate_seeded_tube(
+    field: DivergenceFreeField,
+    *,
+    seed: Sequence[float],
+    steps: int,
+    step_size: float,
+    base_radius: float,
+    radius_variation: float,
+) -> SweptTube:
+    path = integrate_streamline(field, seed=seed, steps=steps, step_size=step_size)
+
+    def radius(index: int, total: int) -> float:
+        if total <= 1:
+            return base_radius
+        ratio = index / (total - 1)
+        return base_radius + radius_variation * (0.5 - abs(ratio - 0.5))
+
+    return build_swept_tube(path, radius=radius)

--- a/tunnelcave_sandbox/src/generation/visualization.py
+++ b/tunnelcave_sandbox/src/generation/visualization.py
@@ -1,0 +1,57 @@
+"""Lightweight visualization helpers for cave continuity analysis."""
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .swept_tube import SweptTube, _vec_add, _vec_norm
+
+
+# //1.- Dataclass capturing sampled continuity information.
+@dataclass
+class ContinuitySample:
+    arc_length: float
+    clearance: float
+    radius: float
+
+
+# //2.- Sample clearance by querying SDF around the tube centerline.
+def sample_tube_clearance(
+    tube: SweptTube,
+    *,
+    step: float,
+    lateral_offsets: Sequence[Sequence[float]],
+) -> Iterable[ContinuitySample]:
+    points = tube.sample_along_path(max(2, int(1.0 / max(step, 1e-6))))
+    arc_length = 0.0
+    previous = points[0]
+    for center_point in points[1:]:
+        segment_length = _vec_norm(
+            (
+                center_point[0] - previous[0],
+                center_point[1] - previous[1],
+                center_point[2] - previous[2],
+            )
+        )
+        arc_length += segment_length
+        previous = center_point
+        distances = []
+        for offset in lateral_offsets:
+            query = _vec_add(center_point, offset)
+            distances.append(tube.sdf(query))
+        clearance = min(distances) if distances else tube.sdf(center_point)
+        radius = -tube.sdf(center_point)
+        yield ContinuitySample(arc_length=arc_length, clearance=clearance, radius=radius)
+
+
+# //3.- Export sampled continuity profile to CSV for manual visualization.
+def export_continuity_csv(
+    samples: Iterable[ContinuitySample],
+    filepath: str,
+) -> None:
+    with open(filepath, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["arc_length", "clearance", "radius"])
+        for sample in samples:
+            writer.writerow([sample.arc_length, sample.clearance, sample.radius])

--- a/tunnelcave_sandbox/tests/conftest.py
+++ b/tunnelcave_sandbox/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for tunnelcave sandbox tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# //1.- Ensure repository root is available on the Python path for package imports.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tunnelcave_sandbox/tests/test_divergence_free.py
+++ b/tunnelcave_sandbox/tests/test_divergence_free.py
@@ -1,0 +1,29 @@
+"""Tests for divergence-free noise utilities."""
+from __future__ import annotations
+
+import pytest
+
+from tunnelcave_sandbox.src.generation import (
+    DivergenceFreeField,
+    GenerationSeeds,
+    finite_difference_divergence,
+)
+
+
+def test_divergence_is_near_zero():
+    seeds = GenerationSeeds(divergence_seed=123, path_seed=999)
+    field = DivergenceFreeField.from_seeds(seeds, harmonic_count=4)
+    samples = []
+    for step in range(5):
+        offset = -0.5 + step * 0.25
+        point = (0.2 + offset, -0.1 + 0.5 * offset, 0.3 - 0.2 * offset)
+        samples.append(abs(finite_difference_divergence(field, point)))
+    assert max(samples) < 1e-3
+
+
+def test_seeded_fields_are_reproducible():
+    seeds = GenerationSeeds(divergence_seed=77, path_seed=12)
+    field_a = DivergenceFreeField.from_seeds(seeds, harmonic_count=5)
+    field_b = DivergenceFreeField.from_seeds(seeds, harmonic_count=5)
+    point = (0.25, -0.4, 0.75)
+    assert field_a.sample(point) == pytest.approx(field_b.sample(point))

--- a/tunnelcave_sandbox/tests/test_swept_tube.py
+++ b/tunnelcave_sandbox/tests/test_swept_tube.py
@@ -1,0 +1,50 @@
+"""Tests for swept tube generation and analytic SDF."""
+from __future__ import annotations
+
+import pytest
+
+from tunnelcave_sandbox.src.generation import (
+    DivergenceFreeField,
+    GenerationSeeds,
+    generate_seeded_tube,
+)
+
+
+def test_seeded_tube_produces_reasonable_sdf():
+    seeds = GenerationSeeds(divergence_seed=5, path_seed=10)
+    field = DivergenceFreeField.from_seeds(seeds, harmonic_count=3)
+    tube = generate_seeded_tube(
+        field,
+        seed=(0.0, 0.0, 0.0),
+        steps=15,
+        step_size=0.3,
+        base_radius=0.25,
+        radius_variation=0.1,
+    )
+    centerline = tube.sample_along_path(5)
+    for point in centerline:
+        clearance = -tube.sdf(point)
+        assert clearance >= 0
+        assert 0.15 <= clearance <= 0.35
+    outside_point = (
+        centerline[len(centerline) // 2][0] + 1.0,
+        centerline[len(centerline) // 2][1],
+        centerline[len(centerline) // 2][2],
+    )
+    assert tube.sdf(outside_point) > 0.5
+
+
+def test_sdf_is_consistent_with_analytic_callable():
+    seeds = GenerationSeeds(divergence_seed=7, path_seed=2)
+    field = DivergenceFreeField.from_seeds(seeds, harmonic_count=4)
+    tube = generate_seeded_tube(
+        field,
+        seed=(0.0, 0.0, 0.0),
+        steps=10,
+        step_size=0.2,
+        base_radius=0.2,
+        radius_variation=0.05,
+    )
+    sdf_func = tube.analytic_sdf()
+    sample_point = (0.5, 0.2, -0.1)
+    assert sdf_func(sample_point) == pytest.approx(tube.sdf(sample_point))

--- a/tunnelcave_sandbox/tests/test_visualization.py
+++ b/tunnelcave_sandbox/tests/test_visualization.py
@@ -1,0 +1,40 @@
+"""Tests validating visualization sampling utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tunnelcave_sandbox.src.generation import (
+    DivergenceFreeField,
+    GenerationSeeds,
+    export_continuity_csv,
+    generate_seeded_tube,
+    sample_tube_clearance,
+)
+
+
+def test_clearance_sampling_monotonic_arc_length(tmp_path: Path):
+    seeds = GenerationSeeds(divergence_seed=8, path_seed=21)
+    field = DivergenceFreeField.from_seeds(seeds, harmonic_count=3)
+    tube = generate_seeded_tube(
+        field,
+        seed=(0.0, 0.0, 0.0),
+        steps=12,
+        step_size=0.25,
+        base_radius=0.2,
+        radius_variation=0.08,
+    )
+    offsets = [
+        (0.2, 0.0, 0.0),
+        (-0.2, 0.0, 0.0),
+        (0.0, 0.2, 0.0),
+    ]
+    samples = list(sample_tube_clearance(tube, step=0.1, lateral_offsets=offsets))
+    arc_lengths = [sample.arc_length for sample in samples]
+    assert arc_lengths == sorted(arc_lengths)
+
+    export_path = tmp_path / "continuity.csv"
+    export_continuity_csv(samples, str(export_path))
+    assert export_path.exists()
+    assert export_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add deterministic configuration seeds and divergence-free noise field utilities for tunnel cave generation
- build swept tube primitives with analytic SDF sampling plus visualization helpers for continuity analysis
- cover new functionality with pytest-based regression tests

## Testing
- pytest tunnelcave_sandbox/tests

------
https://chatgpt.com/codex/tasks/task_e_68def03df3688329b3e3e9e2ca792041