### PR TITLE
Add signed distance field collision sampling to physics subsystem

### DIFF
--- a/go-broker/internal/simulation/sdf.go
+++ b/go-broker/internal/simulation/sdf.go
@@ -1,0 +1,125 @@
+package simulation
+
+import "math"
+
+// Vec3 represents a simple 3D vector for collision math.
+type Vec3 struct {
+        X float64
+        Y float64
+        Z float64
+}
+
+// Add returns the component wise sum of two vectors.
+func (v Vec3) Add(other Vec3) Vec3 {
+        //1.- Combine offsets to advance ray marching positions.
+        return Vec3{X: v.X + other.X, Y: v.Y + other.Y, Z: v.Z + other.Z}
+}
+
+// Sub returns the difference between two vectors.
+func (v Vec3) Sub(other Vec3) Vec3 {
+        //1.- Differences enable distance calculations within the SDF sampler.
+        return Vec3{X: v.X - other.X, Y: v.Y - other.Y, Z: v.Z - other.Z}
+}
+
+// Scale multiplies the vector by a scalar.
+func (v Vec3) Scale(scalar float64) Vec3 {
+        //1.- Scaling lets us travel along a direction by the sampled distance.
+        return Vec3{X: v.X * scalar, Y: v.Y * scalar, Z: v.Z * scalar}
+}
+
+// Dot returns the scalar dot product of two vectors.
+func (v Vec3) Dot(other Vec3) float64 {
+        //1.- Dot products project vectors for plane evaluations.
+        return v.X*other.X + v.Y*other.Y + v.Z*other.Z
+}
+
+// Length computes the Euclidean norm of the vector.
+func (v Vec3) Length() float64 {
+        //1.- Magnitudes are required for analytic SDF distances.
+        return math.Sqrt(v.Dot(v))
+}
+
+// Normalize produces a unit length vector, panicking if the magnitude is zero.
+func (v Vec3) Normalize() Vec3 {
+        //1.- Maintain numerical stability by enforcing a non-zero direction.
+        length := v.Length()
+        if length == 0 {
+                panic("cannot normalize zero vector")
+        }
+        inv := 1.0 / length
+        return Vec3{X: v.X * inv, Y: v.Y * inv, Z: v.Z * inv}
+}
+
+// SignedDistanceField exposes the sampling contract for collision queries.
+type SignedDistanceField interface {
+        Sample(point Vec3) float64
+}
+
+// SampleFunc adapts a function into a SignedDistanceField.
+type SampleFunc func(Vec3) float64
+
+// Sample invokes the wrapped sampling function.
+func (s SampleFunc) Sample(point Vec3) float64 {
+        return s(point)
+}
+
+// SphereField describes an analytic sphere signed distance function.
+type SphereField struct {
+        Center Vec3
+        Radius float64
+}
+
+// Sample calculates the signed distance from a point to the sphere surface.
+func (s SphereField) Sample(point Vec3) float64 {
+        //1.- The radius is subtracted from the distance between the point and center.
+        return point.Sub(s.Center).Length() - s.Radius
+}
+
+// PlaneField describes an infinite plane represented by a point and normal.
+type PlaneField struct {
+        origin Vec3
+        normal Vec3
+}
+
+// NewPlaneField normalizes the normal and stores the plane representation.
+func NewPlaneField(point Vec3, normal Vec3) PlaneField {
+        //1.- Normalize the plane normal to keep signed distances consistent.
+        unit := normal.Normalize()
+        return PlaneField{origin: point, normal: unit}
+}
+
+// Sample returns the signed distance from the plane to the provided point.
+func (p PlaneField) Sample(point Vec3) float64 {
+        //1.- Dot product with the normal projects the delta onto the plane axis.
+        return point.Sub(p.origin).Dot(p.normal)
+}
+
+// Raycast performs sphere tracing against the provided field.
+func Raycast(field SignedDistanceField, origin Vec3, direction Vec3, maxDistance float64, maxSteps int, epsilon float64) (bool, float64, Vec3) {
+        //1.- Normalize the incoming direction vector before marching.
+        dir := direction.Normalize()
+        distance := 0.0
+        current := origin
+        for step := 0; step < maxSteps; step++ {
+                sample := field.Sample(current)
+                if sample < epsilon {
+                        //2.- Return a hit once the sampled distance is within tolerance.
+                        return true, distance, current
+                }
+                distance += sample
+                if distance > maxDistance {
+                        break
+                }
+                //3.- Advance the ray origin using the sampled distance.
+                current = origin.Add(dir.Scale(distance))
+        }
+        capped := math.Min(distance, maxDistance)
+        return false, capped, origin.Add(dir.Scale(capped))
+}
+
+// SphereIntersection evaluates whether a bounding sphere penetrates the field.
+func SphereIntersection(field SignedDistanceField, center Vec3, radius float64) (bool, float64) {
+        //1.- Sample the SDF at the sphere center and subtract the radius to compute clearance.
+        separation := field.Sample(center) - radius
+        return separation <= 0, separation
+}

