### PR TITLE
Add SDF normal-based penetration resolution

### DIFF
--- a/python-sim/physics/__init__.py
+++ b/python-sim/physics/__init__.py
@@ -6,10 +6,13 @@ from .sdf import (
     PlaneField,
     RayHit,
 )
+from .penetration import BodyState, advance_body
 
 __all__ = [
     "SignedDistanceField",
     "SphereField",
     "PlaneField",
     "RayHit",
+    "BodyState",
+    "advance_body",
 ]

--- a/python-sim/physics/penetration.py
+++ b/python-sim/physics/penetration.py
@@ -1,0 +1,81 @@
+"""Penetration resolution utilities for signed distance field collisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple, cast
+
+from .sdf import SignedDistanceField
+
+Vector3 = Tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class BodyState:
+    """State of a spherical body tracked by the simulation."""
+
+    position: Vector3
+    velocity: Vector3
+
+
+def _to_vec3(value: Sequence[float]) -> Vector3:
+    # //1.- Coerce arbitrary sequences into strict three-component tuples.
+    components = tuple(float(component) for component in value)
+    if len(components) != 3:
+        raise ValueError("BodyState physics expects three-dimensional vectors")
+    return cast(Vector3, components)
+
+
+def _add(a: Sequence[float], b: Sequence[float]) -> Vector3:
+    # //1.- Combine vectors component-wise for position integration.
+    ax, ay, az = _to_vec3(a)
+    bx, by, bz = _to_vec3(b)
+    return (ax + bx, ay + by, az + bz)
+
+
+def _scale(vector: Sequence[float], scalar: float) -> Vector3:
+    # //1.- Multiply vectors by scalars to scale velocity by the timestep.
+    vx, vy, vz = _to_vec3(vector)
+    return (vx * scalar, vy * scalar, vz * scalar)
+
+
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    # //1.- Dot product facilitates velocity projection along contact normals.
+    ax, ay, az = _to_vec3(a)
+    bx, by, bz = _to_vec3(b)
+    return ax * bx + ay * by + az * bz
+
+
+def advance_body(
+    state: BodyState,
+    field: SignedDistanceField,
+    *,
+    radius: float,
+    dt: float,
+    normal_epsilon: float = 1e-3,
+) -> BodyState:
+    """Advance a body and resolve penetration against the signed distance field."""
+
+    # //1.- Integrate the body's position forward using explicit Euler integration.
+    predicted_position = _add(state.position, _scale(state.velocity, dt))
+    intersects, clearance = field.sphere_intersection(predicted_position, radius)
+    if not intersects:
+        # //2.- Early exit when no penetration occurs after integration.
+        return BodyState(position=predicted_position, velocity=state.velocity)
+
+    # //3.- Derive the contact normal from the SDF gradient at the penetrated point.
+    normal = field.surface_normal(predicted_position, epsilon=normal_epsilon)
+    penetration_depth = -clearance
+    corrected_position = _add(
+        predicted_position,
+        _scale(normal, penetration_depth),
+    )
+
+    # //4.- Remove inward normal velocity components to prevent re-penetration next frame.
+    inward_speed = _dot(state.velocity, normal)
+    if inward_speed < 0.0:
+        corrected_velocity = _add(state.velocity, _scale(normal, -inward_speed))
+    else:
+        corrected_velocity = state.velocity
+
+    return BodyState(position=corrected_position, velocity=corrected_velocity)

--- a/python-sim/tests/test_physics_penetration.py
+++ b/python-sim/tests/test_physics_penetration.py
@@ -1,0 +1,50 @@
+"""Regression tests for penetration resolution using signed distance fields."""
+
+import sys
+from pathlib import Path
+
+import math
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from physics import BodyState, PlaneField, advance_body
+
+
+def test_surface_normal_matches_plane_orientation():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    normal = plane.surface_normal((0.25, -0.5, 0.75))
+    # //1.- Plane surface normals should align with the provided plane normal.
+    assert normal == pytest.approx((0.0, 1.0, 0.0))
+
+
+def test_penetration_resolution_pushes_body_out():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    state = BodyState(position=(0.0, 0.2, 0.0), velocity=(0.0, -5.0, 0.0))
+    resolved = advance_body(state, plane, radius=1.0, dt=0.1)
+    # //1.- The corrected position should rest exactly one unit above the plane.
+    assert math.isclose(resolved.position[1], 1.0, rel_tol=1e-6, abs_tol=1e-6)
+    # //2.- Inward velocity components are removed to prevent re-entry.
+    assert resolved.velocity == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_penetration_resolution_preserves_tangent_velocity():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    state = BodyState(position=(0.0, 0.5, 0.0), velocity=(10.0, -30.0, 5.0))
+    resolved = advance_body(state, plane, radius=1.0, dt=0.05)
+    # //1.- Tangential velocity components must remain unchanged after resolution.
+    assert resolved.velocity == pytest.approx((10.0, 0.0, 5.0))
+
+
+def test_high_speed_impact_stabilizes_after_single_step():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    state = BodyState(position=(0.0, 8.0, 0.0), velocity=(0.0, -180.0, 0.0))
+    resolved = advance_body(state, plane, radius=1.0, dt=0.05)
+    # //1.- High-speed impacts should still resolve to surface contact without jitter.
+    assert math.isclose(resolved.position[1], 1.0, rel_tol=1e-6, abs_tol=1e-6)
+    assert resolved.velocity == pytest.approx((0.0, 0.0, 0.0))
+
+    # //2.- Subsequent frames should remain stable without re-penetration.
+    follow_up = advance_body(resolved, plane, radius=1.0, dt=0.05)
+    assert math.isclose(follow_up.position[1], 1.0, rel_tol=1e-6, abs_tol=1e-6)
+    assert follow_up.velocity == pytest.approx((0.0, 0.0, 0.0))


### PR DESCRIPTION
## Summary
- add gradient and surface normal helpers to the signed distance field
- implement an SDF-backed penetration resolver that clamps inward velocity
- cover high-speed and tangential collision cases with regression tests

## Testing
- pytest python-sim/tests/test_physics_sdf.py python-sim/tests/test_physics_penetration.py

------
https://chatgpt.com/codex/tasks/task_e_68defc97d120832985af0ea5ba341934