### PR TITLE
Add configurable keybindings and document controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ docker build -t driftpursuit/bot-runner:local python-sim
 docker build -t driftpursuit/web-client:local tunnelcave_sandbox_web
 ```
 
+## Web Client Controls
+
+The Tunnelcave sandbox web client ships with the following keyboard layout. Each action maps to the underlying vehicle control axis noted below:
+
+| Action | Default Key | Axis |
+| --- | --- | --- |
+| Accelerate | W | Throttle (positive) |
+| Brake / Reverse | S | Brake (positive) |
+| Steer Left | A | Steer (negative) |
+| Steer Right | D | Steer (positive) |
+| Handbrake | Space | Handbrake (toggle) |
+| Boost | Left Shift | Boost (toggle) |
+| Shift Down | Q | Gear (negative) |
+| Shift Up | E | Gear (positive) |
+
+Accessibility settings allow players to rebind any action while still displaying the original defaults for reference. The in-game help overlay lists the current key along with the default so customised layouts remain easy to share during cooperative play.
+
 ## Development
 
 Run the unit tests to validate protocol handling and configuration parsing:

--- a/tunnelcave_sandbox_web/src/input/accessibilityOptions.test.ts
+++ b/tunnelcave_sandbox_web/src/input/accessibilityOptions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { AccessibilityOptions } from './accessibilityOptions'
+
+describe('AccessibilityOptions', () => {
+  it('exposes summaries that include default bindings', () => {
+    //1.- Instantiate with defaults so the summary should mirror the baked in layout.
+    const options = new AccessibilityOptions()
+    const accelerator = options
+      .summaries()
+      .find((summary) => summary.action === 'Accelerate')
+    expect(accelerator).toEqual({ action: 'Accelerate', key: 'KeyW', defaultKey: 'KeyW' })
+  })
+
+  it('applies overrides while retaining the original defaults in summaries', () => {
+    //1.- Apply a throttle override and ensure the summary tracks both keys.
+    const options = new AccessibilityOptions()
+    options.apply({ Accelerate: { key: 'ArrowUp' } })
+    const accelerator = options
+      .summaries()
+      .find((summary) => summary.action === 'Accelerate')
+    expect(accelerator).toEqual({ action: 'Accelerate', key: 'ArrowUp', defaultKey: 'KeyW' })
+    //2.- The current configuration should now resolve the override when queried.
+    const binding = options.currentConfiguration().findByKey('ArrowUp')
+    expect(binding?.action).toBe('Accelerate')
+  })
+})

--- a/tunnelcave_sandbox_web/src/input/accessibilityOptions.ts
+++ b/tunnelcave_sandbox_web/src/input/accessibilityOptions.ts
@@ -1,0 +1,30 @@
+import {
+  AccessibilitySummary,
+  KeybindingConfiguration,
+  KeybindingOverrides,
+  createKeybindingConfiguration,
+} from './keybindings'
+
+export class AccessibilityOptions {
+  private config: KeybindingConfiguration
+
+  constructor(config: KeybindingConfiguration = createKeybindingConfiguration()) {
+    //1.- Retain a mutable configuration that can be reissued when overrides are applied.
+    this.config = config
+  }
+
+  summaries(): AccessibilitySummary[] {
+    //1.- Surface the pairing of active and default keys for settings menus.
+    return this.config.accessibilitySummaries()
+  }
+
+  apply(overrides: KeybindingOverrides): void {
+    //1.- Rebuild the configuration so the new bindings take effect immediately.
+    this.config = this.config.withOverrides(overrides)
+  }
+
+  currentConfiguration(): KeybindingConfiguration {
+    //1.- Expose the latest keybinding table for other systems such as overlays.
+    return this.config
+  }
+}

--- a/tunnelcave_sandbox_web/src/input/keyLabels.test.ts
+++ b/tunnelcave_sandbox_web/src/input/keyLabels.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatKeyLabel } from './keyLabels'
+
+describe('formatKeyLabel', () => {
+  it('returns friendly labels for known codes', () => {
+    //1.- Check explicit aliases to guarantee stability across overlays.
+    expect(formatKeyLabel('KeyW')).toBe('W')
+    expect(formatKeyLabel('ArrowLeft')).toBe('Arrow Left')
+    expect(formatKeyLabel('ShiftLeft')).toBe('Left Shift')
+  })
+
+  it('derives labels for letter keys without explicit aliases', () => {
+    //1.- Confirm the helper strips the "Key" prefix for alphabetic codes.
+    expect(formatKeyLabel('KeyR')).toBe('R')
+  })
+
+  it('falls back to the original code for unknown keys', () => {
+    //1.- Provide an unknown identifier so the fallback path is exercised.
+    expect(formatKeyLabel('BracketLeft')).toBe('BracketLeft')
+  })
+})

--- a/tunnelcave_sandbox_web/src/input/keyLabels.ts
+++ b/tunnelcave_sandbox_web/src/input/keyLabels.ts
@@ -1,0 +1,27 @@
+const KEY_ALIASES: Record<string, string> = {
+  //1.- Normalise movement key codes to their printed counterparts.
+  KeyW: 'W',
+  KeyA: 'A',
+  KeyS: 'S',
+  KeyD: 'D',
+  KeyQ: 'Q',
+  KeyE: 'E',
+  ArrowUp: 'Arrow Up',
+  ArrowDown: 'Arrow Down',
+  ArrowLeft: 'Arrow Left',
+  ArrowRight: 'Arrow Right',
+  Space: 'Space',
+  ShiftLeft: 'Left Shift',
+  ShiftRight: 'Right Shift',
+}
+
+export const formatKeyLabel = (key: string): string => {
+  //1.- Provide a readable fallback by stripping the "Key" prefix when applicable.
+  if (KEY_ALIASES[key]) {
+    return KEY_ALIASES[key]
+  }
+  if (key.startsWith('Key') && key.length === 4) {
+    return key.slice(3)
+  }
+  return key
+}

--- a/tunnelcave_sandbox_web/src/input/keybindings.test.ts
+++ b/tunnelcave_sandbox_web/src/input/keybindings.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  KeybindingConfiguration,
+  createKeybindingConfiguration,
+  DEFAULT_BINDING_DEFINITIONS,
+} from './keybindings'
+
+describe('KeybindingConfiguration', () => {
+  it('maps default keys to the expected control axes', () => {
+    //1.- Create a configuration using the baked in defaults.
+    const config = createKeybindingConfiguration()
+    const bindings = config.describe()
+    //2.- Every default definition should be represented in the runtime table.
+    for (const definition of DEFAULT_BINDING_DEFINITIONS) {
+      const binding = bindings.find((entry) => entry.action === definition.action)
+      expect(binding?.axis).toBe(definition.axis)
+      expect(binding?.mode).toBe(definition.mode)
+      expect(binding?.key).toBe(definition.defaultKey)
+    }
+  })
+
+  it('supports rebinding keys while keeping defaults available', () => {
+    //1.- Assign a new accelerator key and keep the defaults for reference.
+    const config = KeybindingConfiguration.withDefaults({
+      Accelerate: { key: 'ArrowUp' },
+    })
+    const overridden = config.describe().find((entry) => entry.action === 'Accelerate')
+    const defaults = config.listDefaults().find((entry) => entry.action === 'Accelerate')
+    //2.- Confirm the override is active without mutating the default listing.
+    expect(overridden?.key).toBe('ArrowUp')
+    expect(defaults?.key).toBe('KeyW')
+  })
+
+  it('provides accessibility summaries pairing current and default keys', () => {
+    //1.- Rebind steering controls to arrow keys for accessibility testing.
+    const config = KeybindingConfiguration.withDefaults({
+      'Steer Left': { key: 'ArrowLeft' },
+      'Steer Right': { key: 'ArrowRight' },
+    })
+    const summaries = config.accessibilitySummaries()
+    //2.- Ensure the summaries expose both the active and default key codes.
+    const left = summaries.find((entry) => entry.action === 'Steer Left')
+    const right = summaries.find((entry) => entry.action === 'Steer Right')
+    expect(left).toEqual({ action: 'Steer Left', key: 'ArrowLeft', defaultKey: 'KeyA' })
+    expect(right).toEqual({ action: 'Steer Right', key: 'ArrowRight', defaultKey: 'KeyD' })
+  })
+})

--- a/tunnelcave_sandbox_web/src/input/keybindings.ts
+++ b/tunnelcave_sandbox_web/src/input/keybindings.ts
@@ -1,0 +1,183 @@
+export type ControlAxis =
+  | 'throttle'
+  | 'brake'
+  | 'steer'
+  | 'handbrake'
+  | 'boost'
+  | 'gear'
+
+export type BindingMode = 'positive' | 'negative' | 'toggle'
+
+export type ControlAction =
+  | 'Accelerate'
+  | 'Brake / Reverse'
+  | 'Steer Left'
+  | 'Steer Right'
+  | 'Handbrake'
+  | 'Boost'
+  | 'Shift Down'
+  | 'Shift Up'
+
+export interface KeybindingDefinition {
+  //1.- Describe the semantic action triggered by the control.
+  action: ControlAction
+  //2.- Persist the default keyboard event code shipped with the game.
+  defaultKey: string
+  //3.- Connect the action to the gameplay axis that consumes the input value.
+  axis: ControlAxis
+  //4.- Explain how the axis is driven when the key is held or toggled.
+  mode: BindingMode
+}
+
+export const DEFAULT_BINDING_DEFINITIONS: KeybindingDefinition[] = [
+  {
+    action: 'Accelerate',
+    defaultKey: 'KeyW',
+    axis: 'throttle',
+    mode: 'positive',
+  },
+  {
+    action: 'Brake / Reverse',
+    defaultKey: 'KeyS',
+    axis: 'brake',
+    mode: 'positive',
+  },
+  {
+    action: 'Steer Left',
+    defaultKey: 'KeyA',
+    axis: 'steer',
+    mode: 'negative',
+  },
+  {
+    action: 'Steer Right',
+    defaultKey: 'KeyD',
+    axis: 'steer',
+    mode: 'positive',
+  },
+  {
+    action: 'Handbrake',
+    defaultKey: 'Space',
+    axis: 'handbrake',
+    mode: 'toggle',
+  },
+  {
+    action: 'Boost',
+    defaultKey: 'ShiftLeft',
+    axis: 'boost',
+    mode: 'toggle',
+  },
+  {
+    action: 'Shift Down',
+    defaultKey: 'KeyQ',
+    axis: 'gear',
+    mode: 'negative',
+  },
+  {
+    action: 'Shift Up',
+    defaultKey: 'KeyE',
+    axis: 'gear',
+    mode: 'positive',
+  },
+]
+
+export interface KeybindingOverride {
+  //1.- Replacement keyboard event code supplied by the player.
+  key: string
+}
+
+export type KeybindingOverrides = Partial<Record<ControlAction, KeybindingOverride>>
+
+export interface Keybinding {
+  //1.- Keyboard event code currently assigned to the action.
+  key: string
+  //2.- Semantic action string displayed across UI surfaces.
+  action: ControlAction
+  //3.- Axis connected to the underlying vehicle input.
+  axis: ControlAxis
+  //4.- Direction or toggle state used when translating into control values.
+  mode: BindingMode
+  //5.- Default keyboard event code stored for accessibility reset flows.
+  defaultKey: string
+}
+
+export interface AccessibilitySummary {
+  //1.- Semantic action that can be remapped.
+  action: ControlAction
+  //2.- Currently assigned keyboard event code.
+  key: string
+  //3.- Reference keyboard event code representing the default layout.
+  defaultKey: string
+}
+
+export class KeybindingConfiguration {
+  private readonly bindings: Map<ControlAction, Keybinding>
+
+  private constructor(bindings: Map<ControlAction, Keybinding>) {
+    //1.- Persist the merged binding table for runtime lookups.
+    this.bindings = bindings
+  }
+
+  static withDefaults(overrides: KeybindingOverrides = {}): KeybindingConfiguration {
+    //1.- Seed the map using the baked in defaults so accessibility menus can revert later.
+    const merged = new Map<ControlAction, Keybinding>()
+    for (const definition of DEFAULT_BINDING_DEFINITIONS) {
+      const override = overrides[definition.action]
+      const key = override?.key ?? definition.defaultKey
+      merged.set(definition.action, {
+        key,
+        action: definition.action,
+        axis: definition.axis,
+        mode: definition.mode,
+        defaultKey: definition.defaultKey,
+      })
+    }
+    return new KeybindingConfiguration(merged)
+  }
+
+  withOverrides(overrides: KeybindingOverrides = {}): KeybindingConfiguration {
+    //1.- Build a fresh configuration applying overrides on top of the current selection.
+    const next = new Map<ControlAction, Keybinding>()
+    for (const binding of this.bindings.values()) {
+      const override = overrides[binding.action]
+      const key = override?.key ?? binding.key
+      next.set(binding.action, { ...binding, key })
+    }
+    return new KeybindingConfiguration(next)
+  }
+
+  describe(): Keybinding[] {
+    //1.- Return a deterministic array for rendering and testing.
+    return [...this.bindings.values()].sort((a, b) => a.action.localeCompare(b.action))
+  }
+
+  findByKey(key: string): Keybinding | undefined {
+    //1.- Locate bindings by keyboard event code to dispatch gameplay input events.
+    for (const binding of this.bindings.values()) {
+      if (binding.key === key) {
+        return binding
+      }
+    }
+    return undefined
+  }
+
+  listDefaults(): Keybinding[] {
+    //1.- Expose the original default keys regardless of user overrides.
+    return [...this.bindings.values()]
+      .map((binding) => ({ ...binding, key: binding.defaultKey }))
+      .sort((a, b) => a.action.localeCompare(b.action))
+  }
+
+  accessibilitySummaries(): AccessibilitySummary[] {
+    //1.- Produce paired current/default keys for accessibility option menus.
+    return this.describe().map((binding) => ({
+      action: binding.action,
+      key: binding.key,
+      defaultKey: binding.defaultKey,
+    }))
+  }
+}
+
+export const createKeybindingConfiguration = (overrides: KeybindingOverrides = {}): KeybindingConfiguration => {
+  //1.- Provide a convenience constructor mirroring the static helper.
+  return KeybindingConfiguration.withDefaults(overrides)
+}

--- a/tunnelcave_sandbox_web/src/ui/helpOverlay.test.ts
+++ b/tunnelcave_sandbox_web/src/ui/helpOverlay.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { createKeybindingConfiguration } from '../input/keybindings'
+import { HelpOverlay } from './helpOverlay'
+
+describe('HelpOverlay', () => {
+  it('renders the default control scheme', () => {
+    //1.- Build the overlay using the stock keybindings.
+    const root = document.createElement('div')
+    const config = createKeybindingConfiguration()
+    new HelpOverlay(root, config)
+    //2.- Extract the rendered keys to validate the help listing.
+    const items = Array.from(root.querySelectorAll('dd')).map((node) => node.textContent)
+    expect(items).toContain('W')
+    expect(items).toContain('D')
+    expect(items).toContain('Space')
+  })
+
+  it('shows both overridden and default keys for remapped actions', () => {
+    //1.- Override throttle and steering to alternate keys for accessibility validation.
+    const root = document.createElement('div')
+    const config = createKeybindingConfiguration({
+      Accelerate: { key: 'ArrowUp' },
+      'Steer Left': { key: 'ArrowLeft' },
+    })
+    new HelpOverlay(root, config)
+    //2.- Confirm the overlay indicates the customised key while referencing the default.
+    const entries = Array.from(root.querySelectorAll('dd')).map((node) => node.textContent)
+    expect(entries).toContain('Arrow Up (default: W)')
+    expect(entries).toContain('Arrow Left (default: A)')
+  })
+})

--- a/tunnelcave_sandbox_web/src/ui/helpOverlay.ts
+++ b/tunnelcave_sandbox_web/src/ui/helpOverlay.ts
@@ -1,0 +1,38 @@
+import { KeybindingConfiguration } from '../input/keybindings'
+import { formatKeyLabel } from '../input/keyLabels'
+
+export class HelpOverlay {
+  private readonly container: HTMLElement
+  private readonly list: HTMLElement
+
+  constructor(root: HTMLElement, keybindings: KeybindingConfiguration) {
+    //1.- Create the persistent overlay container that will hold the help content.
+    this.container = document.createElement('section')
+    this.container.className = 'help-overlay'
+    const heading = document.createElement('h2')
+    heading.textContent = 'Controls'
+    this.list = document.createElement('dl')
+    this.list.className = 'help-controls'
+    this.container.append(heading, this.list)
+    root.append(this.container)
+    this.update(keybindings)
+  }
+
+  update(keybindings: KeybindingConfiguration): void {
+    //1.- Clear existing entries before rendering the latest keybinding layout.
+    this.list.replaceChildren()
+    const entries = keybindings.describe()
+    for (const binding of entries) {
+      //2.- Render the action label followed by the currently assigned key.
+      const term = document.createElement('dt')
+      term.textContent = binding.action
+      const description = document.createElement('dd')
+      const activeLabel = formatKeyLabel(binding.key)
+      const defaultLabel = formatKeyLabel(binding.defaultKey)
+      description.textContent = activeLabel === defaultLabel
+        ? activeLabel
+        : `${activeLabel} (default: ${defaultLabel})`
+      this.list.append(term, description)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- map the web client's default keybindings onto driving control axes and expose accessibility-friendly overrides
- surface the keybinding state in a help overlay that shows both active and default shortcuts
- document the control scheme in the README for easy reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df11e07c7c8329bba63f6301b6406e