### PR TITLE
Add FSM-driven bot archetypes and CLI support

### DIFF
--- a/docs/bot_guides/README.md
+++ b/docs/bot_guides/README.md
@@ -1,0 +1,49 @@
+# FSM Bot Archetypes
+
+The Python simulation now ships with four finite-state-machine driven bots that
+consume the shared intent streaming SDK. Each archetype can be configured via
+the `python -m bots.fsm_cli` entry point and demonstrated with lightweight
+replay snippets stored under `python-sim/bots/replays`.
+
+## Common Usage
+
+```bash
+python -m bots.fsm_cli <archetype> --client-id demo --dry-run --diff-log demo.jsonl \
+  --allow-boost --allow-handbrake
+```
+
+The CLI accepts newline-delimited JSON diffs and writes intents through the
+shared `IntentClient`. Using `--dry-run` swaps the network client for an
+in-memory recorder so the behaviours can be inspected without a running broker.
+
+## Patrol Bot
+
+* States: patrol → investigate → return.
+* Important flags: `--waypoints`, `--alert-distance`, `--linger-ticks`,
+  `--patrol-throttle`, `--allow-handbrake`.
+* Demonstration replay: `python-sim/bots/replays/patrol.jsonl`.
+
+## Chaser Bot
+
+* States: search → chase → attack.
+* Important flags: `--engage-distance`, `--attack-distance`, `--chase-throttle`,
+  `--allow-boost`.
+* Demonstration replay: `python-sim/bots/replays/chaser.jsonl`.
+
+## Coward Bot
+
+* States: harass → retreat → recover.
+* Important flags: `--harass-distance`, `--retreat-distance`, `--safe-health`,
+  `--retreat-throttle`, `--allow-boost`.
+* Demonstration replay: `python-sim/bots/replays/coward.jsonl`.
+
+## Ambusher Bot
+
+* States: hide → stalk → strike → evade.
+* Important flags: `--detection-distance`, `--ambush-distance`,
+  `--strike-throttle`, `--stalk-throttle`, `--allow-boost`.
+* Demonstration replay: `python-sim/bots/replays/ambusher.jsonl`.
+
+Each replay captures two representative diffs to visualise the transition flow.
+Pair the snippets with the CLI dry-run mode to observe the generated intents
+without connecting to the live broker.

--- a/python-sim/bots/__init__.py
+++ b/python-sim/bots/__init__.py
@@ -1,1 +1,29 @@
-"""Example bot implementations for interacting with the DriftPursuit broker."""
+"""Bot implementations for interacting with the Drift Pursuit broker."""
+
+from .ambusher_bot import AmbusherConfig, build_ambusher_bot
+from .chaser_bot import ChaserConfig, build_chaser_bot
+from .coward_bot import CowardConfig, build_coward_bot
+from .fsm_base import FSMContext, FSMState, FiniteStateMachine, IntentPayload, StateResult
+from .fsm_bot import FSMIntentBot, RuntimeToggles
+from .intent_helpers import IntentDict, build_intent
+from .patrol_bot import PatrolConfig, build_patrol_bot
+
+__all__ = [
+    "AmbusherConfig",
+    "ChaserConfig",
+    "CowardConfig",
+    "FSMContext",
+    "FSMIntentBot",
+    "FSMState",
+    "FiniteStateMachine",
+    "IntentDict",
+    "IntentPayload",
+    "RuntimeToggles",
+    "StateResult",
+    "build_ambusher_bot",
+    "build_chaser_bot",
+    "build_coward_bot",
+    "build_intent",
+    "build_patrol_bot",
+    "PatrolConfig",
+]

--- a/python-sim/bots/_sdk.py
+++ b/python-sim/bots/_sdk.py
@@ -1,0 +1,28 @@
+"""Import helpers that tolerate missing optional SDK dependencies in tests."""
+
+from __future__ import annotations
+
+from typing import Mapping, Protocol
+
+try:  # pragma: no cover - exercised when google/protobuf is installed
+    from bot_sdk.intent_client import IntentClient as _IntentClient
+except ModuleNotFoundError:  # pragma: no cover - test environments without protobuf
+    class IntentClient(Protocol):
+        """Protocol describing the subset of IntentClient used by the bots."""
+
+        def start(self) -> None:
+            ...
+
+        def stop(self):
+            ...
+
+        def close(self) -> None:
+            ...
+
+        def send_intent(self, intent: Mapping[str, object]) -> None:
+            ...
+else:  # pragma: no cover - runtime path
+    IntentClient = _IntentClient
+
+
+__all__ = ["IntentClient"]

