### PR TITLE
Add deterministic ECM RNG for decoy break resolution

### DIFF
--- a/docs/combat.md
+++ b/docs/combat.md
@@ -1,0 +1,22 @@
+# Combat ECM Determinism
+
+The electronic countermeasures (ECM) pipeline now derives all decoy resolution
+rolls from a deterministic seed so that combat outcomes are perfectly
+replayable. The seed is constructed with the following recipe:
+
+1. Start with the authoritative match seed broadcast at match creation time.
+2. Append the unique missile identifier assigned by the projectile store.
+3. Append the target vehicle identifier being evaluated for spoofing.
+4. Hash the concatenated payload with `SHA-256` using null-byte separators to
+   avoid accidental collisions between identifiers.
+5. Use the first non-zero 64-bit little-endian segment of the digest as the
+   seed for Go's `math/rand` package.
+
+Because the match seed, missile ID, and target ID are deterministic within a
+replay, every call to `combat.ShouldDecoyBreak` produces the same outcome across
+servers, QA captures, and bot simulations. Bot developers can now author
+training scenarios that rely on stable ECM behaviour, and QA can reproduce
+misfires by replaying the same tick stream.
+
+When new ECM mechanics are introduced, ensure any additional entropy joins the
+hash payload **before** hashing so the deterministic guarantee remains intact.

--- a/go-broker/internal/combat/ecm.go
+++ b/go-broker/internal/combat/ecm.go
@@ -1,0 +1,54 @@
+package combat
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand"
+)
+
+// SeedForOutcome derives a deterministic RNG seed for ECM interactions.
+func SeedForOutcome(matchSeed, missileID, targetID string) int64 {
+	//1.- Hash the inputs with separators so each identifier influences the result independently.
+	digest := sha256.Sum256([]byte("combat.ecm\x00" + matchSeed + "\x00" + missileID + "\x00" + targetID))
+	//2.- Convert the first eight bytes into a signed integer seed for math/rand.
+	seed := int64(binary.LittleEndian.Uint64(digest[0:8]))
+	if seed == 0 {
+		seed = int64(binary.LittleEndian.Uint64(digest[8:16]))
+	}
+	if seed == 0 {
+		seed = 1
+	}
+	return seed
+}
+
+// newECMRand builds a deterministic PRNG bound to the provided ECM tuple.
+func newECMRand(matchSeed, missileID, targetID string) *rand.Rand {
+	//1.- Use the stable seed so that every replay reproduces the same random stream.
+	seed := SeedForOutcome(matchSeed, missileID, targetID)
+	//2.- Create a new PRNG instance to avoid cross-talk between concurrent rolls.
+	return rand.New(rand.NewSource(seed))
+}
+
+// ShouldDecoyBreak resolves whether a decoy spoofs the missile guidance.
+func ShouldDecoyBreak(matchSeed, missileID, targetID string, breakProbability float64) bool {
+	//1.- Clamp invalid probabilities so deterministic replays never panic or misbehave.
+	if math.IsNaN(breakProbability) {
+		return false
+	}
+	if breakProbability < 0 {
+		breakProbability = 0
+	} else if breakProbability > 1 {
+		breakProbability = 1
+	}
+	if breakProbability == 0 {
+		return false
+	}
+	if breakProbability == 1 {
+		return true
+	}
+	//2.- Pull a deterministic roll from the seeded PRNG and compare to the threshold.
+	rng := newECMRand(matchSeed, missileID, targetID)
+	roll := rng.Float64()
+	return roll < breakProbability
+}

--- a/go-broker/internal/combat/ecm_test.go
+++ b/go-broker/internal/combat/ecm_test.go
@@ -1,0 +1,32 @@
+package combat
+
+import "testing"
+
+func TestSeedForOutcomeDeterministic(t *testing.T) {
+	seedA := SeedForOutcome("match-123", "missile-9", "target-4")
+	seedB := SeedForOutcome("match-123", "missile-9", "target-4")
+	if seedA != seedB {
+		t.Fatalf("expected identical seeds, got %d and %d", seedA, seedB)
+	}
+	seedC := SeedForOutcome("match-123", "missile-9", "target-5")
+	if seedA == seedC {
+		t.Fatalf("expected different target to alter the seed")
+	}
+}
+
+func TestShouldDecoyBreakDeterministic(t *testing.T) {
+	rollA := ShouldDecoyBreak("seed", "missile-1", "target-1", 0.5)
+	rollB := ShouldDecoyBreak("seed", "missile-1", "target-1", 0.5)
+	if rollA != rollB {
+		t.Fatalf("expected deterministic outcome")
+	}
+}
+
+func TestShouldDecoyBreakProbabilityBounds(t *testing.T) {
+	if ShouldDecoyBreak("s", "m", "t", -1) {
+		t.Fatalf("negative probability should not break")
+	}
+	if !ShouldDecoyBreak("s", "m", "t", 1.5) {
+		t.Fatalf("probability >= 1 should always break")
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic ECM seeding utilities that hash the match seed, missile ID, and target ID
- expose a replay-safe `ShouldDecoyBreak` helper and cover it with unit tests
- document the seed recipe for bot developers and QA in `docs/combat.md`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df1fcb0dc48329884a8e576482882f