### PR TITLE
Add weapon handling and shared combat balance

### DIFF
--- a/go-broker/internal/combat/weapon_balance.go
+++ b/go-broker/internal/combat/weapon_balance.go
@@ -1,0 +1,105 @@
+package combat
+
+import (
+	"encoding/json"
+	"sync"
+
+	_ "embed"
+)
+
+// WeaponArchetype enumerates the supported weapon behaviour families.
+type WeaponArchetype string
+
+const (
+	WeaponArchetypeShell   WeaponArchetype = "shell"
+	WeaponArchetypeMissile WeaponArchetype = "missile"
+	WeaponArchetypeLaser   WeaponArchetype = "laser"
+)
+
+// WeaponArchetypeConfig defines the baseline balance values for an archetype.
+type WeaponArchetypeConfig struct {
+	CooldownSeconds           float64 `json:"cooldownSeconds"`
+	ProjectileSpeed           float64 `json:"projectileSpeed,omitempty"`
+	ProjectileLifetimeSeconds float64 `json:"projectileLifetimeSeconds,omitempty"`
+	BeamDurationSeconds       float64 `json:"beamDurationSeconds,omitempty"`
+	Damage                    float64 `json:"damage"`
+	MuzzleEffect              string  `json:"muzzleEffect,omitempty"`
+	ImpactEffect              string  `json:"impactEffect,omitempty"`
+	TrailEffect               string  `json:"trailEffect,omitempty"`
+	BeamEffect                string  `json:"beamEffect,omitempty"`
+	DecoyBreakProbability     float64 `json:"decoyBreakProbability,omitempty"`
+}
+
+// WeaponVariantConfig customises an archetype for a specific weapon identifier.
+type WeaponVariantConfig struct {
+	Archetype                 WeaponArchetype `json:"archetype"`
+	CooldownSeconds           *float64        `json:"cooldownSeconds,omitempty"`
+	ProjectileSpeed           *float64        `json:"projectileSpeed,omitempty"`
+	ProjectileLifetimeSeconds *float64        `json:"projectileLifetimeSeconds,omitempty"`
+	BeamDurationSeconds       *float64        `json:"beamDurationSeconds,omitempty"`
+	Damage                    *float64        `json:"damage,omitempty"`
+	MuzzleEffect              string          `json:"muzzleEffect,omitempty"`
+	ImpactEffect              string          `json:"impactEffect,omitempty"`
+	TrailEffect               string          `json:"trailEffect,omitempty"`
+	BeamEffect                string          `json:"beamEffect,omitempty"`
+	DecoyBreakProbability     *float64        `json:"decoyBreakProbability,omitempty"`
+}
+
+// DecoyBalanceConfig captures the shared ECM balance values.
+type DecoyBalanceConfig struct {
+	ActivationDurationSeconds float64 `json:"activationDurationSeconds"`
+	BreakProbability          float64 `json:"breakProbability"`
+}
+
+// WeaponBalanceCatalog mirrors the structure of weapon_balance.json.
+type WeaponBalanceCatalog struct {
+	Archetypes map[string]WeaponArchetypeConfig `json:"archetypes"`
+	Weapons    map[string]WeaponVariantConfig   `json:"weapons"`
+	Decoy      DecoyBalanceConfig               `json:"decoy"`
+}
+
+// Clone produces a defensive copy to protect the cached catalog from mutation.
+func (c WeaponBalanceCatalog) Clone() WeaponBalanceCatalog {
+	clones := WeaponBalanceCatalog{
+		Archetypes: make(map[string]WeaponArchetypeConfig, len(c.Archetypes)),
+		Weapons:    make(map[string]WeaponVariantConfig, len(c.Weapons)),
+		Decoy:      c.Decoy,
+	}
+	for key, value := range c.Archetypes {
+		clones.Archetypes[key] = value
+	}
+	for key, value := range c.Weapons {
+		clones.Weapons[key] = value
+	}
+	return clones
+}
+
+var (
+	weaponBalanceOnce sync.Once
+	weaponBalanceData WeaponBalanceCatalog
+	weaponBalanceErr  error
+)
+
+//go:embed weapon_balance.json
+var weaponBalancePayload []byte
+
+// WeaponBalance exposes the parsed weapon balance catalog shared across runtimes.
+func WeaponBalance() WeaponBalanceCatalog {
+	weaponBalanceOnce.Do(func() {
+		//1.- Parse the embedded JSON payload once so concurrent callers share the same data.
+		weaponBalanceErr = json.Unmarshal(weaponBalancePayload, &weaponBalanceData)
+	})
+	//2.- Surface configuration errors immediately to keep combat deterministic and debuggable.
+	if weaponBalanceErr != nil {
+		panic(weaponBalanceErr)
+	}
+	//3.- Return a clone so tests cannot accidentally mutate the cached catalog.
+	return weaponBalanceData.Clone()
+}
+
+// DecoyBalance returns the decoy balance block.
+func DecoyBalance() DecoyBalanceConfig {
+	//1.- Delegate to WeaponBalance to benefit from lazy parsing and defensive copies.
+	catalog := WeaponBalance()
+	return catalog.Decoy
+}

