### PR TITLE
Add 20 Hz gRPC diff throttle and Python receiver pipeline

### DIFF
--- a/go-broker/internal/grpc/service.go
+++ b/go-broker/internal/grpc/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	brokerpb "driftpursuit/broker/internal/proto/pb"
 	"google.golang.org/grpc/codes"
@@ -12,6 +13,11 @@ import (
 
 // Option customises the behaviour of the gRPC streaming service.
 type Option func(*Service)
+
+// tickerFactory constructs cancellable tick channels for throttled streaming.
+type tickerFactory func(time.Duration) (<-chan time.Time, func())
+
+const diffStreamRateHz = 20
 
 // WithCompressor overrides the default payload compressor.
 func WithCompressor(compressor Compressor) Option {
@@ -26,18 +32,36 @@ func WithCompressor(compressor Compressor) Option {
 type Service struct {
 	broker     BrokerBridge
 	compressor Compressor
+	newTicker  tickerFactory
 	brokerpb.UnimplementedBrokerStreamServiceServer
 }
 
 // NewService wires the gRPC service to the broker bridge and optional settings.
 func NewService(broker BrokerBridge, opts ...Option) *Service {
-	service := &Service{broker: broker, compressor: NewGZIPCompressor()}
+	service := &Service{broker: broker, compressor: NewGZIPCompressor(), newTicker: defaultTickerFactory}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(service)
 		}
 	}
 	return service
+}
+
+// WithTickerFactory overrides the throttling ticker factory (used in tests).
+func WithTickerFactory(factory tickerFactory) Option {
+	return func(s *Service) {
+		if factory != nil {
+			s.newTicker = factory
+		}
+	}
+}
+
+func defaultTickerFactory(interval time.Duration) (<-chan time.Time, func()) {
+	ticker := time.NewTicker(interval)
+	stop := func() {
+		ticker.Stop()
+	}
+	return ticker.C, stop
 }
 
 // StreamStateDiffs relays authoritative world diffs to connected bots.
@@ -58,6 +82,18 @@ func (s *Service) StreamStateDiffs(req *brokerpb.StreamStateDiffsRequest, stream
 		compressor = NewGZIPCompressor()
 	}
 
+	interval := time.Second / diffStreamRateHz
+	if interval <= 0 {
+		interval = time.Second / diffStreamRateHz
+	}
+	tickCh, stop := s.newTicker(interval)
+	defer stop()
+
+	var (
+		pending    []DiffEvent
+		diffClosed bool
+	)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -68,9 +104,27 @@ func (s *Service) StreamStateDiffs(req *brokerpb.StreamStateDiffsRequest, stream
 			return status.Error(codes.DeadlineExceeded, "stream deadline exceeded")
 		case event, ok := <-diffCh:
 			if !ok {
-				//3.- End the stream cleanly when the broker shuts down.
-				return nil
+				//3.- Note the closed channel so the loop terminates after draining.
+				diffClosed = true
+				diffCh = nil
+				if len(pending) == 0 {
+					return nil
+				}
+				continue
 			}
+			//4.- Buffer incoming diffs so they can be flushed at the throttled cadence.
+			pending = append(pending, event)
+		case <-tickCh:
+			if len(pending) == 0 {
+				//5.- Exit once all buffered diffs are drained and the source closed.
+				if diffClosed {
+					return nil
+				}
+				continue
+			}
+			//6.- Pop the oldest buffered diff to preserve deterministic ordering.
+			event := pending[0]
+			pending = pending[1:]
 			compressed, err := compressor.Compress(event.Payload)
 			if err != nil {
 				return status.Errorf(codes.Internal, "compress diff: %v", err)

--- a/go-broker/internal/grpc/service_test.go
+++ b/go-broker/internal/grpc/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	brokerpb "driftpursuit/broker/internal/proto/pb"
 	"google.golang.org/grpc"
@@ -93,14 +94,46 @@ func (s *intentStreamStub) RecvMsg(interface{}) error    { return nil }
 
 var _ grpc.ClientStreamingServer[brokerpb.IntentFrame, brokerpb.IntentStreamAck] = (*intentStreamStub)(nil)
 
+type manualDiffBridge struct {
+	ch <-chan DiffEvent
+}
+
+func (m *manualDiffBridge) SubscribeStateDiffs(context.Context) (<-chan DiffEvent, func(), error) {
+	return m.ch, func() {}, nil
+}
+
+func (m *manualDiffBridge) ProcessIntent(context.Context, *IntentSubmission) IntentResult {
+	return IntentResult{Accepted: true}
+}
+
+var _ BrokerBridge = (*manualDiffBridge)(nil)
+
 func TestServiceStreamStateDiffs(t *testing.T) {
 	compressor := NewGZIPCompressor()
 	payload := []byte("diff-json")
-	bridge := &bridgeStub{events: []DiffEvent{{Tick: 42, Payload: payload}}}
-	service := NewService(bridge)
+	diffCh := make(chan DiffEvent, 1)
+	diffCh <- DiffEvent{Tick: 42, Payload: payload}
+	close(diffCh)
+
+	tickCh := make(chan time.Time, 2)
+	service := NewService(&manualDiffBridge{ch: diffCh}, WithTickerFactory(func(time.Duration) (<-chan time.Time, func()) {
+		return tickCh, func() {}
+	}))
 
 	stream := &diffStreamStub{ctx: context.Background()}
-	if err := service.StreamStateDiffs(&brokerpb.StreamStateDiffsRequest{ClientId: "bot-a"}, stream); err != nil {
+	done := make(chan error, 1)
+	go func() {
+		done <- service.StreamStateDiffs(&brokerpb.StreamStateDiffsRequest{ClientId: "bot-a"}, stream)
+	}()
+
+	go func() {
+		time.Sleep(2 * time.Millisecond)
+		tickCh <- time.Now()
+		time.Sleep(2 * time.Millisecond)
+		tickCh <- time.Now()
+	}()
+
+	if err := <-done; err != nil {
 		t.Fatalf("stream state diffs: %v", err)
 	}
 	if len(stream.frames) != 1 {
@@ -129,6 +162,57 @@ func TestServiceStreamStateDiffsError(t *testing.T) {
 	err := service.StreamStateDiffs(&brokerpb.StreamStateDiffsRequest{}, stream)
 	if status.Code(err) != codes.Internal {
 		t.Fatalf("expected internal error, got %v", err)
+	}
+}
+
+func TestServiceStreamStateDiffsOrdering(t *testing.T) {
+	compressor := NewGZIPCompressor()
+	diffCh := make(chan DiffEvent, 3)
+	ticks := []uint64{1, 2, 3}
+	tickCh := make(chan time.Time, len(ticks)+1)
+	service := NewService(&manualDiffBridge{ch: diffCh}, WithTickerFactory(func(time.Duration) (<-chan time.Time, func()) {
+		return tickCh, func() {}
+	}))
+
+	stream := &diffStreamStub{ctx: context.Background()}
+	payload := []byte("ordered")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- service.StreamStateDiffs(&brokerpb.StreamStateDiffsRequest{ClientId: "bot-a"}, stream)
+	}()
+
+	go func() {
+		for range ticks {
+			time.Sleep(2 * time.Millisecond)
+			tickCh <- time.Now()
+		}
+		time.Sleep(2 * time.Millisecond)
+		tickCh <- time.Now()
+	}()
+
+	for _, tick := range ticks {
+		diffCh <- DiffEvent{Tick: tick, Payload: payload}
+	}
+	close(diffCh)
+
+	if err := <-done; err != nil {
+		t.Fatalf("stream state diffs: %v", err)
+	}
+	if len(stream.frames) != len(ticks) {
+		t.Fatalf("expected %d frames, got %d", len(ticks), len(stream.frames))
+	}
+	for i, frame := range stream.frames {
+		if frame.Tick != ticks[i] {
+			t.Fatalf("frame %d tick mismatch: got %d want %d", i, frame.Tick, ticks[i])
+		}
+		decoded, err := compressor.Decompress(frame.Payload)
+		if err != nil {
+			t.Fatalf("frame %d decompress: %v", i, err)
+		}
+		if string(decoded) != string(payload) {
+			t.Fatalf("frame %d payload mismatch", i)
+		}
 	}
 }
 

--- a/python-sim/bot_sdk/__init__.py
+++ b/python-sim/bot_sdk/__init__.py
@@ -1,0 +1,6 @@
+"""Bot SDK utilities for interacting with the broker."""
+
+from .state_stream import ApplyCallback, CodecRegistry, DiffPayload, StateStreamReceiver
+
+# //1.- Re-export the key primitives so consumers get a compact API surface.
+__all__ = ["ApplyCallback", "CodecRegistry", "DiffPayload", "StateStreamReceiver"]

--- a/python-sim/bot_sdk/state_stream.py
+++ b/python-sim/bot_sdk/state_stream.py
@@ -1,0 +1,138 @@
+"""Deterministic receiver pipeline for broker state diff streams."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import deque
+from heapq import heappop, heappush
+from typing import Callable, Deque, Dict, Mapping, MutableMapping, Optional, Tuple
+
+import gzip
+
+from driftpursuit_proto.generated.driftpursuit.broker.v0 import streaming_pb2
+
+# //1.- Define type aliases so call sites remain concise and typed.
+DiffPayload = Mapping[str, object]
+ApplyCallback = Callable[[int, DiffPayload], None]
+
+
+class CodecRegistry:
+    """Registry that maps encoding identifiers to decompress functions."""
+
+    def __init__(self) -> None:
+        # //2.- Maintain a normalised map so lookups remain case-insensitive.
+        self._codecs: Dict[str, Callable[[bytes], bytes]] = {}
+
+    def register(self, name: str, decoder: Callable[[bytes], bytes]) -> None:
+        """Register a decompressor for the provided encoding name."""
+
+        # //3.- Validate inputs eagerly so misconfigurations surface during setup.
+        if not name:
+            raise ValueError("codec name must be provided")
+        if decoder is None:
+            raise ValueError("decoder must be callable")
+        key = name.lower()
+        self._codecs[key] = decoder
+
+    def decompress(self, name: str, payload: bytes) -> bytes:
+        """Resolve the codec for *name* and return the decoded payload."""
+
+        # //4.- Enforce known encodings to avoid silent corruption.
+        decoder = self._codecs.get((name or "").lower())
+        if decoder is None:
+            raise ValueError(f"unsupported encoding {name!r}")
+        return decoder(payload)
+
+    @classmethod
+    def default(cls) -> "CodecRegistry":
+        """Construct a registry seeded with codecs supported by grpc Python."""
+
+        # //5.- Provide gzip (grpc built-in) and identity for raw payloads.
+        registry = cls()
+        registry.register("gzip", gzip.decompress)
+        registry.register("identity", lambda data: data)
+        return registry
+
+
+class StateStreamReceiver:
+    """Decode, buffer, and apply world diffs from the gRPC stream."""
+
+    def __init__(
+        self,
+        *,
+        start_tick: Optional[int] = None,
+        codec_registry: Optional[CodecRegistry] = None,
+        latency_window: int = 64,
+    ) -> None:
+        # //6.- Allow callers to override codecs for custom compression schemes.
+        self._codecs = codec_registry or CodecRegistry.default()
+        # //7.- Track pending diffs by tick for deterministic application order.
+        self._pending: MutableMapping[int, DiffPayload] = {}
+        self._heap: list[int] = []
+        self._expected_tick = start_tick
+        # //8.- Preserve recent decompression latency samples for monitoring.
+        self._latencies: Deque[float] = deque(maxlen=max(1, latency_window))
+
+    def handle_frame(self, frame: streaming_pb2.StateDiffFrame, apply_diff: ApplyCallback) -> None:
+        """Decode *frame* and synchronously apply eligible diffs via *apply_diff*."""
+
+        # //9.- Store the decoded diff and drain in-order ticks after buffering.
+        payload = self._decode_frame(frame)
+        if frame.tick < 0:
+            raise ValueError("tick must be non-negative")
+        self._pending[frame.tick] = payload
+        heappush(self._heap, frame.tick)
+        self._drain_ready(apply_diff)
+
+    def _decode_frame(self, frame: streaming_pb2.StateDiffFrame) -> DiffPayload:
+        """Decompress and deserialize the diff payload."""
+
+        # //10.- Time the decompression so callers can inspect latency trends.
+        start = time.perf_counter()
+        raw = self._codecs.decompress(frame.encoding or "identity", bytes(frame.payload))
+        duration = time.perf_counter() - start
+        self._latencies.append(duration)
+
+        try:
+            # //11.- Parse the JSON payload into a mapping for downstream use.
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("failed to decode diff payload") from exc
+
+    def _drain_ready(self, apply_diff: ApplyCallback) -> None:
+        """Apply buffered diffs once the expected tick is available."""
+
+        # //12.- Initialise the expected tick when the first diff arrives.
+        if self._expected_tick is None and self._heap:
+            self._expected_tick = self._heap[0]
+
+        while self._heap and self._expected_tick is not None:
+            # //13.- Discard stale ticks that were already applied.
+            while self._heap and self._heap[0] < self._expected_tick:
+                heappop(self._heap)
+            if not self._heap:
+                break
+
+            next_tick = self._heap[0]
+            if next_tick != self._expected_tick:
+                # //14.- Wait until the contiguous sequence is complete.
+                break
+
+            heappop(self._heap)
+            payload = self._pending.pop(next_tick, None)
+            if payload is None:
+                continue
+            apply_diff(next_tick, payload)
+            # //15.- Advance the cursor so subsequent ticks follow sequentially.
+            self._expected_tick = next_tick + 1
+
+    @property
+    def latency_samples(self) -> Tuple[float, ...]:
+        """Expose recent decompression durations for diagnostics."""
+
+        # //16.- Return an immutable snapshot so callers cannot mutate internals.
+        return tuple(self._latencies)
+
+
+__all__ = ["CodecRegistry", "StateStreamReceiver", "DiffPayload", "ApplyCallback"]

--- a/python-sim/tests/test_state_stream.py
+++ b/python-sim/tests/test_state_stream.py
@@ -1,0 +1,60 @@
+"""Unit tests for the gRPC diff receiver pipeline."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import List, Tuple
+
+from driftpursuit_proto.generated.driftpursuit.broker.v0 import streaming_pb2
+
+from bot_sdk.state_stream import CodecRegistry, StateStreamReceiver
+
+
+def make_frame(tick: int, payload: dict, encoding: str = "identity") -> streaming_pb2.StateDiffFrame:
+    """Helper to construct frames with serialised payloads."""
+
+    # //1.- Encode the payload once so the tests stay focused on ordering logic.
+    return streaming_pb2.StateDiffFrame(tick=tick, encoding=encoding, payload=json.dumps(payload).encode("utf-8"))
+
+
+def test_receiver_applies_diffs_in_tick_order() -> None:
+    receiver = StateStreamReceiver(start_tick=1)
+    applied: List[Tuple[int, dict]] = []
+
+    # //2.- Feed frames out of order to ensure buffering waits for missing ticks.
+    frames = [
+        make_frame(2, {"value": "b"}),
+        make_frame(1, {"value": "a"}),
+        make_frame(3, {"value": "c"}),
+    ]
+
+    for frame in frames:
+        receiver.handle_frame(frame, lambda tick, diff: applied.append((tick, diff)))
+
+    assert [tick for tick, _ in applied] == [1, 2, 3]
+    assert [diff["value"] for _, diff in applied] == ["a", "b", "c"]
+
+
+def test_receiver_records_decompression_latency() -> None:
+    delay = 0.01
+
+    # //3.- Register a slow codec that simulates heavy decompression workloads.
+    registry = CodecRegistry.default()
+
+    def slow_decode(data: bytes) -> bytes:
+        time.sleep(delay)
+        return data
+
+    registry.register("slow", slow_decode)
+    receiver = StateStreamReceiver(start_tick=5, codec_registry=registry)
+
+    applied: List[int] = []
+    frame = make_frame(5, {"value": 42}, encoding="slow")
+    receiver.handle_frame(frame, lambda tick, _: applied.append(tick))
+
+    assert applied == [5]
+    samples = receiver.latency_samples
+    assert len(samples) == 1
+    # //4.- Decompression timing should include the artificial delay.
+    assert samples[0] >= delay


### PR DESCRIPTION
## Summary
- throttle the broker gRPC diff stream to 20 Hz with a configurable ticker and buffering
- extend the gRPC service tests to exercise the throttled delivery order
- add a Python bot SDK state stream receiver with codec registry, latency metrics, and unit tests

## Testing
- go test ./...
- PYTHONPATH=python-sim:python-sim/driftpursuit_proto/generated pytest python-sim/tests/test_state_stream.py


------
https://chatgpt.com/codex/tasks/task_e_68df18a09a108329b82e8de66ce6b8e2