### PR TITLE
Annotate loop nodes with metadata and enforce spawn safety

### DIFF
--- a/tunnelcave_sandbox/src/generation/loop_generation.py
+++ b/tunnelcave_sandbox/src/generation/loop_generation.py
@@ -9,6 +9,7 @@ from .config import GenerationSeeds
 from .divergence_free import DivergenceFreeField, integrate_streamline
 from .swept_tube import SweptTube, build_swept_tube
 from .settings import GeneratorSettings
+from ..world import WorldDescriptor, build_loop_descriptor
 
 
 # //1.- Describe the generated loop profile for downstream validation and metrics.
@@ -23,6 +24,7 @@ class LoopProfile:
 class LoopGenerationResult:
     tube: SweptTube
     profile: LoopProfile
+    descriptor: WorldDescriptor
 
 
 # //3.- Compute total steps ensuring the loop meets the configured length target.
@@ -92,7 +94,8 @@ def generate_loop_tube(
     radii, rooms = _build_radius_profile(path_length=len(closed_path), seeds=seeds, settings=settings)
     tube = _tube_from_profile(closed_path, radii)
     profile = LoopProfile(radii=tuple(radii), room_indices=tuple(rooms))
-    return LoopGenerationResult(tube=tube, profile=profile)
+    descriptor = build_loop_descriptor(closed_path, profile.radii, profile.room_indices)
+    return LoopGenerationResult(tube=tube, profile=profile, descriptor=descriptor)
 
 
 # //8.- Validate generated tube against clearance constraints producing diagnostics.

--- a/tunnelcave_sandbox/src/physics/__init__.py
+++ b/tunnelcave_sandbox/src/physics/__init__.py
@@ -1,0 +1,4 @@
+"""Physics helpers modelling tunnel entrance constraints."""
+from .entrance import clip_velocity_outward
+
+__all__ = ["clip_velocity_outward"]

--- a/tunnelcave_sandbox/src/physics/entrance.py
+++ b/tunnelcave_sandbox/src/physics/entrance.py
@@ -1,0 +1,46 @@
+"""Entrance constraint logic ensuring vehicles do not exit against station normals."""
+from __future__ import annotations
+
+from typing import Sequence, Tuple, cast
+
+
+# //1.- Compute dot products without introducing numpy as a dependency.
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+# //2.- Convert arbitrary sequences into concrete 3-tuples for arithmetic.
+def _to_tuple(vector: Sequence[float]) -> Tuple[float, float, float]:
+    components = tuple(float(component) for component in vector)
+    if len(components) != 3:
+        raise ValueError("Entrance physics expects three-dimensional vectors")
+    return cast(Tuple[float, float, float], components)
+
+
+# //3.- Subtract vectors component-wise for velocity correction.
+def _subtract(a: Sequence[float], b: Sequence[float]) -> Tuple[float, float, float]:
+    ax, ay, az = _to_tuple(a)
+    bx, by, bz = _to_tuple(b)
+    return (ax - bx, ay - by, az - bz)
+
+
+# //4.- Scale a vector by a scalar value while preserving dimensionality.
+def _scale(vector: Sequence[float], scalar: float) -> Tuple[float, float, float]:
+    vx, vy, vz = _to_tuple(vector)
+    return (vx * scalar, vy * scalar, vz * scalar)
+
+
+# //5.- Clip the outward velocity component aligned with the provided normal.
+def clip_velocity_outward(
+    velocity: Sequence[float],
+    normal: Sequence[float],
+) -> Tuple[float, float, float]:
+    normal_length_sq = _dot(normal, normal)
+    if normal_length_sq == 0:
+        return _to_tuple(velocity)
+    projection = _dot(velocity, normal)
+    if projection <= 0:
+        return _to_tuple(velocity)
+    scale = projection / normal_length_sq
+    correction = _scale(normal, scale)
+    return _subtract(velocity, correction)

--- a/tunnelcave_sandbox/src/spawn/__init__.py
+++ b/tunnelcave_sandbox/src/spawn/__init__.py
@@ -1,0 +1,4 @@
+"""Spawn selection utilities built on world descriptors."""
+from .selection import select_spawn_node
+
+__all__ = ["select_spawn_node"]

--- a/tunnelcave_sandbox/src/spawn/selection.py
+++ b/tunnelcave_sandbox/src/spawn/selection.py
@@ -1,0 +1,28 @@
+"""Spawn selection utilities that leverage spline metadata descriptors."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from ..generation.swept_tube import SweptTube
+from ..world import SPAWN_TAG, SplineNodeDescriptor, WorldDescriptor
+
+
+# //1.- Sample clearance by querying the swept tube's signed distance field.
+def _node_clearance(tube: SweptTube, node: SplineNodeDescriptor) -> float:
+    return float(-tube.sdf(node.position))
+
+
+# //2.- Select a spawn node constrained by clearance safety thresholds.
+def select_spawn_node(
+    descriptor: WorldDescriptor,
+    tube: SweptTube,
+    *,
+    clearance_threshold: float,
+) -> SplineNodeDescriptor:
+    spawn_nodes: Sequence[SplineNodeDescriptor] = descriptor.tagged(SPAWN_TAG)
+    if not spawn_nodes:
+        raise ValueError("Descriptor does not contain any spawn-tagged nodes")
+    safe_nodes = [node for node in spawn_nodes if _node_clearance(tube, node) >= clearance_threshold]
+    if not safe_nodes:
+        raise ValueError("No spawn nodes satisfy the clearance threshold")
+    return max(safe_nodes, key=lambda node: node.radius)

--- a/tunnelcave_sandbox/src/world/__init__.py
+++ b/tunnelcave_sandbox/src/world/__init__.py
@@ -1,0 +1,18 @@
+"""World descriptor definitions for tunnel cave sandbox generation."""
+"""World descriptor definitions for tunnel cave sandbox generation."""
+
+from .descriptors import (
+    SPAWN_TAG,
+    SET_DRESSING_TAG,
+    SplineNodeDescriptor,
+    WorldDescriptor,
+    build_loop_descriptor,
+)
+
+__all__ = [
+    "SPAWN_TAG",
+    "SET_DRESSING_TAG",
+    "SplineNodeDescriptor",
+    "WorldDescriptor",
+    "build_loop_descriptor",
+]

--- a/tunnelcave_sandbox/src/world/descriptors.py
+++ b/tunnelcave_sandbox/src/world/descriptors.py
@@ -1,0 +1,74 @@
+"""Descriptor helpers annotating spline nodes with gameplay metadata."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
+
+SPAWN_TAG = "spawn"
+SET_DRESSING_TAG = "set_dressing"
+
+
+# //1.- Represent metadata for a single spline node within the generated loop.
+@dataclass(frozen=True)
+class SplineNodeDescriptor:
+    index: int
+    position: Tuple[float, float, float]
+    radius: float
+    tags: Tuple[str, ...]
+
+    # //2.- Provide convenience helpers to query tag membership quickly.
+    def has_tag(self, tag: str) -> bool:
+        return tag in self.tags
+
+
+# //3.- Aggregate spline node descriptors for downstream systems.
+@dataclass(frozen=True)
+class WorldDescriptor:
+    nodes: Tuple[SplineNodeDescriptor, ...]
+
+    # //4.- Filter nodes by metadata tag preserving ordering along the spline.
+    def tagged(self, tag: str) -> Tuple[SplineNodeDescriptor, ...]:
+        return tuple(node for node in self.nodes if node.has_tag(tag))
+
+
+# //5.- Pick a stable spawn index prioritizing authored room locations.
+def _select_spawn_index(radii: Sequence[float], room_indices: Sequence[int]) -> int:
+    if room_indices:
+        return int(room_indices[0])
+    if not radii:
+        raise ValueError("Cannot choose spawn index from empty radii profile")
+    max_index = max(range(len(radii)), key=lambda idx: radii[idx])
+    return int(max_index)
+
+
+# //6.- Normalize tag tuples ensuring determinism for serialization and hashing.
+def _finalize_tags(tags: Iterable[str]) -> Tuple[str, ...]:
+    unique = sorted({tag for tag in tags})
+    return tuple(unique)
+
+
+# //7.- Build world descriptor aligning positions, radii, and metadata tags.
+def build_loop_descriptor(
+    path: Sequence[Sequence[float]],
+    radii: Sequence[float],
+    room_indices: Sequence[int],
+) -> WorldDescriptor:
+    if len(path) != len(radii):
+        raise ValueError("Path and radii must contain the same number of entries")
+    spawn_index = _select_spawn_index(radii, room_indices)
+    room_lookup = set(int(index) for index in room_indices)
+    nodes = []
+    for index, position in enumerate(path):
+        tags = []
+        if index == spawn_index:
+            tags.append(SPAWN_TAG)
+        if index in room_lookup:
+            tags.append(SET_DRESSING_TAG)
+        descriptor = SplineNodeDescriptor(
+            index=int(index),
+            position=tuple(float(component) for component in position),
+            radius=float(radii[index]),
+            tags=_finalize_tags(tags),
+        )
+        nodes.append(descriptor)
+    return WorldDescriptor(nodes=tuple(nodes))

--- a/tunnelcave_sandbox/tests/test_loop_generation.py
+++ b/tunnelcave_sandbox/tests/test_loop_generation.py
@@ -7,6 +7,7 @@ from tunnelcave_sandbox.src.generation import (
     generate_loop_tube,
     load_generator_settings,
 )
+from tunnelcave_sandbox.src.world import SPAWN_TAG
 
 
 # //1.- Loop generation should respect configured radius limits and produce rooms.
@@ -18,6 +19,7 @@ def test_generate_loop_tube_respects_constraints():
     assert min(result.profile.radii) >= settings.clearance.min_radius_m
     assert max(result.profile.radii) <= settings.clearance.max_radius_m
     assert result.profile.room_indices
+    assert result.descriptor.tagged(SPAWN_TAG)
 
 
 # //2.- Loop generation should close the path to form a loop structure.

--- a/tunnelcave_sandbox/tests/test_physics_entrance.py
+++ b/tunnelcave_sandbox/tests/test_physics_entrance.py
@@ -1,0 +1,21 @@
+"""Validate entrance constraint velocity clipping."""
+from __future__ import annotations
+
+from tunnelcave_sandbox.src.physics import clip_velocity_outward
+
+
+# //1.- Outward velocity components aligned with the normal should be removed.
+def test_clip_velocity_outward_removes_normal_component():
+    velocity = (5.0, 2.0, 0.0)
+    normal = (1.0, 0.0, 0.0)
+    clipped = clip_velocity_outward(velocity, normal)
+    assert clipped[0] == 0.0
+    assert clipped[1] == velocity[1]
+
+
+# //2.- Tangential or inward motion should remain unaffected.
+def test_clip_velocity_outward_preserves_inward_motion():
+    velocity = (-3.0, 1.0, 0.0)
+    normal = (1.0, 0.0, 0.0)
+    clipped = clip_velocity_outward(velocity, normal)
+    assert clipped == velocity

--- a/tunnelcave_sandbox/tests/test_spawn_selection.py
+++ b/tunnelcave_sandbox/tests/test_spawn_selection.py
@@ -1,0 +1,44 @@
+"""Ensure spawn selection honours descriptor tagging and safety constraints."""
+from __future__ import annotations
+
+from tunnelcave_sandbox.src.generation import build_swept_tube
+from tunnelcave_sandbox.src.spawn import select_spawn_node
+from tunnelcave_sandbox.src.world import SPAWN_TAG, build_loop_descriptor
+
+
+# //1.- Spawn selection should choose the safest tagged node that meets clearance.
+def test_select_spawn_node_prefers_safe_spawn():
+    path = (
+        (0.0, 0.0, 0.0),
+        (10.0, 0.0, 0.0),
+        (20.0, 0.0, 0.0),
+    )
+    radii = (2.0, 6.0, 2.0)
+    rooms = (1,)
+
+    def radius_callback(index: int, total: int) -> float:
+        return radii[min(index, len(radii) - 1)]
+
+    tube = build_swept_tube(path, radius_callback)
+    descriptor = build_loop_descriptor(path, radii, rooms)
+    spawn_node = select_spawn_node(descriptor, tube, clearance_threshold=4.0)
+    assert SPAWN_TAG in spawn_node.tags
+    assert spawn_node.index == 1
+    assert spawn_node.radius >= 6.0
+
+
+# //2.- Requesting an excessive clearance should raise for visibility.
+def test_select_spawn_node_rejects_insufficient_clearance():
+    path = (
+        (0.0, 0.0, 0.0),
+        (5.0, 0.0, 0.0),
+    )
+    radii = (2.0, 2.0)
+    rooms = (0,)
+    tube = build_swept_tube(path, lambda index, total: radii[min(index, len(radii) - 1)])
+    descriptor = build_loop_descriptor(path, radii, rooms)
+    try:
+        select_spawn_node(descriptor, tube, clearance_threshold=3.0)
+    except ValueError:
+        return
+    raise AssertionError("Expected ValueError for insufficient clearance")

--- a/tunnelcave_sandbox/tests/test_world_descriptors.py
+++ b/tunnelcave_sandbox/tests/test_world_descriptors.py
@@ -1,0 +1,26 @@
+"""Validate world descriptor construction tags spline nodes appropriately."""
+from __future__ import annotations
+
+from tunnelcave_sandbox.src.world import (
+    SPAWN_TAG,
+    SET_DRESSING_TAG,
+    build_loop_descriptor,
+)
+
+
+# //1.- Building a descriptor should mark rooms for set dressing and a spawn point.
+def test_build_loop_descriptor_tags_spawn_and_rooms():
+    path = (
+        (0.0, 0.0, 0.0),
+        (5.0, 0.0, 0.0),
+        (5.0, 5.0, 0.0),
+        (0.0, 0.0, 0.0),
+    )
+    radii = (6.0, 3.0, 7.0, 6.0)
+    rooms = (2,)
+    descriptor = build_loop_descriptor(path, radii, rooms)
+    spawn_nodes = descriptor.tagged(SPAWN_TAG)
+    assert spawn_nodes
+    assert spawn_nodes[0].index == 2
+    assert spawn_nodes[0].has_tag(SET_DRESSING_TAG)
+    assert descriptor.nodes[1].tags == ()


### PR DESCRIPTION
## Summary
- add world descriptor utilities that tag spline nodes for spawn and set dressing metadata and integrate them into loop generation
- implement entrance physics helpers that clip outward velocities along station normals
- add spawn selection logic that chooses safe tagged stations and accompanying tests for descriptors, physics, and spawning

## Testing
- pytest tunnelcave_sandbox/tests

------
https://chatgpt.com/codex/tasks/task_e_68def648ff8883299f379e97858b3ebc