--- a/go-broker/internal/combat/weapon_balance.json
+++ b/go-broker/internal/combat/weapon_balance.json
@@ -1,0 +1,64 @@
+{
+  "archetypes": {
+    "shell": {
+      "cooldownSeconds": 0.2,
+      "projectileSpeed": 780,
+      "projectileLifetimeSeconds": 2.0,
+      "damage": 14,
+      "muzzleEffect": "fx/muzzle/shell",
+      "impactEffect": "fx/impact/shell",
+      "trailEffect": "fx/trail/shell"
+    },
+    "missile": {
+      "cooldownSeconds": 1.8,
+      "projectileSpeed": 240,
+      "projectileLifetimeSeconds": 6.0,
+      "damage": 55,
+      "muzzleEffect": "fx/muzzle/missile",
+      "impactEffect": "fx/impact/missile",
+      "trailEffect": "fx/trail/missile",
+      "decoyBreakProbability": 0.35
+    },
+    "laser": {
+      "cooldownSeconds": 0.1,
+      "beamDurationSeconds": 0.25,
+      "damage": 9,
+      "beamEffect": "fx/beam/laser",
+      "impactEffect": "fx/impact/laser"
+    }
+  },
+  "weapons": {
+    "pulse-cannon": {
+      "archetype": "shell"
+    },
+    "flak-pod": {
+      "archetype": "shell",
+      "projectileLifetimeSeconds": 1.2,
+      "impactEffect": "fx/impact/flak"
+    },
+    "micro-missile": {
+      "archetype": "missile"
+    },
+    "emp-torpedo": {
+      "archetype": "missile",
+      "decoyBreakProbability": 0.5,
+      "impactEffect": "fx/impact/emp"
+    },
+    "scatter-laser": {
+      "archetype": "laser",
+      "beamDurationSeconds": 0.32,
+      "beamEffect": "fx/beam/scatter"
+    },
+    "heavy-plasma": {
+      "archetype": "laser",
+      "beamDurationSeconds": 0.4,
+      "beamEffect": "fx/beam/plasma",
+      "impactEffect": "fx/impact/plasma",
+      "damage": 12
+    }
+  },
+  "decoy": {
+    "activationDurationSeconds": 4.0,
+    "breakProbability": 0.45
+  }
+}

--- a/go-broker/internal/combat/weapon_balance_test.go
+++ b/go-broker/internal/combat/weapon_balance_test.go
@@ -1,0 +1,19 @@
+package combat
+
+import "testing"
+
+func TestWeaponBalanceLoads(t *testing.T) {
+	//1.- Load the catalog and ensure both archetypes and weapons are populated.
+	catalog := WeaponBalance()
+	if len(catalog.Archetypes) == 0 {
+		t.Fatalf("expected archetypes to load")
+	}
+	if len(catalog.Weapons) == 0 {
+		t.Fatalf("expected weapons to load")
+	}
+	//2.- Verify the decoy balance exposes a positive activation window.
+	decoy := DecoyBalance()
+	if decoy.ActivationDurationSeconds <= 0 {
+		t.Fatalf("expected decoy activation duration to be positive")
+	}
+}

