### PR TITLE
Add configurable loop generation and metrics checks

### DIFF
--- a/tunnelcave_sandbox/config/clearance.json
+++ b/tunnelcave_sandbox/config/clearance.json
@@ -1,0 +1,13 @@
+{
+  "min_clearance_m": 3.0,
+  "target_average_clearance_m": 5.0,
+  "min_radius_m": 4.0,
+  "max_radius_m": 30.0,
+  "sampling_step": 0.25,
+  "lateral_sample_offsets": [
+    [35.0, 0.0, 0.0],
+    [-35.0, 0.0, 0.0],
+    [0.0, 35.0, 0.0],
+    [0.0, -35.0, 0.0]
+  ]
+}

--- a/tunnelcave_sandbox/config/loop.json
+++ b/tunnelcave_sandbox/config/loop.json
@@ -1,0 +1,4 @@
+{
+  "target_length_m": 600.0,
+  "step_size_m": 5.0
+}

--- a/tunnelcave_sandbox/config/rooms.json
+++ b/tunnelcave_sandbox/config/rooms.json
@@ -1,0 +1,4 @@
+{
+  "room_diameter_m": 50.0,
+  "room_probability": 0.12
+}

--- a/tunnelcave_sandbox/src/generation/__init__.py
+++ b/tunnelcave_sandbox/src/generation/__init__.py
@@ -8,6 +8,14 @@ from .divergence_free import (
 )
 from .swept_tube import SweptTube, TubeSegment, build_swept_tube, generate_seeded_tube
 from .visualization import ContinuitySample, export_continuity_csv, sample_tube_clearance