--- a/python-sim/bots/ambusher_bot.py
+++ b/python-sim/bots/ambusher_bot.py
@@ -1,0 +1,148 @@
+"""Finite state ambusher bot implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Tuple
+
+from ._sdk import IntentClient
+from .fsm_base import FSMContext, FSMState, FiniteStateMachine, StateResult
+from .fsm_bot import FSMIntentBot, RuntimeToggles
+from .intent_helpers import build_intent
+from .vector_math import distance, heading_to
+
+
+def _bot_pose(world: Mapping[str, object]) -> Tuple[float, float, float]:
+    bot = world.get("bot", {})
+    position = bot.get("position", (0.0, 0.0))
+    heading = bot.get("heading", 0.0)
+    return (float(position[0]), float(position[1]), float(heading))
+
+
+def _target(world: Mapping[str, object]) -> Tuple[float, float]:
+    target = world.get("target", {})
+    position = target.get("position", (0.0, 0.0))
+    return (float(position[0]), float(position[1]))
+
+
+@dataclass
+class AmbusherConfig:
+    """Parameters defining the ambusher behaviour."""
+
+    controller_id: str
+    detection_distance: float = 60.0
+    ambush_distance: float = 25.0
+    strike_throttle: float = 1.0
+    stalk_throttle: float = 0.35
+
+
+@dataclass
+class HideState(FSMState):
+    config: AmbusherConfig
+    name: str = "hide"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //1.- Stay idle until a target moves within the detection cone.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=0.0,
+            steer=0.0,
+        )
+        if distance(pose[:2], target_pos) <= self.config.detection_distance:
+            context.memory["stalk_ticks"] = 5
+            return StateResult(intent, "stalk")
+        return StateResult(intent)
+
+
+@dataclass
+class StalkState(FSMState):
+    config: AmbusherConfig
+    name: str = "stalk"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //2.- Shadow the target slowly until it is close enough for an ambush.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steer = heading_to(pose, target_pos)
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=self.config.stalk_throttle,
+            steer=steer,
+        )
+        gap = distance(pose[:2], target_pos)
+        context.memory["stalk_ticks"] = int(context.memory.get("stalk_ticks", 0)) - 1
+        if gap <= self.config.ambush_distance:
+            context.memory["strike_ticks"] = 4
+            return StateResult(intent, "strike")
+        if gap > self.config.detection_distance * 1.2 and context.memory["stalk_ticks"] <= 0:
+            return StateResult(intent, "hide")
+        return StateResult(intent)
+
+
+@dataclass
+class StrikeState(FSMState):
+    config: AmbusherConfig
+    name: str = "strike"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //3.- Charge aggressively using optional boost toggles.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steer = heading_to(pose, target_pos)
+        toggles: RuntimeToggles = context.config  # type: ignore[assignment]
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=self.config.strike_throttle,
+            steer=steer,
+            boost=toggles.allow_boost,
+        )
+        context.memory["strike_ticks"] = int(context.memory.get("strike_ticks", 0)) - 1
+        if context.memory["strike_ticks"] <= 0:
+            context.memory["evade_ticks"] = 5
+            return StateResult(intent, "evade")
+        return StateResult(intent)
+
+
+@dataclass
+class EvadeState(FSMState):
+    config: AmbusherConfig
+    name: str = "evade"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //4.- Break line of sight before returning to the hiding loop.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steer = -heading_to(pose, target_pos)
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=0.5,
+            steer=steer,
+        )
+        context.memory["evade_ticks"] = int(context.memory.get("evade_ticks", 0)) - 1
+        if context.memory["evade_ticks"] <= 0:
+            return StateResult(intent, "hide")
+        return StateResult(intent)
+
+
+def build_ambusher_bot(
+    client: IntentClient,
+    config: AmbusherConfig,
+    *,
+    toggles: RuntimeToggles | None = None,
+    auto_start: bool = True,
+) -> FSMIntentBot:
+    """Factory for the ambusher FSM bot."""
+
+    # //5.- Wire the hide, stalk, strike, and evade states into the FSM runtime.
+    states = [HideState(config=config), StalkState(config=config), StrikeState(config=config), EvadeState(config=config)]
+    machine = FiniteStateMachine(states, "hide")
+    return FSMIntentBot(client, machine, config.controller_id, toggles=toggles, auto_start=auto_start)
+
+
+__all__ = ["AmbusherConfig", "build_ambusher_bot"]

--- a/python-sim/bots/chaser_bot.py
+++ b/python-sim/bots/chaser_bot.py
@@ -1,0 +1,130 @@
+"""Finite state chaser bot implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Tuple
+
+from ._sdk import IntentClient
+from .fsm_base import FSMContext, FSMState, FiniteStateMachine, StateResult
+from .fsm_bot import FSMIntentBot, RuntimeToggles
+from .intent_helpers import build_intent
+from .vector_math import distance, heading_to
+
+
+def _bot_pose(world: Mapping[str, object]) -> Tuple[float, float, float]:
+    bot = world.get("bot", {})
+    position = bot.get("position", (0.0, 0.0))
+    heading = bot.get("heading", 0.0)
+    return (float(position[0]), float(position[1]), float(heading))
+
+
+def _target(world: Mapping[str, object]) -> Tuple[float, float]:
+    target = world.get("target", {})
+    position = target.get("position", (0.0, 0.0))
+    return (float(position[0]), float(position[1]))
+
+
+@dataclass
+class ChaserConfig:
+    """Parameters governing the aggressiveness of the chaser bot."""
+
+    controller_id: str
+    chase_throttle: float = 0.85
+    search_turn_rate: float = 0.5
+    engage_distance: float = 50.0
+    attack_distance: float = 9.0
+
+
+@dataclass
+class SearchState(FSMState):
+    config: ChaserConfig
+    name: str = "search"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //1.- Rotate in place while no target is within the engage distance.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steer = context.memory.setdefault("search_direction", self.config.search_turn_rate)
+        throttle = 0.1
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=throttle,
+            steer=steer,
+        )
+        if distance(pose[:2], target_pos) <= self.config.engage_distance:
+            context.memory.pop("search_direction", None)
+            return StateResult(intent, "chase")
+        return StateResult(intent)
+
+
+@dataclass
+class ChaseState(FSMState):
+    config: ChaserConfig
+    name: str = "chase"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //2.- Close the gap aggressively until the target is within attack range.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steering = heading_to(pose, target_pos)
+        toggles: RuntimeToggles = context.config  # type: ignore[assignment]
+        throttle = self.config.chase_throttle
+        boost = toggles.allow_boost and distance(pose[:2], target_pos) > self.config.attack_distance * 1.5
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=throttle,
+            steer=steering,
+            boost=boost,
+        )
+        gap = distance(pose[:2], target_pos)
+        if gap <= self.config.attack_distance:
+            context.memory["attack_ticks"] = 3
+            return StateResult(intent, "attack")
+        if gap > self.config.engage_distance * 1.2:
+            return StateResult(intent, "search")
+        return StateResult(intent)
+
+
+@dataclass
+class AttackState(FSMState):
+    config: ChaserConfig
+    name: str = "attack"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //3.- Apply heavy braking when directly on top of the target.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steer = heading_to(pose, target_pos)
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=0.0,
+            brake=1.0,
+            steer=steer,
+        )
+        ticks = int(context.memory.get("attack_ticks", 0)) - 1
+        context.memory["attack_ticks"] = ticks
+        if ticks <= 0 or distance(pose[:2], target_pos) > self.config.attack_distance * 1.5:
+            return StateResult(intent, "chase")
+        return StateResult(intent)
+
+
+def build_chaser_bot(
+    client: IntentClient,
+    config: ChaserConfig,
+    *,
+    toggles: RuntimeToggles | None = None,
+    auto_start: bool = True,
+) -> FSMIntentBot:
+    """Factory for the chaser FSM bot."""
+
+    # //4.- Register the search, chase, and attack states with the machine.
+    states = [SearchState(config=config), ChaseState(config=config), AttackState(config=config)]
+    machine = FiniteStateMachine(states, "search")
+    return FSMIntentBot(client, machine, config.controller_id, toggles=toggles, auto_start=auto_start)
+
+
+__all__ = ["ChaserConfig", "build_chaser_bot"]