--- a/go-broker/internal/combat/weapons.go
+++ b/go-broker/internal/combat/weapons.go
@@ -1,0 +1,202 @@
+package combat
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
+// WeaponBehaviour merges archetype defaults with per-weapon overrides for runtime use.
+type WeaponBehaviour struct {
+	ID                    string
+	Archetype             WeaponArchetype
+	Cooldown              time.Duration
+	Damage                float64
+	ProjectileSpeed       float64
+	ProjectileLifetime    time.Duration
+	BeamDuration          time.Duration
+	MuzzleEffect          string
+	ImpactEffect          string
+	TrailEffect           string
+	BeamEffect            string
+	DecoyBreakProbability float64
+}
+
+// WeaponRequest describes a weapon trigger initiated by a player or bot.
+type WeaponRequest struct {
+	WeaponID                      string
+	MatchSeed                     string
+	ProjectileID                  string
+	TargetID                      string
+	DistanceMeters                float64
+	DecoyActive                   bool
+	DecoyBreakProbabilityOverride *float64
+}
+
+// WeaponEvent captures the resolved behaviour for a weapon trigger.
+type WeaponEvent struct {
+	Behaviour      WeaponBehaviour
+	TravelTime     time.Duration
+	BeamDuration   time.Duration
+	MissileSpoofed bool
+	DecoyTriggered bool
+}
+
+// DecoyEvent describes a decoy activation window available to missile handlers.
+type DecoyEvent struct {
+	Duration         time.Duration
+	BreakProbability float64
+}
+
+// ResolveWeaponBehaviour returns the merged behaviour for the provided weapon identifier.
+func ResolveWeaponBehaviour(weaponID string) (WeaponBehaviour, error) {
+	catalog := WeaponBalance()
+	variant, ok := catalog.Weapons[weaponID]
+	if !ok {
+		return WeaponBehaviour{}, errors.New("unknown weapon identifier")
+	}
+	base, ok := catalog.Archetypes[string(variant.Archetype)]
+	if !ok {
+		return WeaponBehaviour{}, errors.New("missing archetype configuration")
+	}
+
+	behaviour := WeaponBehaviour{ID: weaponID, Archetype: variant.Archetype}
+	behaviour.Cooldown = durationFromSeconds(pickFloat(base.CooldownSeconds, variant.CooldownSeconds, true))
+	behaviour.ProjectileSpeed = pickFloat(base.ProjectileSpeed, variant.ProjectileSpeed, false)
+	behaviour.ProjectileLifetime = durationFromSeconds(pickFloat(base.ProjectileLifetimeSeconds, variant.ProjectileLifetimeSeconds, false))
+	behaviour.BeamDuration = durationFromSeconds(pickFloat(base.BeamDurationSeconds, variant.BeamDurationSeconds, false))
+	behaviour.Damage = pickFloat(base.Damage, variant.Damage, false)
+	behaviour.MuzzleEffect = pickString(base.MuzzleEffect, variant.MuzzleEffect)
+	behaviour.ImpactEffect = pickString(base.ImpactEffect, variant.ImpactEffect)
+	behaviour.TrailEffect = pickString(base.TrailEffect, variant.TrailEffect)
+	behaviour.BeamEffect = pickString(base.BeamEffect, variant.BeamEffect)
+	behaviour.DecoyBreakProbability = clampProbability(pickFloat(base.DecoyBreakProbability, variant.DecoyBreakProbability, true))
+	return behaviour, nil
+}
+
+// HandleWeaponFire evaluates the appropriate weapon handler based on the resolved archetype.
+func HandleWeaponFire(req WeaponRequest) (WeaponEvent, error) {
+	behaviour, err := ResolveWeaponBehaviour(req.WeaponID)
+	if err != nil {
+		return WeaponEvent{}, err
+	}
+	switch behaviour.Archetype {
+	case WeaponArchetypeShell:
+		return handleShellFire(req, behaviour), nil
+	case WeaponArchetypeMissile:
+		return handleMissileFire(req, behaviour), nil
+	case WeaponArchetypeLaser:
+		return handleLaserFire(req, behaviour), nil
+	default:
+		return WeaponEvent{}, errors.New("unsupported weapon archetype")
+	}
+}
+
+// HandleDecoyActivation generates the decoy activation window based on balance configuration.
+func HandleDecoyActivation() DecoyEvent {
+	balance := DecoyBalance()
+	//1.- Convert the configured activation window from seconds to a duration.
+	duration := durationFromSeconds(balance.ActivationDurationSeconds)
+	//2.- Clamp the probability so missile handlers operate with safe values.
+	probability := clampProbability(balance.BreakProbability)
+	return DecoyEvent{Duration: duration, BreakProbability: probability}
+}
+
+// TriggerBotWeapon exposes a simplified surface for bot controllers to fire weapons.
+func TriggerBotWeapon(req WeaponRequest) (WeaponEvent, error) {
+	//1.- Delegate to HandleWeaponFire so bot triggers share the same deterministic flow as players.
+	event, err := HandleWeaponFire(req)
+	if err != nil {
+		return WeaponEvent{}, err
+	}
+	//2.- Mark the trigger as bot-driven so downstream telemetry can attribute the source if desired.
+	event.DecoyTriggered = event.DecoyTriggered || req.DecoyActive
+	return event, nil
+}
+
+// TriggerBotDecoy allows bot controllers to activate decoys using shared balance values.
+func TriggerBotDecoy() DecoyEvent {
+	//1.- Bots use the same decoy pipeline so they respect match balance tuning.
+	return HandleDecoyActivation()
+}
+
+func handleShellFire(req WeaponRequest, behaviour WeaponBehaviour) WeaponEvent {
+	//1.- Shells are ballistic; compute flight time using the configured projectile speed.
+	travel := projectileTravelTime(req.DistanceMeters, behaviour.ProjectileSpeed)
+	return WeaponEvent{Behaviour: behaviour, TravelTime: travel}
+}
+
+func handleMissileFire(req WeaponRequest, behaviour WeaponBehaviour) WeaponEvent {
+	//1.- Missiles spawn projectiles so compute travel time identical to shells.
+	travel := projectileTravelTime(req.DistanceMeters, behaviour.ProjectileSpeed)
+	//2.- Determine whether an active decoy spoofs the missile guidance.
+	probability := behaviour.DecoyBreakProbability
+	if req.DecoyBreakProbabilityOverride != nil {
+		probability = clampProbability(*req.DecoyBreakProbabilityOverride)
+	}
+	decoyTriggered := req.DecoyActive && probability > 0
+	spoofed := false
+	if decoyTriggered && req.MatchSeed != "" && req.ProjectileID != "" && req.TargetID != "" {
+		spoofed = ShouldDecoyBreak(req.MatchSeed, req.ProjectileID, req.TargetID, probability)
+	}
+	return WeaponEvent{Behaviour: behaviour, TravelTime: travel, MissileSpoofed: spoofed, DecoyTriggered: decoyTriggered}
+}
+
+func handleLaserFire(req WeaponRequest, behaviour WeaponBehaviour) WeaponEvent {
+	_ = req
+	//1.- Lasers are hitscan so flight time is effectively zero while the beam persists.
+	return WeaponEvent{Behaviour: behaviour, BeamDuration: behaviour.BeamDuration}
+}
+
+func pickFloat(base float64, override *float64, allowZero bool) float64 {
+	//1.- Use the override when present while respecting zero-friendly fields like probabilities.
+	if override != nil {
+		if !allowZero && *override <= 0 {
+			return base
+		}
+		return *override
+	}
+	if !allowZero && base < 0 {
+		return 0
+	}
+	return base
+}
+
+func pickString(base, override string) string {
+	//1.- Prefer the override when provided so art teams can customise effects per weapon.
+	if override != "" {
+		return override
+	}
+	return base
+}
+
+func durationFromSeconds(seconds float64) time.Duration {
+	//1.- Guard against invalid configuration to avoid negative durations entering the pipeline.
+	if !(seconds > 0) {
+		return 0
+	}
+	return time.Duration(seconds * float64(time.Second))
+}
+
+func projectileTravelTime(distanceMeters, speedMetersPerSecond float64) time.Duration {
+	//1.- A non-positive speed or distance yields zero travel time to simplify downstream logic.
+	if !(distanceMeters > 0) || !(speedMetersPerSecond > 0) {
+		return 0
+	}
+	seconds := distanceMeters / speedMetersPerSecond
+	return durationFromSeconds(seconds)
+}
+
+func clampProbability(probability float64) float64 {
+	//1.- NaN probabilities collapse to zero to keep determinism intact.
+	if math.IsNaN(probability) {
+		return 0
+	}
+	if probability < 0 {
+		return 0
+	}
+	if probability > 1 {
+		return 1
+	}
+	return probability
+}