+from .settings import GeneratorSettings, LoopSettings, RoomSettings, ClearanceSettings, load_generator_settings
+from .loop_generation import (
+    LoopProfile,
+    LoopGenerationResult,
+    generate_loop_tube,
+    verify_loop_clearance,
+)
+from .metrics import LoopMetrics, MetricsSummary, collect_generation_metrics, export_generation_metrics
 
 __all__ = [
     "GenerationSeeds",
@@ -20,6 +28,19 @@ __all__ = [
     "TubeSegment",
     "build_swept_tube",
     "generate_seeded_tube",
+    "GeneratorSettings",
+    "LoopSettings",
+    "RoomSettings",
+    "ClearanceSettings",
+    "load_generator_settings",
+    "LoopProfile",
+    "LoopGenerationResult",
+    "generate_loop_tube",
+    "verify_loop_clearance",
+    "LoopMetrics",
+    "MetricsSummary",
+    "collect_generation_metrics",
+    "export_generation_metrics",
     "ContinuitySample",
     "export_continuity_csv",
     "sample_tube_clearance",

--- a/tunnelcave_sandbox/src/generation/loop_generation.py
+++ b/tunnelcave_sandbox/src/generation/loop_generation.py
@@ -1,0 +1,113 @@
+"""High-level loop generation orchestrating radius and clearance constraints."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+from .config import GenerationSeeds
+from .divergence_free import DivergenceFreeField, integrate_streamline
+from .swept_tube import SweptTube, build_swept_tube
+from .settings import GeneratorSettings
+
+
+# //1.- Describe the generated loop profile for downstream validation and metrics.
+@dataclass(frozen=True)
+class LoopProfile:
+    radii: Sequence[float]
+    room_indices: Sequence[int]
+
+
+# //2.- Capture both the swept tube and supporting profile metadata.
+@dataclass(frozen=True)
+class LoopGenerationResult:
+    tube: SweptTube
+    profile: LoopProfile
+
+
+# //3.- Compute total steps ensuring the loop meets the configured length target.
+def _compute_step_count(settings: GeneratorSettings) -> int:
+    steps = max(2, int(math.ceil(settings.loop.target_length_m / settings.loop.step_size_m)))
+    return steps
+
+
+# //4.- Produce a deterministic radius profile constrained by configuration bounds.
+def _build_radius_profile(
+    *,
+    path_length: int,
+    seeds: GenerationSeeds,
+    settings: GeneratorSettings,
+) -> Tuple[List[float], List[int]]:
+    rng = seeds.create_generators()["path"]
+    radii: List[float] = []
+    rooms: List[int] = []
+    min_radius = max(settings.clearance.min_radius_m, settings.clearance.min_clearance_m)
+    max_radius = max(settings.clearance.max_radius_m, min_radius)
+    room_radius = min(settings.rooms.room_radius_m, max_radius)
+    for index in range(path_length):
+        radius = rng.uniform(min_radius, max_radius)
+        if rng.random() < settings.rooms.room_probability:
+            radius = max(room_radius, min_radius)
+            rooms.append(index)
+        radius = max(min(radius, max_radius), min_radius)
+        radii.append(radius)
+    if not rooms and path_length:
+        radii[-1] = max(room_radius, min_radius)
+        rooms.append(path_length - 1)
+    return radii, rooms
+
+
+# //5.- Attach the starting point to close the loop for a seamless circuit.
+def _close_loop(path: List[Sequence[float]]) -> List[Sequence[float]]:
+    if path[0] != path[-1]:
+        path.append(path[0])
+    return path
+
+
+# //6.- Build swept tube from explicit radius profile for consistent sampling.
+def _tube_from_profile(path: Sequence[Sequence[float]], radii: Sequence[float]) -> SweptTube:
+    def radius_callback(index: int, total: int) -> float:
+        clamped = min(index, len(radii) - 1)
+        return float(radii[clamped])
+
+    return build_swept_tube(path, radius=radius_callback)
+
+
+# //7.- High-level helper generating a single loop instance from seeds.
+def generate_loop_tube(
+    field: DivergenceFreeField,
+    *,
+    seeds: GenerationSeeds,
+    origin: Sequence[float] = (0.0, 0.0, 0.0),
+    settings: GeneratorSettings,
+) -> LoopGenerationResult:
+    steps = _compute_step_count(settings)
+    path = integrate_streamline(
+        field,
+        seed=origin,
+        steps=steps,
+        step_size=settings.loop.step_size_m,
+    )
+    closed_path = _close_loop(list(path))
+    radii, rooms = _build_radius_profile(path_length=len(closed_path), seeds=seeds, settings=settings)
+    tube = _tube_from_profile(closed_path, radii)
+    profile = LoopProfile(radii=tuple(radii), room_indices=tuple(rooms))
+    return LoopGenerationResult(tube=tube, profile=profile)
+
+
+# //8.- Validate generated tube against clearance constraints producing diagnostics.
+def verify_loop_clearance(
+    result: LoopGenerationResult,
+    *,
+    settings: GeneratorSettings,
+) -> Tuple[float, float]:
+    min_radius = min(result.profile.radii)
+    max_radius = max(result.profile.radii)
+    average_radius = sum(result.profile.radii) / len(result.profile.radii)
+    if min_radius < settings.clearance.min_clearance_m:
+        raise ValueError("Generated loop violates minimum clearance constraint")
+    if min(result.profile.radii) < settings.clearance.min_radius_m:
+        raise ValueError("Generated loop violates minimum radius constraint")
+    if max_radius > settings.clearance.max_radius_m:
+        raise ValueError("Generated loop violates maximum radius constraint")
+    return min_radius, average_radius

--- a/tunnelcave_sandbox/src/generation/metrics.py
+++ b/tunnelcave_sandbox/src/generation/metrics.py
@@ -1,0 +1,118 @@
+"""Metrics export for verifying generated loop statistics across seeds."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from statistics import mean
+from typing import List, Sequence
+
+from .config import GenerationSeeds
+from .divergence_free import DivergenceFreeField
+from .loop_generation import (
+    LoopGenerationResult,
+    generate_loop_tube,
+    verify_loop_clearance,
+)
+from .settings import GeneratorSettings
+
+
+# //1.- Encapsulate per-seed metrics derived from generated loops.
+@dataclass(frozen=True)
+class LoopMetrics:
+    seed: GenerationSeeds
+    min_radius: float
+    max_radius: float
+    min_clearance: float
+    average_clearance: float
+    room_count: int
+
+
+# //2.- Aggregate statistics for a collection of seeds plus compliance summary.
+@dataclass(frozen=True)
+class MetricsSummary:
+    metrics: Sequence[LoopMetrics]
+    meets_radius_bounds: bool
+    meets_clearance_targets: bool
+    has_rooms: bool
+
+
+# //3.- Compute metrics for a single generated loop instance.
+def _compute_metrics_for_result(
+    result: LoopGenerationResult,
+    *,
+    settings: GeneratorSettings,
+    seeds: GenerationSeeds,
+) -> LoopMetrics:
+    min_clearance, average_clearance = verify_loop_clearance(result, settings=settings)
+    min_radius = min(result.profile.radii)
+    max_radius = max(result.profile.radii)
+    room_count = len(result.profile.room_indices)
+    return LoopMetrics(
+        seed=seeds,
+        min_radius=min_radius,
+        max_radius=max_radius,
+        min_clearance=min_clearance,
+        average_clearance=average_clearance,
+        room_count=room_count,
+    )
+
+
+# //4.- Evaluate compliance of the metric collection against configured targets.
+def _evaluate_targets(metrics: Sequence[LoopMetrics], settings: GeneratorSettings) -> MetricsSummary:
+    meets_radius = all(
+        settings.clearance.min_radius_m <= metric.min_radius <= settings.clearance.max_radius_m
+        and metric.max_radius <= settings.clearance.max_radius_m
+        for metric in metrics
+    )
+    meets_clearance = (
+        all(metric.min_clearance >= settings.clearance.min_clearance_m for metric in metrics)
+        and mean(metric.average_clearance for metric in metrics) >= settings.clearance.target_average_clearance_m
+    )
+    has_rooms = any(metric.room_count > 0 for metric in metrics)
+    return MetricsSummary(
+        metrics=tuple(metrics),
+        meets_radius_bounds=meets_radius,
+        meets_clearance_targets=meets_clearance,
+        has_rooms=has_rooms,
+    )
+
+
+# //5.- Orchestrate generation across multiple seeds collecting metrics.
+def collect_generation_metrics(
+    *,
+    seeds: Sequence[GenerationSeeds],
+    settings: GeneratorSettings,
+) -> MetricsSummary:
+    metrics: List[LoopMetrics] = []
+    for seed in seeds:
+        field = DivergenceFreeField.from_seeds(seed)
+        result = generate_loop_tube(field, seeds=seed, settings=settings)
+        metrics.append(_compute_metrics_for_result(result, settings=settings, seeds=seed))
+    return _evaluate_targets(metrics, settings)
+
+
+# //6.- Export metrics summary to JSON for CI validation or dashboards.
+def export_generation_metrics(
+    summary: MetricsSummary,
+    *,
+    filepath: str,
+) -> None:
+    payload = {
+        "meets_radius_bounds": summary.meets_radius_bounds,
+        "meets_clearance_targets": summary.meets_clearance_targets,
+        "has_rooms": summary.has_rooms,
+        "metrics": [
+            {
+                "divergence_seed": metric.seed.divergence_seed,
+                "path_seed": metric.seed.path_seed,
+                "min_radius": metric.min_radius,
+                "max_radius": metric.max_radius,
+                "min_clearance": metric.min_clearance,
+                "average_clearance": metric.average_clearance,
+                "room_count": metric.room_count,
+            }
+            for metric in summary.metrics
+        ],
+    }
+    with open(filepath, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)

--- a/tunnelcave_sandbox/src/generation/settings.py
+++ b/tunnelcave_sandbox/src/generation/settings.py
@@ -1,0 +1,97 @@
+"""Structured loader for tunnel generation settings."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+# //1.- Capture loop settings controlling total distance and integration step.
+@dataclass(frozen=True)
+class LoopSettings:
+    target_length_m: float
+    step_size_m: float
+
+
+# //2.- Record room expansion behaviour sourced from configuration files.
+@dataclass(frozen=True)
+class RoomSettings:
+    room_radius_m: float
+    room_probability: float
+
+
+# //3.- Encapsulate clearance and radius bounds for generated tubes.
+@dataclass(frozen=True)
+class ClearanceSettings:
+    min_clearance_m: float
+    target_average_clearance_m: float
+    min_radius_m: float
+    max_radius_m: float
+    sampling_step: float
+    lateral_sample_offsets: Sequence[Sequence[float]]
+
+
+# //4.- Aggregate complete generator settings for downstream modules.
+@dataclass(frozen=True)
+class GeneratorSettings:
+    loop: LoopSettings
+    rooms: RoomSettings
+    clearance: ClearanceSettings
+
+
+# //5.- Resolve repository default configuration directory lazily.
+def _default_config_directory() -> str:
+    base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    return os.path.join(base_dir, "config")
+
+
+# //6.- Load a single JSON configuration file and coerce to dictionary.
+def _read_json_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+# //7.- Construct loop settings from on-disk JSON configuration.
+def _load_loop_settings(config_dir: str) -> LoopSettings:
+    payload = _read_json_config(os.path.join(config_dir, "loop.json"))
+    return LoopSettings(
+        target_length_m=float(payload["target_length_m"]),
+        step_size_m=float(payload["step_size_m"]),
+    )
+
+
+# //8.- Build room settings while normalizing diameter to radius units.
+def _load_room_settings(config_dir: str) -> RoomSettings:
+    payload = _read_json_config(os.path.join(config_dir, "rooms.json"))
+    diameter = float(payload.get("room_diameter_m", 0.0))
+    radius = float(payload.get("room_radius_m", diameter / 2 if diameter else 0.0))
+    return RoomSettings(
+        room_radius_m=radius,
+        room_probability=float(payload["room_probability"]),
+    )
+
+
+# //9.- Interpret clearance configuration including sampling metadata.
+def _load_clearance_settings(config_dir: str) -> ClearanceSettings:
+    payload = _read_json_config(os.path.join(config_dir, "clearance.json"))
+    offsets: List[List[float]] = []
+    for vector in payload["lateral_sample_offsets"]:
+        offsets.append([float(component) for component in vector])
+    return ClearanceSettings(
+        min_clearance_m=float(payload["min_clearance_m"]),
+        target_average_clearance_m=float(payload["target_average_clearance_m"]),
+        min_radius_m=float(payload["min_radius_m"]),
+        max_radius_m=float(payload["max_radius_m"]),
+        sampling_step=float(payload["sampling_step"]),
+        lateral_sample_offsets=tuple(tuple(item for item in vector) for vector in offsets),
+    )
+
+
+# //10.- Public helper assembling full generator settings bundle.
+def load_generator_settings(config_dir: str | None = None) -> GeneratorSettings:
+    directory = config_dir or _default_config_directory()
+    loop = _load_loop_settings(directory)
+    rooms = _load_room_settings(directory)
+    clearance = _load_clearance_settings(directory)
+    return GeneratorSettings(loop=loop, rooms=rooms, clearance=clearance)

--- a/tunnelcave_sandbox/tests/test_loop_generation.py
+++ b/tunnelcave_sandbox/tests/test_loop_generation.py
@@ -1,0 +1,29 @@
+"""Tests verifying loop generation enforces configuration constraints."""
+from __future__ import annotations
+
+from tunnelcave_sandbox.src.generation import (
+    DivergenceFreeField,
+    GenerationSeeds,
+    generate_loop_tube,
+    load_generator_settings,
+)
+
+
+# //1.- Loop generation should respect configured radius limits and produce rooms.
+def test_generate_loop_tube_respects_constraints():
+    settings = load_generator_settings()
+    seeds = GenerationSeeds(divergence_seed=1, path_seed=2)
+    field = DivergenceFreeField.from_seeds(seeds, harmonic_count=3)
+    result = generate_loop_tube(field, seeds=seeds, settings=settings)
+    assert min(result.profile.radii) >= settings.clearance.min_radius_m
+    assert max(result.profile.radii) <= settings.clearance.max_radius_m
+    assert result.profile.room_indices
+
+
+# //2.- Loop generation should close the path to form a loop structure.
+def test_generate_loop_tube_produces_closed_path():
+    settings = load_generator_settings()
+    seeds = GenerationSeeds(divergence_seed=3, path_seed=4)
+    field = DivergenceFreeField.from_seeds(seeds, harmonic_count=2)
+    result = generate_loop_tube(field, seeds=seeds, settings=settings)
+    assert result.tube.segments[0].start == result.tube.segments[-1].end

--- a/tunnelcave_sandbox/tests/test_metrics.py
+++ b/tunnelcave_sandbox/tests/test_metrics.py
@@ -1,0 +1,34 @@
+"""Tests validating generation metrics export workflow."""
+from __future__ import annotations
+
+import json
+
+from tunnelcave_sandbox.src.generation import (
+    GenerationSeeds,
+    collect_generation_metrics,
+    export_generation_metrics,
+    load_generator_settings,
+)
+
+
+# //1.- Metrics collection should produce compliant summaries across seeds.
+def test_collect_generation_metrics_and_export(tmp_path):
+    settings = load_generator_settings()
+    seeds = [
+        GenerationSeeds(divergence_seed=5, path_seed=6),
+        GenerationSeeds(divergence_seed=7, path_seed=8),
+        GenerationSeeds(divergence_seed=9, path_seed=10),
+    ]
+    summary = collect_generation_metrics(seeds=seeds, settings=settings)
+    assert summary.meets_radius_bounds
+    assert summary.meets_clearance_targets
+    assert summary.has_rooms
+
+    output_path = tmp_path / "metrics.json"
+    export_generation_metrics(summary, filepath=str(output_path))
+
+    with output_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    assert payload["meets_radius_bounds"] is True
+    assert payload["metrics"]
+    assert len(payload["metrics"]) == len(seeds)

--- a/tunnelcave_sandbox/tests/test_settings.py
+++ b/tunnelcave_sandbox/tests/test_settings.py
@@ -1,0 +1,17 @@
+"""Tests for generator configuration loading."""
+from __future__ import annotations
+
+from tunnelcave_sandbox.src.generation import load_generator_settings
+
+
+# //1.- Ensure configuration loader parses bundled JSON files correctly.
+def test_load_generator_settings_uses_defaults():
+    settings = load_generator_settings()
+    assert settings.loop.target_length_m > 0
+    assert settings.loop.step_size_m > 0
+    assert settings.rooms.room_radius_m > 0
+    assert 0.0 < settings.rooms.room_probability <= 1.0
+    assert settings.clearance.min_radius_m >= settings.clearance.min_clearance_m
+    assert settings.clearance.max_radius_m >= settings.clearance.min_radius_m
+    assert settings.clearance.sampling_step > 0
+    assert settings.clearance.lateral_sample_offsets


### PR DESCRIPTION
## Summary
- add JSON configuration files for loop length, room cadence, and clearance bounds
- implement loop generation utilities that honor configured radius constraints and expose metrics helpers
- export new metrics and configuration helpers through the package along with targeted unit tests

## Testing
- pytest tunnelcave_sandbox/tests

------
https://chatgpt.com/codex/tasks/task_e_68def3fb2c2c83298e4910b12fb1ddbb