--- a/python-sim/bots/coward_bot.py
+++ b/python-sim/bots/coward_bot.py
@@ -1,0 +1,128 @@
+"""Finite state coward bot implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Tuple
+
+from ._sdk import IntentClient
+from .fsm_base import FSMContext, FSMState, FiniteStateMachine, StateResult
+from .fsm_bot import FSMIntentBot, RuntimeToggles
+from .intent_helpers import build_intent
+from .vector_math import distance, heading_to
+
+
+def _bot_pose(world: Mapping[str, object]) -> Tuple[float, float, float]:
+    bot = world.get("bot", {})
+    position = bot.get("position", (0.0, 0.0))
+    heading = bot.get("heading", 0.0)
+    return (float(position[0]), float(position[1]), float(heading))
+
+
+def _target(world: Mapping[str, object]) -> Tuple[float, float]:
+    target = world.get("target", {})
+    position = target.get("position", (0.0, 0.0))
+    return (float(position[0]), float(position[1]))
+
+
+def _health(world: Mapping[str, object]) -> float:
+    bot = world.get("bot", {})
+    return float(bot.get("health", 1.0))
+
+
+@dataclass
+class CowardConfig:
+    """Parameters driving the cowardly behaviour."""
+
+    controller_id: str
+    harass_distance: float = 40.0
+    retreat_distance: float = 55.0
+    safe_health: float = 0.45
+    retreat_throttle: float = 0.95
+
+
+@dataclass
+class HarassState(FSMState):
+    config: CowardConfig
+    name: str = "harass"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //1.- Maintain range while peppering the target if health is high enough.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        gap = distance(pose[:2], target_pos)
+        steer = heading_to(pose, target_pos)
+        throttle = 0.6 if gap > self.config.harass_distance else 0.2
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=throttle,
+            steer=steer,
+        )
+        if _health(world) <= self.config.safe_health:
+            context.memory["recover_ticks"] = 8
+            return StateResult(intent, "retreat")
+        return StateResult(intent)
+
+
+@dataclass
+class RetreatState(FSMState):
+    config: CowardConfig
+    name: str = "retreat"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //2.- Flee from the opponent and build distance while health regenerates.
+        pose = _bot_pose(world)
+        target_pos = _target(world)
+        steer = -heading_to(pose, target_pos)
+        toggles: RuntimeToggles = context.config  # type: ignore[assignment]
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=self.config.retreat_throttle,
+            steer=steer,
+            boost=toggles.allow_boost,
+        )
+        gap = distance(pose[:2], target_pos)
+        if gap >= self.config.retreat_distance:
+            return StateResult(intent, "recover")
+        return StateResult(intent)
+
+
+@dataclass
+class RecoverState(FSMState):
+    config: CowardConfig
+    name: str = "recover"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //3.- Circle while waiting for the recover timer before re-engaging.
+        steer = 0.6
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=0.3,
+            steer=steer,
+        )
+        ticks = int(context.memory.get("recover_ticks", 0)) - 1
+        context.memory["recover_ticks"] = ticks
+        if ticks <= 0 and _health(world) > self.config.safe_health:
+            return StateResult(intent, "harass")
+        return StateResult(intent)
+
+
+def build_coward_bot(
+    client: IntentClient,
+    config: CowardConfig,
+    *,
+    toggles: RuntimeToggles | None = None,
+    auto_start: bool = True,
+) -> FSMIntentBot:
+    """Factory for the coward FSM bot."""
+
+    # //4.- Compose harass, retreat, and recover states to drive the coward.
+    states = [HarassState(config=config), RetreatState(config=config), RecoverState(config=config)]
+    machine = FiniteStateMachine(states, "harass")
+    return FSMIntentBot(client, machine, config.controller_id, toggles=toggles, auto_start=auto_start)
+
+
+__all__ = ["CowardConfig", "build_coward_bot"]

--- a/python-sim/bots/fsm_base.py
+++ b/python-sim/bots/fsm_base.py
@@ -1,0 +1,76 @@
+"""Finite state machine utilities for intent-driven bots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, MutableMapping, Protocol
+
+IntentPayload = MutableMapping[str, object]
+
+
+@dataclass
+class StateResult:
+    """Outcome of a state update including the next intent and transition."""
+
+    intent: IntentPayload
+    transition: str | None = None
+
+
+class FSMState(Protocol):
+    """Protocol describing a single finite state machine state."""
+
+    name: str
+
+    def act(self, world: Mapping[str, object], context: "FSMContext") -> StateResult:
+        """Compute the next intent and optional transition."""
+
+
+@dataclass
+class FSMContext:
+    """Shared runtime information passed to each state."""
+
+    sequence: int = 0
+    memory: Dict[str, object] = field(default_factory=dict)
+    config: object | None = None
+
+    def next_sequence(self) -> int:
+        """Increment and return the intent sequence counter."""
+
+        # //1.- Bump the internal sequence so intents remain monotonically increasing.
+        self.sequence += 1
+        return self.sequence
+
+
+class FiniteStateMachine:
+    """Small helper that manages state transitions and intent generation."""
+
+    def __init__(self, states: Iterable[FSMState], initial: str) -> None:
+        # //1.- Index all states by name so transitions can resolve quickly at runtime.
+        self._states: Dict[str, FSMState] = {state.name: state for state in states}
+        if initial not in self._states:
+            raise ValueError(f"unknown initial state {initial!r}")
+        # //2.- Remember the active state's name to evaluate it on each tick.
+        self._active = initial
+
+    @property
+    def active(self) -> str:
+        """Return the name of the current state for diagnostics and tests."""
+
+        return self._active
+
+    def step(self, world: Mapping[str, object], context: FSMContext) -> IntentPayload:
+        """Evaluate the current state and switch if a transition is requested."""
+
+        # //3.- Fetch the active state implementation before executing it.
+        state = self._states[self._active]
+        result = state.act(world, context)
+        # //4.- Apply transitions only when the state explicitly requests them.
+        if result.transition:
+            if result.transition not in self._states:
+                raise ValueError(f"unknown state transition {result.transition!r}")
+            self._active = result.transition
+        # //5.- Return the intent so callers can forward it to the intent client.
+        return result.intent
+
+
+__all__ = ["FiniteStateMachine", "FSMContext", "FSMState", "IntentPayload", "StateResult"]