--- a/go-broker/internal/simulation/sdf_test.go
+++ b/go-broker/internal/simulation/sdf_test.go
@@ -1,0 +1,64 @@
+package simulation
+
+import (
+        "math"
+        "testing"
+)
+
+func TestSphereFieldSamplingMatchesAnalytic(t *testing.T) {
+        field := SphereField{Center: Vec3{}, Radius: 2}
+        cases := []struct {
+                point    Vec3
+                expected float64
+        }{
+                {point: Vec3{}, expected: -2},
+                {point: Vec3{X: 2}, expected: 0},
+                {point: Vec3{Y: 3}, expected: 1},
+                {point: Vec3{X: 1, Y: 2, Z: 2}, expected: math.Sqrt(9) - 2},
+        }
+        for _, tc := range cases {
+                //1.- Compare analytic distance with SDF sampling results.
+                if got := field.Sample(tc.point); math.Abs(got-tc.expected) > 1e-7 {
+                        t.Fatalf("expected %f, got %f", tc.expected, got)
+                }
+        }
+}
+
+func TestRaycastHitsSphereSurface(t *testing.T) {
+        field := SphereField{Center: Vec3{}, Radius: 2}
+        hit, distance, position := Raycast(field, Vec3{Z: 5}, Vec3{Z: -1}, 100, 128, 1e-3)
+        //1.- Ray should intersect three units along the negative Z axis.
+        if !hit {
+                t.Fatal("expected ray to hit sphere")
+        }
+        if math.Abs(distance-3) > 1e-3 {
+                t.Fatalf("expected distance 3, got %f", distance)
+        }
+        if math.Abs(position.Z-2) > 1e-3 {
+                t.Fatalf("expected hit at z=2, got %f", position.Z)
+        }
+}
+
+func TestSphereIntersectionDetectsPlanePenetration(t *testing.T) {
+        plane := NewPlaneField(Vec3{}, Vec3{Y: 1})
+        hit, separation := SphereIntersection(plane, Vec3{Y: 0.5}, 1)
+        //1.- Sphere should intersect the plane with half unit penetration.
+        if !hit {
+                t.Fatal("expected intersection")
+        }
+        if math.Abs(separation+0.5) > 1e-7 {
+                t.Fatalf("expected separation -0.5, got %f", separation)
+        }
+}
+
+func TestSphereIntersectionHonoursClearance(t *testing.T) {
+        plane := NewPlaneField(Vec3{}, Vec3{Y: 1})
+        hit, separation := SphereIntersection(plane, Vec3{Y: 2.5}, 1)
+        //1.- Clearance should equal signed distance minus radius.
+        if hit {
+                t.Fatal("expected no intersection")
+        }
+        if math.Abs(separation-1.5) > 1e-7 {
+                t.Fatalf("expected separation 1.5, got %f", separation)
+        }
+}

--- a/python-sim/physics/__init__.py
+++ b/python-sim/physics/__init__.py
@@ -1,0 +1,15 @@
+"""Physics utilities for collision detection using signed distance fields."""
+
+from .sdf import (
+    SignedDistanceField,
+    SphereField,
+    PlaneField,
+    RayHit,
+)
+
+__all__ = [
+    "SignedDistanceField",
+    "SphereField",
+    "PlaneField",
+    "RayHit",
+]

