### PR TITLE
Add physics integrator and assist alignment controls

### DIFF
--- a/go-broker/internal/physics/guidance.go
+++ b/go-broker/internal/physics/guidance.go
@@ -1,0 +1,93 @@
+package physics
+
+import (
+	"math"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+// GuidanceSpline represents a polyline used for assisted alignment.
+type GuidanceSpline struct {
+	nodes []Vec3
+}
+
+// NewGuidanceSpline defensively copies nodes for use during alignment.
+func NewGuidanceSpline(nodes []Vec3) *GuidanceSpline {
+	//1.- Require at least two nodes to compute tangents along the spline.
+	if len(nodes) < 2 {
+		return nil
+	}
+	copied := make([]Vec3, len(nodes))
+	copy(copied, nodes)
+	return &GuidanceSpline{nodes: copied}
+}
+
+// tangentFor returns the unit tangent of the closest segment to the position.
+func (g *GuidanceSpline) tangentFor(position Vec3) (Vec3, bool) {
+	//1.- Ensure the spline has data before computing tangents.
+	if g == nil || len(g.nodes) < 2 {
+		return Vec3{}, false
+	}
+	bestDistance := math.MaxFloat64
+	bestTangent := Vec3{}
+	//2.- Iterate over each segment and choose the closest projection.
+	for idx := 0; idx < len(g.nodes)-1; idx++ {
+		a := g.nodes[idx]
+		b := g.nodes[idx+1]
+		ab := Vec3{X: b.X - a.X, Y: b.Y - a.Y, Z: b.Z - a.Z}
+		abLenSquared := ab.X*ab.X + ab.Y*ab.Y + ab.Z*ab.Z
+		if abLenSquared == 0 {
+			continue
+		}
+		ap := Vec3{X: position.X - a.X, Y: position.Y - a.Y, Z: position.Z - a.Z}
+		t := (ap.X*ab.X + ap.Y*ab.Y + ap.Z*ab.Z) / abLenSquared
+		if t < 0 {
+			t = 0
+		} else if t > 1 {
+			t = 1
+		}
+		closest := Vec3{X: a.X + ab.X*t, Y: a.Y + ab.Y*t, Z: a.Z + ab.Z*t}
+		dx := position.X - closest.X
+		dy := position.Y - closest.Y
+		dz := position.Z - closest.Z
+		distance := math.Sqrt(dx*dx + dy*dy + dz*dz)
+		if distance < bestDistance {
+			bestDistance = distance
+			length := math.Sqrt(abLenSquared)
+			inv := 1.0 / length
+			bestTangent = Vec3{X: ab.X * inv, Y: ab.Y * inv, Z: ab.Z * inv}
+		}
+	}
+	return bestTangent, bestDistance < math.MaxFloat64
+}
+
+// AlignToGuidance rotates the vehicle orientation toward the spline tangent.
+func AlignToGuidance(state *pb.VehicleState, spline *GuidanceSpline) {
+	//1.- Guard against missing prerequisites so manual mode is unaffected.
+	if state == nil || spline == nil || state.Position == nil {
+		return
+	}
+	tangent, ok := spline.tangentFor(FromProtoVec3(state.Position))
+	if !ok {
+		return
+	}
+	//2.- Compute yaw and pitch angles from the tangent vector.
+	horizontal := math.Sqrt(tangent.X*tangent.X + tangent.Z*tangent.Z)
+	yaw := 0.0
+	if horizontal != 0 {
+		yaw = math.Atan2(tangent.X, tangent.Z) * 180.0 / math.Pi
+	}
+	pitch := math.Atan2(tangent.Y, horizontal) * 180.0 / math.Pi
+	//3.- Apply the orientation and dampen angular velocity for stability.
+	if state.Orientation == nil {
+		state.Orientation = &pb.Orientation{}
+	}
+	state.Orientation.YawDeg = wrapAngleDeg(yaw)
+	state.Orientation.PitchDeg = wrapAngleDeg(pitch)
+	state.Orientation.RollDeg = 0
+	if state.AngularVelocity != nil {
+		state.AngularVelocity.X = 0
+		state.AngularVelocity.Y = 0
+		state.AngularVelocity.Z = 0
+	}
+}

--- a/go-broker/internal/physics/guidance_test.go
+++ b/go-broker/internal/physics/guidance_test.go
@@ -1,0 +1,39 @@
+package physics
+
+import (
+	"math"
+	"testing"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+func TestAlignToGuidanceAdjustsOrientation(t *testing.T) {
+	//1.- Create a straight spline pointing along the positive X axis.
+	spline := NewGuidanceSpline([]Vec3{{X: 0, Y: 0, Z: 0}, {X: 10, Y: 0, Z: 0}})
+	state := &pb.VehicleState{
+		Position:        &pb.Vector3{X: 1, Y: 0, Z: 0},
+		Orientation:     &pb.Orientation{YawDeg: 0, PitchDeg: 0, RollDeg: 0},
+		AngularVelocity: &pb.Vector3{X: 5, Y: -5, Z: 2},
+	}
+	//2.- Align to the spline and verify the yaw target is achieved.
+	AlignToGuidance(state, spline)
+	if math.Abs(state.Orientation.YawDeg-90) > 1e-9 {
+		t.Fatalf("expected yaw to align to +X, got %.2f", state.Orientation.YawDeg)
+	}
+	if math.Abs(state.Orientation.PitchDeg) > 1e-9 {
+		t.Fatalf("expected level pitch, got %.2f", state.Orientation.PitchDeg)
+	}
+	if state.AngularVelocity == nil || state.AngularVelocity.X != 0 || state.AngularVelocity.Y != 0 || state.AngularVelocity.Z != 0 {
+		t.Fatalf("expected angular velocity to be dampened")
+	}
+}
+
+func TestAlignToGuidanceHandlesNilInputs(t *testing.T) {
+	//1.- Exercise nil and degenerate paths to ensure stability.
+	AlignToGuidance(nil, nil)
+	state := &pb.VehicleState{}
+	AlignToGuidance(state, nil)
+	if state.Orientation != nil {
+		t.Fatalf("orientation should remain unset without guidance")
+	}
+}

--- a/go-broker/internal/physics/integrator.go
+++ b/go-broker/internal/physics/integrator.go
@@ -1,0 +1,82 @@
+package physics
+
+import (
+	"math"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+// Vec3 is a lightweight vector helper used by the physics utilities.
+type Vec3 struct {
+	X float64
+	Y float64
+	Z float64
+}
+
+// FromProtoVec3 converts a protobuf vector into the helper representation.
+func FromProtoVec3(v *pb.Vector3) Vec3 {
+	//1.- Protect against nil inputs to keep call sites concise.
+	if v == nil {
+		return Vec3{}
+	}
+	return Vec3{X: v.X, Y: v.Y, Z: v.Z}
+}
+
+// ToProtoVec3 copies the helper representation back into a protobuf vector.
+func ToProtoVec3(v Vec3, dst *pb.Vector3) *pb.Vector3 {
+	//1.- Allocate the destination if required for easier callers.
+	if dst == nil {
+		dst = &pb.Vector3{}
+	}
+	//2.- Copy each component for the mutation based workflow.
+	dst.X = v.X
+	dst.Y = v.Y
+	dst.Z = v.Z
+	return dst
+}
+
+// wrapAngleDeg normalizes an angle to the [-180, 180) range.
+func wrapAngleDeg(angle float64) float64 {
+	//1.- Use math.Mod to keep values bounded across many integration steps.
+	wrapped := math.Mod(angle+180.0, 360.0)
+	if wrapped < 0 {
+		wrapped += 360.0
+	}
+	return wrapped - 180.0
+}
+
+// integrateLinear applies velocity over the timestep to update the position.
+func integrateLinear(position *pb.Vector3, velocity *pb.Vector3, step float64) {
+	//1.- Skip integration when inputs are missing or invalid.
+	if position == nil || velocity == nil || step <= 0 {
+		return
+	}
+	//2.- Advance each axis using the standard Euler integration.
+	position.X += velocity.X * step
+	position.Y += velocity.Y * step
+	position.Z += velocity.Z * step
+}
+
+// integrateAngular applies angular velocity to the Euler orientation.
+func integrateAngular(orientation *pb.Orientation, angularVelocity *pb.Vector3, step float64) {
+	//1.- Require valid orientation data before attempting integration.
+	if orientation == nil || angularVelocity == nil || step <= 0 {
+		return
+	}
+	//2.- Update each Euler component in degrees per second then wrap.
+	orientation.YawDeg = wrapAngleDeg(orientation.YawDeg + angularVelocity.Y*step)
+	orientation.PitchDeg = wrapAngleDeg(orientation.PitchDeg + angularVelocity.X*step)
+	orientation.RollDeg = wrapAngleDeg(orientation.RollDeg + angularVelocity.Z*step)
+}
+
+// IntegrateVehicle advances both linear and angular state for the vehicle.
+func IntegrateVehicle(state *pb.VehicleState, step float64) {
+	//1.- Guard against nil or invalid timesteps for robustness.
+	if state == nil || step <= 0 {
+		return
+	}
+	//2.- Integrate translation if both position and velocity are present.
+	integrateLinear(state.Position, state.Velocity, step)
+	//3.- Integrate rotation using the angular velocity channel.
+	integrateAngular(state.Orientation, state.AngularVelocity, step)
+}

--- a/go-broker/internal/physics/integrator_test.go
+++ b/go-broker/internal/physics/integrator_test.go
@@ -1,0 +1,48 @@
+package physics
+
+import (
+	"math"
+	"testing"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+)
+
+func TestIntegrateVehicleUpdatesLinearAndAngular(t *testing.T) {
+	//1.- Construct a vehicle with both velocity components populated.
+	state := &pb.VehicleState{
+		Position:        &pb.Vector3{X: 1, Y: 2, Z: 3},
+		Velocity:        &pb.Vector3{X: 4, Y: -2, Z: 0.5},
+		Orientation:     &pb.Orientation{YawDeg: 10, PitchDeg: -5, RollDeg: 0},
+		AngularVelocity: &pb.Vector3{X: 20, Y: 30, Z: -10},
+	}
+	//2.- Advance the state by half a second and verify results.
+	IntegrateVehicle(state, 0.5)
+	if math.Abs(state.Position.X-3) > 1e-9 {
+		t.Fatalf("unexpected X %.2f", state.Position.X)
+	}
+	if math.Abs(state.Position.Y-1) > 1e-9 {
+		t.Fatalf("unexpected Y %.2f", state.Position.Y)
+	}
+	if math.Abs(state.Position.Z-3.25) > 1e-9 {
+		t.Fatalf("unexpected Z %.2f", state.Position.Z)
+	}
+	if math.Abs(state.Orientation.YawDeg-25) > 1e-9 {
+		t.Fatalf("unexpected yaw %.2f", state.Orientation.YawDeg)
+	}
+	if math.Abs(state.Orientation.PitchDeg-5) > 1e-9 {
+		t.Fatalf("unexpected pitch %.2f", state.Orientation.PitchDeg)
+	}
+	if math.Abs(state.Orientation.RollDeg+5) > 1e-9 {
+		t.Fatalf("unexpected roll %.2f", state.Orientation.RollDeg)
+	}
+}
+
+func TestIntegrateVehicleHandlesInvalidInput(t *testing.T) {
+	//1.- Use nil state and zero timestep to ensure safe no-op behaviour.
+	IntegrateVehicle(nil, 0.5)
+	state := &pb.VehicleState{}
+	IntegrateVehicle(state, -1)
+	if state.Position != nil || state.Orientation != nil {
+		t.Fatalf("integration should not allocate with invalid input")
+	}
+}

--- a/go-broker/internal/simulation/assist_test.go
+++ b/go-broker/internal/simulation/assist_test.go
@@ -1,0 +1,71 @@
+package simulation
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"driftpursuit/broker/internal/physics"
+	pb "driftpursuit/broker/internal/proto/pb"
+	"driftpursuit/broker/internal/state"
+)
+
+func TestManualModeRetainsAngularIntegration(t *testing.T) {
+	//1.- Configure the world with a placeholder guidance spline.
+	world := state.NewWorldState()
+	world.Vehicles.SetGuidanceSpline(physics.NewGuidanceSpline([]physics.Vec3{{X: 0, Y: 0, Z: 0}, {X: 0, Y: 0, Z: 10}}))
+	vehicle := &pb.VehicleState{
+		VehicleId:           "manual-1",
+		Position:            &pb.Vector3{X: 0, Y: 0, Z: 0},
+		Velocity:            &pb.Vector3{X: 0, Y: 0, Z: 0},
+		Orientation:         &pb.Orientation{YawDeg: 0, PitchDeg: 0, RollDeg: 0},
+		AngularVelocity:     &pb.Vector3{Y: 90},
+		FlightAssistEnabled: false,
+	}
+	world.Vehicles.Upsert(vehicle)
+	world.Vehicles.ConsumeDiff()
+	//2.- Advance half a second and expect the yaw to integrate freely.
+	diff := world.AdvanceTick(500 * time.Millisecond)
+	if len(diff.Vehicles.Updated) != 1 {
+		t.Fatalf("expected vehicle diff entry")
+	}
+	updated := diff.Vehicles.Updated[0]
+	if math.Abs(updated.Orientation.YawDeg-45) > 1e-9 {
+		t.Fatalf("expected yaw 45 degrees, got %.2f", updated.Orientation.YawDeg)
+	}
+}
+
+func TestAssistModeAlignsToSpline(t *testing.T) {
+	//1.- Configure a spline that climbs upward while moving along +Z.
+	world := state.NewWorldState()
+	spline := physics.NewGuidanceSpline([]physics.Vec3{{X: 0, Y: 0, Z: 0}, {X: 0, Y: 5, Z: 5}})
+	world.Vehicles.SetGuidanceSpline(spline)
+	vehicle := &pb.VehicleState{
+		VehicleId:           "assist-1",
+		Position:            &pb.Vector3{X: 0, Y: 0, Z: 0},
+		Velocity:            &pb.Vector3{X: 0, Y: 0, Z: 0},
+		Orientation:         &pb.Orientation{YawDeg: -90, PitchDeg: 0, RollDeg: 45},
+		AngularVelocity:     &pb.Vector3{X: 0, Y: -120, Z: 30},
+		FlightAssistEnabled: true,
+	}
+	world.Vehicles.Upsert(vehicle)
+	world.Vehicles.ConsumeDiff()
+	//2.- Advance one tick and expect the orientation to match the spline tangent.
+	diff := world.AdvanceTick(1 * time.Second)
+	if len(diff.Vehicles.Updated) != 1 {
+		t.Fatalf("expected updated vehicle")
+	}
+	updated := diff.Vehicles.Updated[0]
+	if math.Abs(updated.Orientation.YawDeg) > 1e-9 {
+		t.Fatalf("expected yaw 0, got %.2f", updated.Orientation.YawDeg)
+	}
+	if math.Abs(updated.Orientation.PitchDeg-45) > 1e-9 {
+		t.Fatalf("expected pitch 45, got %.2f", updated.Orientation.PitchDeg)
+	}
+	if math.Abs(updated.Orientation.RollDeg) > 1e-9 {
+		t.Fatalf("expected roll 0, got %.2f", updated.Orientation.RollDeg)
+	}
+	if updated.AngularVelocity == nil || updated.AngularVelocity.X != 0 || updated.AngularVelocity.Y != 0 || updated.AngularVelocity.Z != 0 {
+		t.Fatalf("expected angular velocity dampening")
+	}
+}

--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts"
+    "test": "ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/typescript-client/src/physics/integrator.test.ts
+++ b/typescript-client/src/physics/integrator.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert";
+import {
+  GuidanceSpline,
+  applyAssistAlignment,
+  integrateVehicle,
+  wrapAngleDeg,
+  type VehicleStateLike,
+} from "./integrator";
+
+//1.- Verify the integrator advances both linear and angular state over a step.
+{
+  const state: VehicleStateLike = {
+    position: { x: 1, y: 2, z: 3 },
+    velocity: { x: 4, y: -2, z: 0.5 },
+    orientation: { yawDeg: 10, pitchDeg: -5, rollDeg: 0 },
+    angularVelocity: { x: 20, y: 30, z: -10 },
+  };
+  integrateVehicle(state, 0.5);
+  assert.ok(Math.abs((state.position?.x ?? 0) - 3) < 1e-9, "unexpected x");
+  assert.ok(Math.abs((state.position?.y ?? 0) - 1) < 1e-9, "unexpected y");
+  assert.ok(Math.abs((state.position?.z ?? 0) - 3.25) < 1e-9, "unexpected z");
+  assert.ok(Math.abs((state.orientation?.yawDeg ?? 0) - 25) < 1e-9, "unexpected yaw");
+  assert.ok(Math.abs((state.orientation?.pitchDeg ?? 0) - 5) < 1e-9, "unexpected pitch");
+  assert.ok(Math.abs((state.orientation?.rollDeg ?? 0) + 5) < 1e-9, "unexpected roll");
+}
+
+//2.- Confirm wrapAngleDeg keeps values within the inclusive-exclusive range.
+{
+  assert.strictEqual(wrapAngleDeg(540), -180 + 0, "540 should wrap to -180");
+  assert.ok(wrapAngleDeg(-725) >= -180 && wrapAngleDeg(-725) < 180, "wrapped range");
+}
+
+//3.- Ensure assist alignment reorients the craft along the spline.
+{
+  const spline = new GuidanceSpline([
+    { x: 0, y: 0, z: 0 },
+    { x: 0, y: 5, z: 5 },
+  ]);
+  const state: VehicleStateLike = {
+    position: { x: 0, y: 0, z: 0 },
+    orientation: { yawDeg: -90, pitchDeg: 0, rollDeg: 30 },
+    angularVelocity: { x: 15, y: -40, z: 5 },
+    flightAssistEnabled: true,
+  };
+  applyAssistAlignment(state, spline);
+  assert.ok(Math.abs(state.orientation?.yawDeg ?? 0) < 1e-9, "yaw alignment");
+  assert.ok(Math.abs((state.orientation?.pitchDeg ?? 0) - 45) < 1e-9, "pitch alignment");
+  assert.ok(Math.abs(state.orientation?.rollDeg ?? 0) < 1e-9, "roll alignment");
+  assert.strictEqual(state.angularVelocity?.x, 0, "angular x dampened");
+  assert.strictEqual(state.angularVelocity?.y, 0, "angular y dampened");
+  assert.strictEqual(state.angularVelocity?.z, 0, "angular z dampened");
+}

--- a/typescript-client/src/physics/integrator.ts
+++ b/typescript-client/src/physics/integrator.ts
@@ -1,0 +1,144 @@
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface OrientationDeg {
+  yawDeg: number;
+  pitchDeg: number;
+  rollDeg: number;
+}
+
+export interface VehicleStateLike {
+  position?: Vec3;
+  velocity?: Vec3;
+  orientation?: OrientationDeg;
+  angularVelocity?: Vec3;
+  flightAssistEnabled?: boolean;
+}
+
+// wrapAngleDeg normalizes an angle into the [-180, 180) interval.
+export function wrapAngleDeg(angle: number): number {
+  //1.- Use modulo arithmetic to prevent unbounded growth over long runs.
+  const wrapped = ((angle + 180) % 360 + 360) % 360;
+  return wrapped - 180;
+}
+
+// integrateLinear advances a position using simple Euler integration.
+export function integrateLinear(position: Vec3 | undefined, velocity: Vec3 | undefined, step: number): void {
+  //1.- Guard against invalid inputs so callers can pass partial state objects.
+  if (!position || !velocity || !(step > 0)) {
+    return;
+  }
+  //2.- Apply the displacement derived from velocity * dt on each axis.
+  position.x += velocity.x * step;
+  position.y += velocity.y * step;
+  position.z += velocity.z * step;
+}
+
+// integrateAngular updates Euler angles from angular velocity in degrees/s.
+export function integrateAngular(orientation: OrientationDeg | undefined, angularVelocity: Vec3 | undefined, step: number): void {
+  //1.- Skip when the vehicle lacks rotation data or the step is degenerate.
+  if (!orientation || !angularVelocity || !(step > 0)) {
+    return;
+  }
+  //2.- Add the integrated deltas and wrap to keep the values bounded.
+  orientation.yawDeg = wrapAngleDeg(orientation.yawDeg + angularVelocity.y * step);
+  orientation.pitchDeg = wrapAngleDeg(orientation.pitchDeg + angularVelocity.x * step);
+  orientation.rollDeg = wrapAngleDeg(orientation.rollDeg + angularVelocity.z * step);
+}
+
+// integrateVehicle mutates the provided state with both linear and angular updates.
+export function integrateVehicle(state: VehicleStateLike | undefined, step: number): void {
+  //1.- Support defensive callers by no-oping on invalid state or timestep.
+  if (!state || !(step > 0)) {
+    return;
+  }
+  //2.- Apply both translation and rotation integration in place.
+  integrateLinear(state.position, state.velocity, step);
+  integrateAngular(state.orientation, state.angularVelocity, step);
+}
+
+export class GuidanceSpline {
+  private readonly nodes: Vec3[];
+
+  constructor(nodes: Vec3[]) {
+    //1.- Require at least two nodes so a tangent can be computed.
+    if (nodes.length < 2) {
+      throw new Error("GuidanceSpline requires at least two nodes");
+    }
+    //2.- Copy the input to prevent external mutation after construction.
+    this.nodes = nodes.map((node) => ({ ...node }));
+  }
+
+  private tangentFor(position: Vec3): Vec3 | undefined {
+    //1.- Track the closest segment to the provided position.
+    let bestDistance = Number.POSITIVE_INFINITY;
+    let bestTangent: Vec3 | undefined;
+    for (let i = 0; i < this.nodes.length - 1; i += 1) {
+      const a = this.nodes[i];
+      const b = this.nodes[i + 1];
+      const ab = { x: b.x - a.x, y: b.y - a.y, z: b.z - a.z };
+      const abLenSquared = ab.x * ab.x + ab.y * ab.y + ab.z * ab.z;
+      if (abLenSquared === 0) {
+        continue;
+      }
+      const ap = { x: position.x - a.x, y: position.y - a.y, z: position.z - a.z };
+      let t = (ap.x * ab.x + ap.y * ab.y + ap.z * ab.z) / abLenSquared;
+      if (t < 0) {
+        t = 0;
+      } else if (t > 1) {
+        t = 1;
+      }
+      const closest = { x: a.x + ab.x * t, y: a.y + ab.y * t, z: a.z + ab.z * t };
+      const dx = position.x - closest.x;
+      const dy = position.y - closest.y;
+      const dz = position.z - closest.z;
+      const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        const length = Math.sqrt(abLenSquared);
+        bestTangent = { x: ab.x / length, y: ab.y / length, z: ab.z / length };
+      }
+    }
+    return bestTangent;
+  }
+
+  align(state: VehicleStateLike): void {
+    //1.- Only operate when both the spline and vehicle position are available.
+    if (!state.position) {
+      return;
+    }
+    const tangent = this.tangentFor(state.position);
+    if (!tangent) {
+      return;
+    }
+    //2.- Compute yaw and pitch angles from the tangent direction.
+    const horizontal = Math.sqrt(tangent.x * tangent.x + tangent.z * tangent.z);
+    const yaw = horizontal === 0 ? 0 : (Math.atan2(tangent.x, tangent.z) * 180) / Math.PI;
+    const pitch = (Math.atan2(tangent.y, horizontal) * 180) / Math.PI;
+    //3.- Allocate orientation if necessary and zero angular velocity for stability.
+    if (!state.orientation) {
+      state.orientation = { yawDeg: 0, pitchDeg: 0, rollDeg: 0 };
+    }
+    state.orientation.yawDeg = wrapAngleDeg(yaw);
+    state.orientation.pitchDeg = wrapAngleDeg(pitch);
+    state.orientation.rollDeg = 0;
+    if (state.angularVelocity) {
+      state.angularVelocity.x = 0;
+      state.angularVelocity.y = 0;
+      state.angularVelocity.z = 0;
+    }
+  }
+}
+
+// applyAssistAlignment conditionally aligns the craft when assist is active.
+export function applyAssistAlignment(state: VehicleStateLike | undefined, spline: GuidanceSpline | undefined): void {
+  //1.- Skip unless assist mode is toggled and the spline is available.
+  if (!state || !state.flightAssistEnabled || !spline) {
+    return;
+  }
+  //2.- Delegate to the spline alignment helper.
+  spline.align(state);
+}


### PR DESCRIPTION
## Summary
- add a dedicated physics package that integrates linear/angular state and supports guidance-aligned assist behaviour
- wire vehicle advancement through the integrator with optional guidance splines and cover manual/assist transitions in simulation tests
- mirror the integrator and assist logic in the TypeScript client with matching unit coverage and include the new tests in the suite

## Testing
- go test ./...
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68defdfb7aa08329a9c29459f73b062d