--- a/python-sim/bots/fsm_bot.py
+++ b/python-sim/bots/fsm_bot.py
@@ -1,0 +1,73 @@
+"""Base runtime for FSM-driven intent bots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._sdk import IntentClient
+from .fsm_base import FSMContext, FiniteStateMachine, IntentPayload
+
+
+@dataclass
+class RuntimeToggles:
+    """Feature switches that can be exposed on the CLI."""
+
+    allow_boost: bool = False
+    allow_handbrake: bool = False
+
+
+class FSMIntentBot:
+    """Glue between the shared IntentClient and an FSM policy."""
+
+    def __init__(
+        self,
+        client: IntentClient,
+        machine: FiniteStateMachine,
+        controller_id: str,
+        *,
+        toggles: RuntimeToggles | None = None,
+        auto_start: bool = True,
+    ) -> None:
+        # //1.- Store collaborators so the bot can forward intents on every tick.
+        self._client = client
+        self._machine = machine
+        self._controller_id = controller_id
+        self._context = FSMContext(config=toggles or RuntimeToggles())
+        if auto_start:
+            # //2.- Kick off the streaming loop immediately for realtime usage.
+            self._client.start()
+
+    @property
+    def context(self) -> FSMContext:
+        """Expose the mutable context so tests can inspect internal state."""
+
+        return self._context
+
+    @property
+    def active_state(self) -> str:
+        """Return the current FSM state name for diagnostics."""
+
+        # //3.- Surface the FSM's active state without leaking the machine internals.
+        return self._machine.active
+
+    def process_diff(self, diff: Mapping[str, object]) -> IntentPayload:
+        """Advance the FSM with the supplied world diff and send the resulting intent."""
+
+        # //4.- Execute the current state logic and capture the resulting intent.
+        intent = self._machine.step(diff, self._context)
+        # //5.- Queue the intent for streaming while relying on the SDK for rate limiting.
+        self._client.send_intent(intent)
+        return intent
+
+    def close(self) -> None:
+        """Tear down the streaming loop and release resources."""
+
+        # //6.- Stop the intent stream gracefully then dispose the channel.
+        try:
+            self._client.stop()
+        finally:
+            self._client.close()
+
+
+__all__ = ["FSMIntentBot", "RuntimeToggles"]

--- a/python-sim/bots/fsm_cli.py
+++ b/python-sim/bots/fsm_cli.py
@@ -1,0 +1,177 @@
+"""Command line interface for running FSM-based bots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Iterator, List, Sequence
+
+from . import (
+    AmbusherConfig,
+    ChaserConfig,
+    CowardConfig,
+    FSMIntentBot,
+    PatrolConfig,
+    RuntimeToggles,
+    build_ambusher_bot,
+    build_chaser_bot,
+    build_coward_bot,
+    build_patrol_bot,
+)
+from ._sdk import IntentClient
+
+class _RecordingIntentClient(IntentClient):
+    """Intent client variant that records intents instead of streaming."""
+
+    def __init__(self, client_id: str) -> None:
+        # //1.- Bypass the base class initialiser because tests inject this stub directly.
+        self._client_id = client_id
+        self.sent: List[dict[str, object]] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial method
+        # //2.- Stub start to preserve the IntentClient API surface.
+        return
+
+    def stop(self):  # pragma: no cover - trivial method
+        # //3.- Return a sentinel acknowledgement structure to satisfy callers.
+        return None
+
+    def close(self) -> None:  # pragma: no cover - trivial method
+        # //4.- No resources are allocated so there is nothing to release.
+        return
+
+    def send_intent(self, intent):
+        # //5.- Store the payload so tests can assert over generated intents.
+        self.sent.append(dict(intent))
+
+
+def _parse_waypoints(raw: str) -> List[tuple[float, float]]:
+    # //6.- Split the incoming string into comma-separated coordinate pairs.
+    pairs = [item.strip() for item in raw.split(";") if item.strip()]
+    waypoints: List[tuple[float, float]] = []
+    for pair in pairs:
+        x_str, y_str = pair.split(",")
+        waypoints.append((float(x_str), float(y_str)))
+    return waypoints
+
+
+def _diff_stream(path: str | None) -> Iterator[dict[str, object]]:
+    # //7.- Yield JSON decoded diffs from stdin or the provided file path.
+    stream = sys.stdin if path in (None, "-") else open(path, "r", encoding="utf-8")
+    try:
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+    finally:
+        if stream is not sys.stdin:
+            stream.close()
+
+
+def create_parser() -> argparse.ArgumentParser:
+    # //8.- Construct the top-level parser shared across tests and runtime execution.
+    parser = argparse.ArgumentParser(description="Run FSM-based Drift Pursuit bots")
+    parser.add_argument("archetype", choices=["patrol", "chaser", "coward", "ambusher"], help="Bot archetype to run")
+    parser.add_argument("--address", default="127.0.0.1:43127", help="Broker gRPC endpoint")
+    parser.add_argument("--client-id", required=True, help="Unique controller identifier")
+    parser.add_argument("--rate-hz", type=float, default=10.0, help="Intent streaming rate")
+    parser.add_argument("--allow-boost", action="store_true", help="Enable boost usage when applicable")
+    parser.add_argument("--allow-handbrake", action="store_true", help="Enable handbrake usage where supported")
+    parser.add_argument("--diff-log", default="-", help="Path to newline-delimited JSON diffs (default: stdin)")
+    parser.add_argument("--dry-run", action="store_true", help="Record intents locally instead of streaming")
+
+    patrol = parser.add_argument_group("patrol", "Patrol bot options")
+    patrol.add_argument("--waypoints", help="Semicolon separated list of x,y waypoint coordinates")
+    patrol.add_argument("--alert-distance", type=float, default=30.0)
+    patrol.add_argument("--linger-ticks", type=int, default=12)
+    patrol.add_argument("--patrol-throttle", type=float, default=0.4)
+
+    chaser = parser.add_argument_group("chaser", "Chaser bot options")
+    chaser.add_argument("--engage-distance", type=float, default=50.0)
+    chaser.add_argument("--attack-distance", type=float, default=9.0)
+    chaser.add_argument("--chase-throttle", type=float, default=0.85)
+
+    coward = parser.add_argument_group("coward", "Coward bot options")
+    coward.add_argument("--harass-distance", type=float, default=40.0)
+    coward.add_argument("--retreat-distance", type=float, default=55.0)
+    coward.add_argument("--safe-health", type=float, default=0.45)
+    coward.add_argument("--retreat-throttle", type=float, default=0.95)
+
+    ambusher = parser.add_argument_group("ambusher", "Ambusher bot options")
+    ambusher.add_argument("--detection-distance", type=float, default=60.0)
+    ambusher.add_argument("--ambush-distance", type=float, default=25.0)
+    ambusher.add_argument("--strike-throttle", type=float, default=1.0)
+    ambusher.add_argument("--stalk-throttle", type=float, default=0.35)
+    return parser
+
+
+def _build_bot(args: argparse.Namespace) -> FSMIntentBot:
+    # //9.- Instantiate the requested bot archetype with the provided configuration.
+    toggles = RuntimeToggles(allow_boost=args.allow_boost, allow_handbrake=args.allow_handbrake)
+    if args.dry_run:
+        client = _RecordingIntentClient(args.client_id)
+        auto_start = False
+    else:
+        client = IntentClient(args.address, args.client_id, rate_hz=args.rate_hz)
+        auto_start = True
+
+    if args.archetype == "patrol":
+        if not args.waypoints:
+            raise ValueError("--waypoints must be provided for patrol archetype")
+        config = PatrolConfig(
+            controller_id=args.client_id,
+            waypoints=_parse_waypoints(args.waypoints),
+            alert_distance=args.alert_distance,
+            linger_ticks=args.linger_ticks,
+            patrol_throttle=args.patrol_throttle,
+        )
+        return build_patrol_bot(client, config, toggles=toggles, auto_start=auto_start)
+
+    if args.archetype == "chaser":
+        config = ChaserConfig(
+            controller_id=args.client_id,
+            engage_distance=args.engage_distance,
+            attack_distance=args.attack_distance,
+            chase_throttle=args.chase_throttle,
+        )
+        return build_chaser_bot(client, config, toggles=toggles, auto_start=auto_start)
+
+    if args.archetype == "coward":
+        config = CowardConfig(
+            controller_id=args.client_id,
+            harass_distance=args.harass_distance,
+            retreat_distance=args.retreat_distance,
+            safe_health=args.safe_health,
+            retreat_throttle=args.retreat_throttle,
+        )
+        return build_coward_bot(client, config, toggles=toggles, auto_start=auto_start)
+
+    config = AmbusherConfig(
+        controller_id=args.client_id,
+        detection_distance=args.detection_distance,
+        ambush_distance=args.ambush_distance,
+        strike_throttle=args.strike_throttle,
+        stalk_throttle=args.stalk_throttle,
+    )
+    return build_ambusher_bot(client, config, toggles=toggles, auto_start=auto_start)
+
+
+def run(args: Sequence[str] | None = None) -> int:
+    # //10.- Parse arguments, run the bot against the diff stream, and flush intents.
+    parser = create_parser()
+    parsed = parser.parse_args(args)
+    bot = _build_bot(parsed)
+    try:
+        for diff in _diff_stream(parsed.diff_log):
+            bot.process_diff(diff)
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        return 130
+    finally:
+        bot.close()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by manual runs
+    sys.exit(run())

