### PR TITLE
Add ground vehicle placeholders and surface constraint

### DIFF
--- a/docs/network_schemas.md
+++ b/docs/network_schemas.md
@@ -49,6 +49,15 @@ The generated bindings streamline deserialisation in each language:
 - **Python** — `vehicle_pb2.VehicleState.FromString` provides the strongly typed view needed by automation tools.
 - **TypeScript** — The ts-proto bindings expose `VehicleState.encode`, `VehicleState.decode`, and JSON helpers so browser and Node clients can validate their payloads before delivery.
 
+## Ground vehicle roster status
+
+Ground vehicles are intentionally absent from the live roster until the shared
+surface-bound physics stack is production ready. Placeholder configuration entries
+live alongside the Skiff stats so UI experiments can enumerate the future roster
+without allowing selection. The client marks those entries as non-selectable and
+provides explanatory messaging while the drivetrain, suspension, and balance data
+are still under development.
+
 //3.- Capture pilot intent frames
 
 Real-time control streams follow the `Intent` schema so the broker can enforce limits before forwarding commands downstream.

--- a/python-sim/physics/__init__.py
+++ b/python-sim/physics/__init__.py
@@ -6,7 +6,7 @@ from .sdf import (
     PlaneField,
     RayHit,
 )
-from .penetration import BodyState, advance_body
+from .penetration import BodyState, advance_body, advance_surface_bound_body
 
 __all__ = [
     "SignedDistanceField",
@@ -15,4 +15,5 @@ __all__ = [
     "RayHit",
     "BodyState",
     "advance_body",
+    "advance_surface_bound_body",
 ]

--- a/python-sim/tests/test_physics_surface_constraint.py
+++ b/python-sim/tests/test_physics_surface_constraint.py
@@ -1,0 +1,29 @@
+"""Validate ground vehicle surface constraints keep actors glued to the track."""
+
+import sys
+from pathlib import Path
+
+import math
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from physics import BodyState, PlaneField, advance_surface_bound_body  # type: ignore  # pylint: disable=import-error
+
+
+def test_upward_velocity_gets_suppressed():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    state = BodyState(position=(0.0, 1.0, 0.0), velocity=(0.0, 12.0, 0.0))
+    # //1.- Advance the surface-bound body so it cannot lift away from the ground.
+    constrained = advance_surface_bound_body(state, plane, radius=1.0, dt=0.1)
+    assert math.isclose(constrained.position[1], 1.0, rel_tol=1e-6, abs_tol=1e-6)
+    assert constrained.velocity == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_tangential_motion_survives_constraint():
+    plane = PlaneField((0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    state = BodyState(position=(0.0, 1.0, 0.0), velocity=(10.0, 4.0, -3.0))
+    # //1.- After the constraint vertical motion should vanish while tangential remains.
+    constrained = advance_surface_bound_body(state, plane, radius=1.0, dt=0.05)
+    assert constrained.velocity == pytest.approx((10.0, 0.0, -3.0))

--- a/tunnelcave_sandbox_web/src/world/vehicleLoadout.ts
+++ b/tunnelcave_sandbox_web/src/world/vehicleLoadout.ts
@@ -1,0 +1,24 @@
+import { vehicleRoster, VehicleRosterEntry } from "../../../typescript-client/src/vehicleRoster";
+
+export interface LoadoutOption {
+  //1.- Provide the identifier for binding UI selection state.
+  id: string;
+  //2.- Human readable label surfaced to players.
+  displayName: string;
+  //3.- Snapshot of the underlying roster entry so tooltips can access metadata.
+  reference: VehicleRosterEntry;
+}
+
+export function getSelectableVehicles(): LoadoutOption[] {
+  //1.- Filter the roster so UI widgets only offer selectable entries.
+  return vehicleRoster
+    .filter((entry) => entry.selectable)
+    .map((entry) => ({ id: entry.id, displayName: entry.displayName, reference: entry }));
+}
+
+export function getDisabledVehicles(): LoadoutOption[] {
+  //1.- Surface disabled entries along with their metadata for tooltip messaging.
+  return vehicleRoster
+    .filter((entry) => !entry.selectable)
+    .map((entry) => ({ id: entry.id, displayName: entry.displayName, reference: entry }));
+}

--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts"
+    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/typescript-client/src/gameplayConfig.test.ts
+++ b/typescript-client/src/gameplayConfig.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { skiffStats } from "./gameplayConfig";
+import { groundVehiclePlaceholders, skiffStats } from "./gameplayConfig";
 
 //1.- Verify each stat so mismatches between client and server are immediately obvious.
 assert.strictEqual(skiffStats.maxSpeedMps, 120.0, "max speed should match shared config");
@@ -11,3 +11,16 @@ assert.strictEqual(skiffStats.verticalAccelerationMps2, 16.0, "vertical accelera
 assert.strictEqual(skiffStats.boostAccelerationMps2, 48.0, "boost acceleration should match shared config");
 assert.strictEqual(skiffStats.boostDurationSeconds, 3.5, "boost duration should match shared config");
 assert.strictEqual(skiffStats.boostCooldownSeconds, 9.0, "boost cooldown should match shared config");
+
+//1.- Materialise the placeholder roster so the assertions stay deterministic.
+const placeholderEntries = Object.entries(groundVehiclePlaceholders);
+//2.- Ensure each placeholder stays non-selectable until the physics layer supports ground vehicles.
+placeholderEntries.forEach(([identifier, config]) => {
+  assert.strictEqual(config.selectable, false, `${identifier} should remain disabled in the roster`);
+  assert.ok(config.notes.length > 0, `${identifier} placeholder must document why it is disabled`);
+  assert.strictEqual(
+    config.stats.maxSpeedMps,
+    0,
+    `${identifier} placeholder uses zero stats until gameplay data arrives`,
+  );
+});

--- a/typescript-client/src/gameplayConfig.ts
+++ b/typescript-client/src/gameplayConfig.ts
@@ -15,6 +15,17 @@ export interface VehicleStats {
 
 const SKIFF_CONFIG_PATH = resolve(__dirname, "../../go-broker/internal/gameplay/skiff.json");
 
+export interface GroundVehicleConfig {
+  //1.- Expose descriptive metadata so future UI work can surface the upcoming roster.
+  displayName: string;
+  //2.- Flag whether the entry can be selected in the current build.
+  selectable: boolean;
+  //3.- Provide placeholder stats that will be replaced once design finalises the values.
+  stats: VehicleStats;
+  //4.- Human-readable note that explains why the vehicle remains disabled.
+  notes: string;
+}
+
 function loadSkiffStats(): VehicleStats {
   //1.- Parse the shared JSON payload once so both runtimes agree on the numbers.
   const payload = readFileSync(SKIFF_CONFIG_PATH, "utf-8");
@@ -24,3 +35,45 @@ function loadSkiffStats(): VehicleStats {
 }
 
 export const skiffStats: VehicleStats = loadSkiffStats();
+
+export const groundVehiclePlaceholders: Record<string, GroundVehicleConfig> = Object.freeze({
+  duneRunner: Object.freeze({
+    //1.- Placeholder entry ensures UI wiring survives until dune runner stats land.
+    displayName: "Dune Runner",
+    //2.- Disable selection so ground vehicles stay off while physics support matures.
+    selectable: false,
+    stats: Object.freeze({
+      //3.- Zeroed stats highlight that gameplay numbers are pending balancing work.
+      maxSpeedMps: 0,
+      maxAngularSpeedDegPerSec: 0,
+      forwardAccelerationMps2: 0,
+      reverseAccelerationMps2: 0,
+      strafeAccelerationMps2: 0,
+      verticalAccelerationMps2: 0,
+      boostAccelerationMps2: 0,
+      boostDurationSeconds: 0,
+      boostCooldownSeconds: 0,
+    }),
+    //4.- Give future maintainers context about why the entry remains disabled.
+    notes: "Waiting on ground handling tune before exposing dune runner to players.",
+  }),
+  trailBlazer: Object.freeze({
+    //1.- Trail Blazer shares the same placeholder scaffolding for upcoming releases.
+    displayName: "Trail Blazer",
+    selectable: false,
+    stats: Object.freeze({
+      //2.- Leave accelerations empty until drivetrain specs arrive from design.
+      maxSpeedMps: 0,
+      maxAngularSpeedDegPerSec: 0,
+      forwardAccelerationMps2: 0,
+      reverseAccelerationMps2: 0,
+      strafeAccelerationMps2: 0,
+      verticalAccelerationMps2: 0,
+      boostAccelerationMps2: 0,
+      boostDurationSeconds: 0,
+      boostCooldownSeconds: 0,
+    }),
+    //3.- Capture the pending dependency chain so we can remove the guard once satisfied.
+    notes: "Requires completed suspension model and shared tuning sheet before launch.",
+  }),
+});

--- a/typescript-client/src/vehicleLoadoutBridge.test.ts
+++ b/typescript-client/src/vehicleLoadoutBridge.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert";
+import { groundVehiclePlaceholders } from "./gameplayConfig";
+import { getDisabledVehicles, getSelectableVehicles } from "../../tunnelcave_sandbox_web/src/world/vehicleLoadout";
+
+//1.- Selectable helper should only return the Skiff while ground vehicles are placeholders.
+const selectable = getSelectableVehicles();
+assert.deepStrictEqual(
+  selectable.map((option) => option.id),
+  ["skiff"],
+  "only the skiff should remain available",
+);
+
+//2.- Disabled helper mirrors the placeholder roster to keep messaging aligned.
+const disabledIds = getDisabledVehicles()
+  .map((option) => option.id)
+  .sort();
+const placeholderIds = Object.keys(groundVehiclePlaceholders).sort();
+assert.deepStrictEqual(disabledIds, placeholderIds, "ground vehicles must be disabled in the UI");

--- a/typescript-client/src/vehicleRoster.test.ts
+++ b/typescript-client/src/vehicleRoster.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { groundVehiclePlaceholders } from "./gameplayConfig";
+import { isVehicleSelectable, vehicleRoster } from "./vehicleRoster";
+
+//1.- Confirm the Skiff remains selectable for players.
+const skiffEntry = vehicleRoster.find((entry) => entry.id === "skiff");
+assert.ok(skiffEntry, "skiff entry should exist");
+assert.strictEqual(skiffEntry?.selectable, true, "skiff should be selectable");
+
+//2.- Validate that every ground placeholder is exposed but remains disabled.
+Object.keys(groundVehiclePlaceholders).forEach((identifier) => {
+  const entry = vehicleRoster.find((candidate) => candidate.id === identifier);
+  assert.ok(entry, `${identifier} placeholder should appear in the roster`);
+  assert.strictEqual(entry?.selectable, false, `${identifier} should not be selectable`);
+  assert.strictEqual(
+    isVehicleSelectable(identifier),
+    false,
+    `${identifier} helper should report non-selectable status`,
+  );
+});
+
+//3.- Unknown identifiers should also be rejected by the helper for safety.
+assert.strictEqual(isVehicleSelectable("unknown"), false, "unknown vehicles must be rejected");

--- a/typescript-client/src/vehicleRoster.ts
+++ b/typescript-client/src/vehicleRoster.ts
@@ -1,0 +1,44 @@
+import { GroundVehicleConfig, groundVehiclePlaceholders, skiffStats, VehicleStats } from "./gameplayConfig";
+
+export interface VehicleRosterEntry {
+  //1.- Provide a stable identifier consumed by UI components and telemetry.
+  id: string;
+  //2.- Expose a human-friendly label for the selection widget.
+  displayName: string;
+  //3.- Carry the stats payload so previews can reflect the tuned numbers.
+  stats: VehicleStats;
+  //4.- Flag whether the entry is currently selectable by players.
+  selectable: boolean;
+  //5.- Explain why an entry is disabled so tooltips and logs remain informative.
+  disabledReason?: string;
+}
+
+function liftGroundPlaceholder(identifier: string, config: GroundVehicleConfig): VehicleRosterEntry {
+  //1.- Convert the placeholder structure into the roster format expected by the UI.
+  return Object.freeze({
+    id: identifier,
+    displayName: config.displayName,
+    stats: config.stats,
+    selectable: config.selectable,
+    disabledReason: config.selectable ? undefined : config.notes,
+  });
+}
+
+export const vehicleRoster: readonly VehicleRosterEntry[] = Object.freeze([
+  Object.freeze({
+    //1.- Skiff remains the sole selectable craft until ground vehicles are production ready.
+    id: "skiff",
+    displayName: "Skiff",
+    stats: skiffStats,
+    selectable: true,
+  }),
+  ...Object.entries(groundVehiclePlaceholders).map(([identifier, config]) =>
+    liftGroundPlaceholder(identifier, config),
+  ),
+]);
+
+export function isVehicleSelectable(identifier: string): boolean {
+  //1.- Look up the roster entry and default to false when unknown identifiers appear.
+  const entry = vehicleRoster.find((candidate) => candidate.id === identifier);
+  return entry ? entry.selectable : false;
+}


### PR DESCRIPTION
## Summary
- add ground vehicle placeholder configurations with metadata for future expansion
- expose roster utilities that keep ground entries disabled in the client UI
- constrain surface-bound physics to keep ground vehicles on the floor and document their unsupported status

## Testing
- npx ts-node src/gameplayConfig.test.ts
- npx ts-node src/vehicleRoster.test.ts
- npx ts-node src/vehicleLoadoutBridge.test.ts
- npx ts-node src/vehicle_state.test.ts
- npx ts-node src/combat_event.test.ts
- npx ts-node src/intentPublisher.test.ts
- npx ts-node src/interpolator.test.ts
- npx ts-node src/physics/integrator.test.ts
- npx ts-node src/timeSync.test.ts
- npx ts-node src/authToken.test.ts
- npx ts-node src/eventStream.test.ts
- npx ts-node src/world_chunk_loader.test.ts
- pytest python-sim/tests/test_physics_surface_constraint.py


------
https://chatgpt.com/codex/tasks/task_e_68df049f3f8483298ee359c7a521adc1