--- a/python-sim/physics/sdf.py
+++ b/python-sim/physics/sdf.py
@@ -1,0 +1,147 @@
+"""Signed distance field sampling and collision helpers."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Sequence, Tuple
+
+Vector3 = Tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class RayHit:
+    """Result from ray marching against an SDF."""
+
+    hit: bool
+    distance: float
+    position: Vector3
+
+
+class SignedDistanceField:
+    """Signed distance field exposing sampling and collision routines."""
+
+    def __init__(self, sampler: Callable[[Vector3], float]):
+        if sampler is None:
+            raise ValueError("sampler must be provided")
+        self._sampler = sampler
+
+    def sample(self, point: Sequence[float]) -> float:
+        """Sample the field at the provided point."""
+
+        vec = _to_vec3(point)
+        return float(self._sampler(vec))
+
+    def ray_intersection(
+        self,
+        origin: Sequence[float],
+        direction: Sequence[float],
+        *,
+        max_distance: float = 200.0,
+        epsilon: float = 1e-3,
+        max_steps: int = 128,
+    ) -> RayHit:
+        """Perform sphere tracing to intersect a ray with the field."""
+
+        ray_origin = _to_vec3(origin)
+        ray_dir = _normalize(direction)
+        distance = 0.0
+        current = ray_origin
+        for _ in range(max_steps):
+            sample = self.sample(current)
+            # //1.- Report a hit once the ray is sufficiently close to the surface.
+            if sample < epsilon:
+                return RayHit(True, distance, current)
+            distance += sample
+            # //2.- Abort when marching beyond the configured distance budget.
+            if distance > max_distance:
+                break
+            current = _add(ray_origin, _scale(ray_dir, distance))
+        final_pos = _add(ray_origin, _scale(ray_dir, min(distance, max_distance)))
+        return RayHit(False, min(distance, max_distance), final_pos)
+
+    def sphere_intersection(
+        self,
+        center: Sequence[float],
+        radius: float,
+    ) -> Tuple[bool, float]:
+        """Check whether a bounding sphere intersects the field surface."""
+
+        sphere_center = _to_vec3(center)
+        sdf_distance = self.sample(sphere_center) - float(radius)
+        # //1.- Negative signed distance indicates penetration with the surface.
+        return sdf_distance <= 0.0, sdf_distance
+
+
+class SphereField(SignedDistanceField):
+    """Analytic sphere SDF."""
+
+    def __init__(self, center: Sequence[float], radius: float):
+        center_vec = _to_vec3(center)
+        radius = float(radius)
+
+        def sampler(point: Vector3) -> float:
+            # //1.- Euclidean distance from the center determines the signed value.
+            return _length(_sub(point, center_vec)) - radius
+
+        super().__init__(sampler)
+
+
+class PlaneField(SignedDistanceField):
+    """Half-space represented by a normalized plane."""
+
+    def __init__(self, point: Sequence[float], normal: Sequence[float]):
+        origin = _to_vec3(point)
+        normal_vec = _normalize(normal)
+
+        def sampler(position: Vector3) -> float:
+            # //1.- Dot product projects the point onto the plane normal.
+            return _dot(_sub(position, origin), normal_vec)
+
+        super().__init__(sampler)
+
+
+def _to_vec3(value: Sequence[float]) -> Vector3:
+    iterator = iter(value)
+    try:
+        x = float(next(iterator))
+        y = float(next(iterator))
+        z = float(next(iterator))
+    except StopIteration as exc:  # pragma: no cover - defensive guard.
+        raise ValueError("expected three components") from exc
+    # //1.- Convert the input sequence into a canonical tuple for downstream math.
+    return (x, y, z)
+
+
+def _length(vector: Sequence[float]) -> float:
+    # //1.- Compute the Euclidean norm without numpy dependencies.
+    return math.sqrt(sum(component * component for component in vector))
+
+
+def _normalize(value: Sequence[float]) -> Vector3:
+    vec = _to_vec3(value)
+    norm = _length(vec)
+    if norm == 0:
+        raise ValueError("direction vector must be non-zero")
+    # //1.- Scale the vector by its magnitude to prevent unstable ray marching.
+    return (vec[0] / norm, vec[1] / norm, vec[2] / norm)
+
+
+def _add(a: Sequence[float], b: Sequence[float]) -> Vector3:
+    # //1.- Vector addition composes marching steps and offsets.
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def _sub(a: Sequence[float], b: Sequence[float]) -> Vector3:
+    # //1.- Differences between vectors support distance and projection operations.
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _scale(vector: Sequence[float], scalar: float) -> Vector3:
+    # //1.- Scalar multiplication adjusts traversal distances along a direction.
+    return (vector[0] * scalar, vector[1] * scalar, vector[2] * scalar)
+
+
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    # //1.- Dot product supplies projection helpers for the plane SDF.
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]

--- a/python-sim/tests/test_physics_sdf.py
+++ b/python-sim/tests/test_physics_sdf.py
@@ -1,0 +1,65 @@
+"""Unit tests for SDF sampling and collision helpers."""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from physics import PlaneField, SphereField
+
+
+def test_sphere_sampling_matches_analytic():
+    field = SphereField((0.0, 0.0, 0.0), 2.0)
+    cases = [
+        ((0.0, 0.0, 0.0), -2.0),
+        ((2.0, 0.0, 0.0), 0.0),
+        ((0.0, 3.0, 0.0), 1.0),
+        ((1.0, 2.0, 2.0), math.sqrt(9.0) - 2.0),
+    ]
+    for point, expected in cases:
+        # //1.- Ensure analytic sphere distances match signed distance samples.
+        assert math.isclose(field.sample(point), expected, rel_tol=1e-7)
+
+
+def test_ray_intersection_hits_sphere_surface():
+    field = SphereField((0.0, 0.0, 0.0), 2.0)
+    hit = field.ray_intersection((0.0, 0.0, 5.0), (0.0, 0.0, -1.0))
+    # //1.- Ray should strike the sphere three units away from the origin point.
+    assert hit.hit
+    assert math.isclose(hit.distance, 3.0, rel_tol=1e-3, abs_tol=1e-3)
+    assert math.isclose(hit.position[2], 2.0, rel_tol=1e-3, abs_tol=1e-3)
+
+
+def test_sphere_intersection_detects_plane_penetration():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    intersects, separation = plane.sphere_intersection((0.0, 0.5, 0.0), 1.0)
+    # //1.- The sphere center is half a unit above the plane with radius one.
+    assert intersects
+    assert math.isclose(separation, -0.5, rel_tol=1e-7)
+
+
+def test_sphere_intersection_respects_clearance():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    intersects, separation = plane.sphere_intersection((0.0, 2.5, 0.0), 1.0)
+    # //1.- Verify the clearance equals signed distance minus the radius.
+    assert not intersects
+    assert math.isclose(separation, 1.5, rel_tol=1e-7)
+
+
+def test_ray_intersection_handles_inside_origin():
+    field = SphereField((0.0, 0.0, 0.0), 2.0)
+    hit = field.ray_intersection((0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
+    # //1.- Starting inside returns an immediate hit at zero distance.
+    assert hit.hit
+    assert hit.distance == 0.0
+    assert hit.position == (0.0, 0.0, 0.0)
+
+
+def test_sample_requires_three_components():
+    field = SphereField((0.0, 0.0, 0.0), 1.0)
+    # //1.- Ensure the helper raises when insufficient coordinates are supplied.
+    with pytest.raises(ValueError):
+        field.sample((1.0, 2.0))


### PR DESCRIPTION
## Summary
- add shared signed distance field sampling utilities with ray and sphere collision helpers for the python simulator
- expose equivalent SDF collision sampling structures within the Go simulation package for server-side physics
- add analytic shape regression tests for both runtimes covering ray and sphere intersection accuracy

## Testing
- pytest tests/test_physics_sdf.py
- go test ./internal/simulation


------
https://chatgpt.com/codex/tasks/task_e_68def86d62148329afab4cf84d56b371