--- a/python-sim/bots/intent_helpers.py
+++ b/python-sim/bots/intent_helpers.py
@@ -1,0 +1,46 @@
+"""Utility helpers for constructing Drift Pursuit intent payloads."""
+
+from __future__ import annotations
+
+from typing import MutableMapping
+
+IntentDict = MutableMapping[str, object]
+
+
+def build_intent(
+    sequence: int,
+    *,
+    controller_id: str,
+    throttle: float = 0.0,
+    steer: float = 0.0,
+    brake: float = 0.0,
+    boost: bool = False,
+    handbrake: bool = False,
+    gear: int = 1,
+) -> IntentDict:
+    """Create a minimal intent payload for broker submission."""
+
+    # //1.- Clamp the floating point inputs to the expected control ranges.
+    throttle = max(0.0, min(1.0, throttle))
+    brake = max(0.0, min(1.0, brake))
+    steer = max(-1.0, min(1.0, steer))
+    # //2.- Normalise the gear selection to keep it within plausible limits.
+    if gear < -1:
+        gear = -1
+    if gear > 6:
+        gear = 6
+    # //3.- Assemble the payload so bots only expose supported schema fields.
+    return {
+        "schema_version": "1",
+        "controller_id": controller_id,
+        "sequence_id": sequence,
+        "throttle": throttle,
+        "brake": brake,
+        "steer": steer,
+        "handbrake": handbrake,
+        "gear": gear,
+        "boost": boost,
+    }
+
+
+__all__ = ["IntentDict", "build_intent"]