--- a/go-broker/internal/combat/weapons_test.go
+++ b/go-broker/internal/combat/weapons_test.go
@@ -1,0 +1,125 @@
+package combat
+
+import "testing"
+
+func TestResolveWeaponBehaviour(t *testing.T) {
+	//1.- Resolve a shell weapon and ensure the archetype merges correctly.
+	behaviour, err := ResolveWeaponBehaviour("pulse-cannon")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if behaviour.Archetype != WeaponArchetypeShell {
+		t.Fatalf("expected shell archetype, got %v", behaviour.Archetype)
+	}
+	if behaviour.ProjectileSpeed <= 0 {
+		t.Fatalf("expected projectile speed to be set")
+	}
+	if behaviour.Cooldown <= 0 {
+		t.Fatalf("expected cooldown to be positive")
+	}
+}
+
+func TestHandleMissileFireWithDecoy(t *testing.T) {
+	//1.- Pull the missile behaviour so the test can assert decoy probabilities.
+	behaviour, err := ResolveWeaponBehaviour("micro-missile")
+	if err != nil {
+		t.Fatalf("unexpected error resolving behaviour: %v", err)
+	}
+	if behaviour.DecoyBreakProbability <= 0 {
+		t.Fatalf("expected missile to have decoy probability")
+	}
+	//2.- Fire the missile with an active decoy to exercise the spoof path.
+	event, err := HandleWeaponFire(WeaponRequest{
+		WeaponID:       "micro-missile",
+		MatchSeed:      "match-seed",
+		ProjectileID:   "missile-1",
+		TargetID:       "target-1",
+		DistanceMeters: 400,
+		DecoyActive:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !event.DecoyTriggered {
+		t.Fatalf("expected decoy to trigger for missile")
+	}
+	//3.- Determinism check ensures repeated calls share the same spoof outcome.
+	repeat, err := HandleWeaponFire(WeaponRequest{
+		WeaponID:       "micro-missile",
+		MatchSeed:      "match-seed",
+		ProjectileID:   "missile-1",
+		TargetID:       "target-1",
+		DistanceMeters: 400,
+		DecoyActive:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error on repeat: %v", err)
+	}
+	if event.MissileSpoofed != repeat.MissileSpoofed {
+		t.Fatalf("expected deterministic spoof outcome")
+	}
+}
+
+func TestHandleShellFire(t *testing.T) {
+	//1.- Compute shell travel time to validate projectile handling.
+	event, err := HandleWeaponFire(WeaponRequest{WeaponID: "pulse-cannon", DistanceMeters: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.TravelTime <= 0 {
+		t.Fatalf("expected positive travel time")
+	}
+}
+
+func TestHandleLaserFire(t *testing.T) {
+	//1.- Ensure lasers expose beam duration rather than projectile travel.
+	event, err := HandleWeaponFire(WeaponRequest{WeaponID: "scatter-laser"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.BeamDuration <= 0 {
+		t.Fatalf("expected beam duration for laser")
+	}
+}
+
+func TestHandleDecoyActivation(t *testing.T) {
+	//1.- Derive decoy activation values shared with the client HUD.
+	decoy := HandleDecoyActivation()
+	if decoy.Duration <= 0 {
+		t.Fatalf("expected decoy duration")
+	}
+	if decoy.BreakProbability <= 0 {
+		t.Fatalf("expected positive decoy probability")
+	}
+}
+
+func TestTriggerBotWeaponCoversAllArchetypes(t *testing.T) {
+	//1.- Iterate representative weapons to ensure bot triggers support every archetype.
+	tests := []struct {
+		weaponID string
+	}{
+		{weaponID: "pulse-cannon"},
+		{weaponID: "micro-missile"},
+		{weaponID: "scatter-laser"},
+	}
+	for _, tc := range tests {
+		event, err := TriggerBotWeapon(WeaponRequest{WeaponID: tc.weaponID, DistanceMeters: 150, MatchSeed: "seed", ProjectileID: "proj", TargetID: "target"})
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", tc.weaponID, err)
+		}
+		if event.Behaviour.ID != tc.weaponID {
+			t.Fatalf("expected behaviour id %s, got %s", tc.weaponID, event.Behaviour.ID)
+		}
+	}
+}
+
+func TestTriggerBotDecoy(t *testing.T) {
+	//1.- Ensure bot decoy triggers reflect the shared balance payload.
+	decoy := TriggerBotDecoy()
+	if decoy.Duration <= 0 {
+		t.Fatalf("expected decoy duration")
+	}
+	if decoy.BreakProbability <= 0 {
+		t.Fatalf("expected positive probability")
+	}
+}

--- a/tunnelcave_sandbox_web/src/combat/weaponBehaviours.test.ts
+++ b/tunnelcave_sandbox_web/src/combat/weaponBehaviours.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { planWeaponFire, planDecoyActivation, resolveMissileSpoof } from './weaponBehaviours'
+
+describe('weaponBehaviours', () => {
+  it('computes projectile travel time for shells', () => {
+    //1.- Resolve the pulse cannon behaviour over a 780 metre engagement range.
+    const plan = planWeaponFire('pulse-cannon', 780)
+    //2.- Expect a one second flight time and immutable payload for presentation logic.
+    expect(plan.travelTimeSeconds).toBeCloseTo(1, 3)
+    expect(Object.isFrozen(plan)).toBe(true)
+    expect(plan.behaviour.archetype).toBe('shell')
+  })
+
+  it('exposes beam duration for lasers', () => {
+    //1.- Scatter laser should present a beam duration without projectile travel time.
+    const plan = planWeaponFire('scatter-laser', 200)
+    //2.- Ensure lasers remain hitscan while exposing beam persistence for VFX scheduling.
+    expect(plan.travelTimeSeconds).toBe(0)
+    expect(plan.beamDurationSeconds).toBeGreaterThan(0)
+  })
+
+  it('mirrors Go ECM spoof resolution for missiles', () => {
+    //1.- Prepare a missile plan with an active decoy and deterministic identifiers.
+    const plan = planWeaponFire('micro-missile', 300)
+    const options = {
+      matchSeed: 'match-seed',
+      missileId: 'missile-1',
+      targetId: 'target-1',
+      decoyActive: true,
+    }
+    const first = resolveMissileSpoof(plan, options)
+    //2.- Re-run the resolution to confirm the roll stays deterministic for replays.
+    const second = resolveMissileSpoof(plan, options)
+    expect(first).toBe(second)
+  })
+
+  it('provides decoy activation windows for HUD feedback', () => {
+    //1.- Activate the decoy plan sourced from shared gameplay tuning.
+    const activation = planDecoyActivation()
+    //2.- Confirm the activation exposes both duration and probability data.
+    expect(activation.durationSeconds).toBeGreaterThan(0)
+    expect(activation.breakProbability).toBeGreaterThan(0)
+    expect(Object.isFrozen(activation)).toBe(true)
+  })
+})

--- a/tunnelcave_sandbox_web/src/combat/weaponBehaviours.ts
+++ b/tunnelcave_sandbox_web/src/combat/weaponBehaviours.ts
@@ -1,0 +1,118 @@
+import {
+  decoyBalance,
+  resolveWeaponBalance,
+  ResolvedWeaponBalance,
+} from "../../../typescript-client/src/gameplayConfig";
+import { createHash } from "node:crypto";
+
+export interface WeaponFirePlan {
+  //1.- Behaviour snapshot mirrored from the shared gameplay configuration.
+  behaviour: ResolvedWeaponBalance;
+  //2.- Projectile flight time expressed in seconds for ballistic archetypes.
+  travelTimeSeconds: number;
+  //3.- Beam persistence in seconds for hitscan archetypes.
+  beamDurationSeconds: number;
+  //4.- Probability that an active decoy spoofs missiles using this plan.
+  decoyBreakProbability: number;
+}
+
+export interface MissileSpoofOptions {
+  //1.- Shared match seed ensuring deterministic ECM resolution between client and server.
+  matchSeed: string;
+  //2.- Unique missile identifier emitted by the projectile system.
+  missileId: string;
+  //3.- Target entity identifier the missile is pursuing.
+  targetId: string;
+  //4.- Whether a decoy is active when the missile evaluates the spoof roll.
+  decoyActive: boolean;
+  //5.- Optional probability override for special missiles with custom ECM tuning.
+  breakProbabilityOverride?: number;
+}
+
+export interface DecoyActivationPlan {
+  //1.- Duration in seconds that the decoy remains active.
+  durationSeconds: number;
+  //2.- Spoof probability applied to missiles while the decoy is active.
+  breakProbability: number;
+}
+
+const ECM_NAMESPACE = "combat.ecm\u0000";
+
+export function planWeaponFire(weaponId: string, distanceMeters: number): WeaponFirePlan {
+  //1.- Resolve the shared weapon behaviour and merge archetype defaults with variant overrides.
+  const behaviour = resolveWeaponBalance(weaponId);
+  const projectileSpeed = behaviour.projectileSpeed ?? 0;
+  const travelTimeSeconds = projectileSpeed > 0 && distanceMeters > 0 ? distanceMeters / projectileSpeed : 0;
+  const beamDurationSeconds = behaviour.beamDurationSeconds ?? 0;
+  const decoyBreakProbability = behaviour.decoyBreakProbability ?? 0;
+  //2.- Freeze the plan so presentation logic cannot mutate shared behaviour at runtime.
+  return Object.freeze({
+    behaviour,
+    travelTimeSeconds,
+    beamDurationSeconds,
+    decoyBreakProbability,
+  });
+}
+
+export function planDecoyActivation(): DecoyActivationPlan {
+  //1.- Return a frozen activation plan so HUD widgets operate on immutable data.
+  return Object.freeze({
+    durationSeconds: decoyBalance.activationDurationSeconds,
+    breakProbability: decoyBalance.breakProbability,
+  });
+}
+
+export function resolveMissileSpoof(plan: WeaponFirePlan, options: MissileSpoofOptions): boolean {
+  //1.- Skip spoof resolution when no decoy is active or the archetype does not use missiles.
+  const probability = options.breakProbabilityOverride ?? plan.decoyBreakProbability;
+  if (!options.decoyActive || !probability || probability <= 0) {
+    return false;
+  }
+  if (!options.matchSeed || !options.missileId || !options.targetId) {
+    return false;
+  }
+  //2.- Compute the deterministic random roll using the same recipe as the Go runtime.
+  const roll = deterministicRoll(options.matchSeed, options.missileId, options.targetId);
+  return roll < clampProbability(probability);
+}
+
+function deterministicRoll(matchSeed: string, missileId: string, targetId: string): number {
+  //1.- Hash the identifiers so identical tuples generate the same pseudo-random sequence.
+  const hash = createHash("sha256");
+  hash.update(ECM_NAMESPACE, "utf8");
+  hash.update(matchSeed, "utf8");
+  hash.update("\u0000", "utf8");
+  hash.update(missileId, "utf8");
+  hash.update("\u0000", "utf8");
+  hash.update(targetId, "utf8");
+  const digest = hash.digest();
+  //2.- Consume eight byte chunks until a non-zero seed emerges, mirroring the Go routine.
+  for (let offset = 0; offset + 8 <= digest.length; offset += 8) {
+    const seed = digest.readBigUInt64LE(offset);
+    if (seed !== 0n) {
+      return numberFromSeed(seed);
+    }
+  }
+  return numberFromSeed(1n);
+}
+
+function numberFromSeed(seed: bigint): number {
+  //1.- Convert the 64-bit seed into a floating point number within [0, 1).
+  const max = BigInt(1) << BigInt(53);
+  const masked = seed & (max - BigInt(1));
+  return Number(masked) / Number(max);
+}
+
+function clampProbability(probability: number): number {
+  //1.- Keep the probability bounded to avoid NaNs or infinities from surfacing in consumers.
+  if (!Number.isFinite(probability)) {
+    return 0;
+  }
+  if (probability < 0) {
+    return 0;
+  }
+  if (probability > 1) {
+    return 1;
+  }
+  return probability;
+}


### PR DESCRIPTION
## Summary
- add shared weapon balance catalogue and weapon handlers to the Go combat module, including bot-trigger helpers and decoy support
- expose the same balance data through gameplayConfig.ts and add deterministic weapon planning utilities for the web client
- introduce vitest and ts-node coverage for the new weapon logic alongside Go unit tests for shells, missiles, lasers, and decoys

## Testing
- go test ./... (from go-broker)
- npm test (from typescript-client)
- npm test (from tunnelcave_sandbox_web)


------
https://chatgpt.com/codex/tasks/task_e_68df29589b0483299c5e2ea79c72c1b1