--- a/python-sim/bots/patrol_bot.py
+++ b/python-sim/bots/patrol_bot.py
@@ -1,0 +1,137 @@
+"""Finite state patrol bot implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping, Tuple
+
+from ._sdk import IntentClient
+from .fsm_base import FSMContext, FSMState, FiniteStateMachine, StateResult
+from .fsm_bot import FSMIntentBot, RuntimeToggles
+from .intent_helpers import build_intent
+from .vector_math import distance, heading_to
+
+
+@dataclass
+class PatrolConfig:
+    """Runtime parameters controlling the patrol behaviour."""
+
+    controller_id: str
+    waypoints: List[Tuple[float, float]]
+    patrol_throttle: float = 0.4
+    alert_distance: float = 30.0
+    linger_ticks: int = 12
+
+    def __post_init__(self) -> None:
+        # //1.- Ensure at least two waypoints exist so the patrol loop makes sense.
+        if len(self.waypoints) < 2:
+            raise ValueError("waypoints must contain at least two entries")
+
+
+def _bot_pose(world: Mapping[str, object]) -> Tuple[float, float, float]:
+    bot = world.get("bot", {})
+    position = bot.get("position", (0.0, 0.0))
+    heading = bot.get("heading", 0.0)
+    return (float(position[0]), float(position[1]), float(heading))
+
+
+def _target_position(world: Mapping[str, object]) -> Tuple[float, float]:
+    target = world.get("target", {})
+    position = target.get("position", (0.0, 0.0))
+    return (float(position[0]), float(position[1]))
+
+
+@dataclass
+class PatrolState(FSMState):
+    config: PatrolConfig
+    name: str = "patrol"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //2.- Progress towards the current waypoint and advance when close enough.
+        waypoint_index = int(context.memory.get("waypoint_index", 0))
+        waypoint = self.config.waypoints[waypoint_index]
+        pose = _bot_pose(world)
+        steer = heading_to(pose, waypoint)
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=self.config.patrol_throttle,
+            steer=steer,
+        )
+        if distance(pose[:2], waypoint) < 3.0:
+            waypoint_index = (waypoint_index + 1) % len(self.config.waypoints)
+            context.memory["waypoint_index"] = waypoint_index
+        target_pos = _target_position(world)
+        if distance(pose[:2], target_pos) <= self.config.alert_distance:
+            context.memory["linger"] = self.config.linger_ticks
+            context.memory["return_waypoint"] = context.memory.get("waypoint_index", 0)
+            return StateResult(intent, "investigate")
+        return StateResult(intent)
+
+
+@dataclass
+class InvestigateState(FSMState):
+    config: PatrolConfig
+    name: str = "investigate"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //3.- Face towards the target while counting down the linger window.
+        pose = _bot_pose(world)
+        target_pos = _target_position(world)
+        steer = heading_to(pose, target_pos)
+        toggles: RuntimeToggles = context.config  # type: ignore[assignment]
+        throttle = min(1.0, self.config.patrol_throttle + 0.2)
+        handbrake = toggles.allow_handbrake and distance(pose[:2], target_pos) < 6.0
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=throttle,
+            steer=steer,
+            handbrake=handbrake,
+        )
+        linger = int(context.memory.get("linger", 0)) - 1
+        context.memory["linger"] = linger
+        if distance(pose[:2], target_pos) > self.config.alert_distance * 1.5 and linger <= 0:
+            return StateResult(intent, "return")
+        return StateResult(intent)
+
+
+@dataclass
+class ReturnState(FSMState):
+    config: PatrolConfig
+    name: str = "return"
+
+    def act(self, world: Mapping[str, object], context: FSMContext) -> StateResult:
+        # //4.- Head back to the last recorded waypoint before resuming patrol.
+        pose = _bot_pose(world)
+        waypoint_index = int(context.memory.get("return_waypoint", 0))
+        waypoint = self.config.waypoints[waypoint_index]
+        steer = heading_to(pose, waypoint)
+        intent = build_intent(
+            context.next_sequence(),
+            controller_id=self.config.controller_id,
+            throttle=self.config.patrol_throttle,
+            steer=steer,
+        )
+        if distance(pose[:2], waypoint) < 2.0:
+            context.memory["waypoint_index"] = waypoint_index
+            return StateResult(intent, "patrol")
+        return StateResult(intent)
+
+
+def build_patrol_bot(
+    client: IntentClient,
+    config: PatrolConfig,
+    *,
+    toggles: RuntimeToggles | None = None,
+    auto_start: bool = True,
+) -> FSMIntentBot:
+    """Factory that wires the patrol FSM into the shared runtime."""
+
+    # //5.- Assemble the FSM with the three states backing the patrol behaviour.
+    states = [PatrolState(config=config), InvestigateState(config=config), ReturnState(config=config)]
+    machine = FiniteStateMachine(states, "patrol")
+    return FSMIntentBot(client, machine, config.controller_id, toggles=toggles, auto_start=auto_start)
+
+
+__all__ = ["PatrolConfig", "build_patrol_bot"]

--- a/python-sim/bots/replays/ambusher.jsonl
+++ b/python-sim/bots/replays/ambusher.jsonl
@@ -1,0 +1,2 @@
+{"bot": {"position": [100, 40], "heading": 3.14, "health": 1.0}, "target": {"position": [150, 45]}, "note": "waiting in cover"}
+{"bot": {"position": [120, 42], "heading": 3.0, "health": 1.0}, "target": {"position": [118, 42]}, "note": "strike dash"}

--- a/python-sim/bots/replays/chaser.jsonl
+++ b/python-sim/bots/replays/chaser.jsonl
@@ -1,0 +1,2 @@
+{"bot": {"position": [0, 0], "heading": 0, "health": 1.0}, "target": {"position": [40, -5]}, "note": "search sweep"}
+{"bot": {"position": [10, -1], "heading": 0.2, "health": 1.0}, "target": {"position": [12, -1]}, "note": "attack braking"}

--- a/python-sim/bots/replays/coward.jsonl
+++ b/python-sim/bots/replays/coward.jsonl
@@ -1,0 +1,2 @@
+{"bot": {"position": [5, 5], "heading": 1.57, "health": 0.3}, "target": {"position": [7, 5]}, "note": "panic retreat"}
+{"bot": {"position": [20, 15], "heading": 1.2, "health": 0.8}, "target": {"position": [30, 15]}, "note": "safe regroup"}

--- a/python-sim/bots/replays/patrol.jsonl
+++ b/python-sim/bots/replays/patrol.jsonl
@@ -1,0 +1,2 @@
+{"bot": {"position": [0, 0], "heading": 0, "health": 1.0}, "target": {"position": [80, 0]}, "note": "patrol sweep"}
+{"bot": {"position": [5, 0], "heading": 0.1, "health": 1.0}, "target": {"position": [6, 1]}, "note": "investigate intruder"}

--- a/python-sim/bots/vector_math.py
+++ b/python-sim/bots/vector_math.py
@@ -1,0 +1,54 @@
+"""Lightweight 2D vector helpers for bot navigation logic."""
+
+from __future__ import annotations
+
+from math import atan2, hypot
+from typing import Iterable, Tuple
+
+
+def distance(a: Iterable[float], b: Iterable[float]) -> float:
+    """Compute the Euclidean distance between two points."""
+
+    ax, ay = a
+    bx, by = b
+    # //1.- Use hypot so floating point precision stays robust for long patrol paths.
+    return hypot(bx - ax, by - ay)
+
+
+def direction(a: Iterable[float], b: Iterable[float]) -> Tuple[float, float]:
+    """Return a unit vector pointing from a to b."""
+
+    ax, ay = a
+    bx, by = b
+    dx = bx - ax
+    dy = by - ay
+    mag = hypot(dx, dy) or 1.0
+    # //2.- Normalise to keep the vector safe for multiplication with speed factors.
+    return (dx / mag, dy / mag)
+
+
+def heading_to(a: Iterable[float], b: Iterable[float]) -> float:
+    """Compute the signed steering input required to face target b from a."""
+
+    ax, ay, heading = a
+    tx, ty = b
+    desired = atan2(ty - ay, tx - ax)
+    delta = desired - heading
+    # //3.- Wrap the delta into the [-pi, pi] range for consistent steering decisions.
+    while delta > 3.141592653589793:
+        delta -= 2 * 3.141592653589793
+    while delta < -3.141592653589793:
+        delta += 2 * 3.141592653589793
+    # //4.- Convert the angle into a steer value by dividing by pi.
+    return max(-1.0, min(1.0, delta / 3.141592653589793))
+
+
+def velocity_towards(speed: float, direction_vector: Iterable[float]) -> Tuple[float, float]:
+    """Scale a unit direction vector by the requested speed."""
+
+    dx, dy = direction_vector
+    # //5.- Multiply components individually to keep the helper branch-free.
+    return (dx * speed, dy * speed)
+
+
+__all__ = ["distance", "direction", "heading_to", "velocity_towards"]

--- a/python-sim/tests/test_fsm_bots.py
+++ b/python-sim/tests/test_fsm_bots.py
@@ -1,0 +1,172 @@
+"""Unit tests covering the FSM-based bot archetypes."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Mapping
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bots import (
+    AmbusherConfig,
+    ChaserConfig,
+    CowardConfig,
+    PatrolConfig,
+    RuntimeToggles,
+    build_ambusher_bot,
+    build_chaser_bot,
+    build_coward_bot,
+    build_patrol_bot,
+)
+from bots.fsm_cli import _build_bot, create_parser
+
+
+class FakeIntentClient:
+    """Minimal IntentClient replacement used for deterministic testing."""
+
+    def __init__(self) -> None:
+        self.sent: list[Mapping[str, object]] = []
+        self.started = False
+
+    def start(self) -> None:
+        # //1.- Tests control streaming manually so the worker is never started.
+        self.started = True
+
+    def stop(self) -> None:
+        # //2.- Capture shutdown requests without touching network resources.
+        self.started = False
+
+    def close(self) -> None:
+        # //3.- No resources to release but the method matches the production API.
+        return
+
+    def send_intent(self, intent: Mapping[str, object]) -> None:
+        # //4.- Record the payload so assertions can inspect the generated commands.
+        self.sent.append(dict(intent))
+
+
+def make_world(position: tuple[float, float], heading: float, target: tuple[float, float], health: float = 1.0) -> Mapping[str, object]:
+    # //5.- Assemble a synthetic world diff understood by the test FSMs.
+    return {
+        "bot": {"position": position, "heading": heading, "health": health},
+        "target": {"position": target},
+    }
+
+
+def test_patrol_bot_transitions() -> None:
+    # //6.- Verify patrol transitions across patrol, investigate, and return states.
+    client = FakeIntentClient()
+    config = PatrolConfig(controller_id="patrol", waypoints=[(0, 0), (10, 0)], linger_ticks=1)
+    bot = build_patrol_bot(client, config, toggles=RuntimeToggles(allow_handbrake=True), auto_start=False)
+
+    bot.process_diff(make_world((0, 0), 0.0, (100, 0)))
+    assert bot.active_state == "patrol"
+
+    bot.process_diff(make_world((1.5, 0), 0.0, (2.0, 0.0)))
+    assert bot.active_state == "investigate"
+    bot.process_diff(make_world((1.5, 0), 0.0, (2.0, 0.0)))
+    assert client.sent[-1]["handbrake"] is True
+
+    bot.process_diff(make_world((1.5, 0), 0.0, (70.0, 0.0)))
+    assert bot.active_state == "return"
+
+    bot.process_diff(make_world((10.0, 0), 0.0, (70.0, 0.0)))
+    assert bot.active_state == "patrol"
+    bot.close()
+
+
+def test_chaser_bot_attack_cycle() -> None:
+    # //7.- Confirm the chaser escalates through search, chase, and attack states.
+    client = FakeIntentClient()
+    config = ChaserConfig(controller_id="chaser")
+    bot = build_chaser_bot(client, config, toggles=RuntimeToggles(allow_boost=True), auto_start=False)
+
+    bot.process_diff(make_world((0, 0), 0.0, (200, 0)))
+    assert bot.active_state == "search"
+
+    bot.process_diff(make_world((0, 0), 0.0, (20, 0)))
+    assert bot.active_state == "chase"
+    bot.process_diff(make_world((0, 0), 0.0, (20, 0)))
+    assert client.sent[-1]["boost"] is True
+
+    bot.process_diff(make_world((0, 0), 0.0, (5, 0)))
+    assert bot.active_state == "attack"
+
+    bot.process_diff(make_world((0, 0), 0.0, (30, 0)))
+    assert bot.active_state == "chase"
+    bot.close()
+
+
+def test_coward_bot_retreat_and_recover() -> None:
+    # //8.- Ensure the coward retreats on low health and re-engages when safe.
+    client = FakeIntentClient()
+    config = CowardConfig(controller_id="coward")
+    bot = build_coward_bot(client, config, toggles=RuntimeToggles(allow_boost=True), auto_start=False)
+
+    bot.process_diff(make_world((0, 0), 0.0, (10, 0), health=0.3))
+    assert bot.active_state == "retreat"
+
+    bot.process_diff(make_world((0, 0), 0.0, (70, 0), health=0.3))
+    assert bot.active_state == "recover"
+
+    for _ in range(8):
+        bot.process_diff(make_world((0, 0), 0.0, (70, 0), health=0.8))
+    assert bot.active_state == "harass"
+    bot.close()
+
+
+def test_ambusher_bot_cycle() -> None:
+    # //9.- Validate the ambusher flows through hide, stalk, strike, and evade states.
+    client = FakeIntentClient()
+    config = AmbusherConfig(controller_id="ambusher")
+    bot = build_ambusher_bot(client, config, toggles=RuntimeToggles(allow_boost=True), auto_start=False)
+
+    bot.process_diff(make_world((0, 0), 0.0, (50, 0)))
+    assert bot.active_state == "stalk"
+
+    for _ in range(3):
+        bot.process_diff(make_world((0, 0), 0.0, (20, 0)))
+    assert bot.active_state == "strike"
+
+    for _ in range(6):
+        bot.process_diff(make_world((0, 0), 0.0, (120, 0)))
+    bot.process_diff(make_world((0, 0), 0.0, (200, 0)))
+    assert bot.active_state == "hide"
+    bot.close()
+
+
+def test_cli_dry_run_configures_patrol_bot(tmp_path) -> None:
+    # //10.- Exercise the CLI builder to confirm flags feed into the patrol bot.
+    diff_file = tmp_path / "diffs.jsonl"
+    diff_file.write_text(
+        "\n".join(
+            [
+                json.dumps(make_world((0, 0), 0.0, (100, 0))),
+                json.dumps(make_world((1.0, 0), 0.0, (2.0, 0))),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    parser = create_parser()
+    args = parser.parse_args(
+        [
+            "patrol",
+            "--client-id",
+            "cli",
+            "--waypoints",
+            "0,0;10,0",
+            "--allow-handbrake",
+            "--dry-run",
+            "--diff-log",
+            str(diff_file),
+        ]
+    )
+    bot = _build_bot(args)
+    try:
+        for diff in (json.loads(line) for line in diff_file.read_text(encoding="utf-8").splitlines()):
+            bot.process_diff(diff)
+        assert bot.active_state == "investigate"
+    finally:
+        bot.close()


### PR DESCRIPTION
## Summary
- introduce reusable FSM primitives and a runtime wrapper for intent-driven bots
- implement patrol, chaser, coward, and ambusher archetypes plus a configurable CLI with dry-run support
- document usage alongside lightweight replay snippets for each behaviour and add unit coverage

## Testing
- pytest python-sim/tests/test_fsm_bots.py

------
https://chatgpt.com/codex/tasks/task_e_68df21ab2b9c832984cce96c91bb1a8a