### PR TITLE
Implement ECM probability window tracking

### DIFF
--- a/docs/combat.md
+++ b/docs/combat.md
@@ -20,3 +20,23 @@ misfires by replaying the same tick stream.
 
 When new ECM mechanics are introduced, ensure any additional entropy joins the
 hash payload **before** hashing so the deterministic guarantee remains intact.
+
+## Time-Windowed ECM Resolution
+
+To model the 65% to 20% spoof decay across a three second decoy window, the Go
+runtime exposes `combat.MissileECMTracker`. The tracker keeps a seeded random
+number generator per missile engagement so every elapsed-time query consumes the
+next deterministic roll from the shared stream. Replaying the same match seed,
+missile identifier, and target identifier therefore produces identical spoof
+timelines regardless of how many times the simulation checks the decoy window.
+
+1. `combat.DefaultECMProbabilityWindow()` encodes the plateau at 65% for the
+   first 1.5 seconds and the linear decay to 20% by the three second mark.
+2. `tracker.Resolve(seed, missileID, targetID, elapsed, window)` returns the
+   deterministic spoof outcome for the provided elapsed timestamp.
+3. `tracker.Release(...)` and `tracker.Reset()` allow callers to recycle state
+   after missiles complete their engagements, keeping long-running matches from
+   growing unbounded maps.
+
+These primitives allow the bot interface and combat server to observe the same
+ECM behaviour while maintaining deterministic replays.

--- a/go-broker/internal/combat/ecm.go
+++ b/go-broker/internal/combat/ecm.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"math"
 	"math/rand"
+	"sync"
+	"time"
 )
 
 // SeedForOutcome derives a deterministic RNG seed for ECM interactions.
@@ -51,4 +53,187 @@ func ShouldDecoyBreak(matchSeed, missileID, targetID string, breakProbability fl
 	rng := newECMRand(matchSeed, missileID, targetID)
 	roll := rng.Float64()
 	return roll < breakProbability
+}
+
+const (
+	defaultECMInitialProbability = 0.65
+	defaultECMFinalProbability   = 0.20
+)
+
+var (
+	defaultECMInitialDuration = 1500 * time.Millisecond
+	defaultECMTotalDuration   = 3 * time.Second
+)
+
+// ECMProbabilityWindow describes how spoof probabilities evolve during an engagement.
+type ECMProbabilityWindow struct {
+	InitialProbability float64
+	InitialDuration    time.Duration
+	FinalProbability   float64
+	TotalDuration      time.Duration
+}
+
+// DefaultECMProbabilityWindow returns the shared 65% to 20% decay profile over three seconds.
+func DefaultECMProbabilityWindow() ECMProbabilityWindow {
+	//1.- Provide the tuned defaults mirroring the bot interface timeline.
+	return ECMProbabilityWindow{
+		InitialProbability: defaultECMInitialProbability,
+		InitialDuration:    defaultECMInitialDuration,
+		FinalProbability:   defaultECMFinalProbability,
+		TotalDuration:      defaultECMTotalDuration,
+	}
+}
+
+// ProbabilityAt resolves the interpolated spoof probability for the provided elapsed time.
+func (w ECMProbabilityWindow) ProbabilityAt(elapsed time.Duration) float64 {
+	//1.- Normalise invalid durations so callers cannot trigger negative time windows.
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	window := w.normalised()
+	start := clampProbability(window.InitialProbability)
+	end := clampProbability(window.FinalProbability)
+	//2.- Before the plateau expires the probability remains at the initial level.
+	if window.InitialDuration > 0 && elapsed <= window.InitialDuration {
+		return start
+	}
+	//3.- After the total window the probability stabilises at the configured final value.
+	if window.TotalDuration <= 0 || elapsed >= window.TotalDuration {
+		return end
+	}
+	span := window.TotalDuration - window.InitialDuration
+	if span <= 0 {
+		return end
+	}
+	progress := float64(elapsed-window.InitialDuration) / float64(span)
+	if progress < 0 {
+		progress = 0
+	} else if progress > 1 {
+		progress = 1
+	}
+	probability := start + (end-start)*progress
+	return clampProbability(probability)
+}
+
+// normalised guards the window against invalid durations to keep interpolation stable.
+func (w ECMProbabilityWindow) normalised() ECMProbabilityWindow {
+	//1.- Ensure durations are non-negative so interpolation math remains sane.
+	if w.InitialDuration < 0 {
+		w.InitialDuration = 0
+	}
+	if w.TotalDuration < 0 {
+		w.TotalDuration = 0
+	}
+	//2.- Guarantee the total duration is at least as long as the plateau.
+	if w.TotalDuration != 0 && w.TotalDuration < w.InitialDuration {
+		w.TotalDuration = w.InitialDuration
+	}
+	return w
+}
+
+// MissileECMTracker stores deterministic RNG streams per missile engagement.
+type MissileECMTracker struct {
+	mu     sync.Mutex
+	states map[string]*missileECMState
+}
+
+// missileECMState captures the evolving spoof context for a single missile.
+type missileECMState struct {
+	rng         *rand.Rand
+	window      ECMProbabilityWindow
+	lastElapsed time.Duration
+	lastOutcome bool
+	hasOutcome  bool
+	spoofed     bool
+}
+
+// NewMissileECMTracker constructs an empty tracker ready to service missile timelines.
+func NewMissileECMTracker() *MissileECMTracker {
+	//1.- Prepare the backing store lazily so tests can reset state between runs.
+	return &MissileECMTracker{states: make(map[string]*missileECMState)}
+}
+
+// Resolve applies the probability window for the missile at the provided elapsed time.
+func (t *MissileECMTracker) Resolve(matchSeed, missileID, targetID string, elapsed time.Duration, window ECMProbabilityWindow) bool {
+	//1.- Bail out early when identifiers are missing or the window carries no chance to spoof.
+	if matchSeed == "" || missileID == "" || targetID == "" {
+		return false
+	}
+	if window.InitialProbability <= 0 && window.FinalProbability <= 0 {
+		return false
+	}
+	key := missileECMKey(matchSeed, missileID, targetID)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.states[key]
+	if !ok {
+		//2.- Lazily create the RNG so each missile follows its own deterministic stream.
+		state = &missileECMState{
+			rng:    newECMRand(matchSeed, missileID, targetID),
+			window: window.normalised(),
+		}
+		t.states[key] = state
+	}
+	return state.evaluate(elapsed)
+}
+
+// Release discards the stored state for the missile once its engagement concludes.
+func (t *MissileECMTracker) Release(matchSeed, missileID, targetID string) {
+	//1.- Remove the missile entry so repeated engagements restart from the original seed.
+	key := missileECMKey(matchSeed, missileID, targetID)
+	t.mu.Lock()
+	delete(t.states, key)
+	t.mu.Unlock()
+}
+
+// Reset clears every tracked missile, primarily for deterministic test harnesses.
+func (t *MissileECMTracker) Reset() {
+	//1.- Replace the state map with a fresh instance to drop all cached RNG streams.
+	t.mu.Lock()
+	t.states = make(map[string]*missileECMState)
+	t.mu.Unlock()
+}
+
+// evaluate advances the deterministic RNG when a new elapsed timestamp is requested.
+func (s *missileECMState) evaluate(elapsed time.Duration) bool {
+	//1.- Once spoofed the missile remains spoofed regardless of later evaluations.
+	if s.spoofed {
+		s.lastOutcome = true
+		if elapsed > s.lastElapsed {
+			s.lastElapsed = elapsed
+		}
+		s.hasOutcome = true
+		return true
+	}
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	//2.- Replaying an earlier or identical timestamp reuses the cached deterministic result.
+	if s.hasOutcome && elapsed <= s.lastElapsed {
+		return s.lastOutcome
+	}
+	probability := s.window.ProbabilityAt(elapsed)
+	if probability <= 0 {
+		s.lastElapsed = elapsed
+		s.lastOutcome = false
+		s.hasOutcome = true
+		return false
+	}
+	//3.- Consume the next roll from the seeded RNG to decide the spoof outcome.
+	roll := s.rng.Float64()
+	if roll < probability {
+		s.spoofed = true
+		s.lastOutcome = true
+	} else {
+		s.lastOutcome = false
+	}
+	s.lastElapsed = elapsed
+	s.hasOutcome = true
+	return s.lastOutcome
+}
+
+// missileECMKey derives the composite key used to store state per missile engagement.
+func missileECMKey(matchSeed, missileID, targetID string) string {
+	//1.- Join identifiers with a separator so collisions remain impossible within the tracker.
+	return matchSeed + "\x00" + missileID + "\x00" + targetID
 }

--- a/go-broker/internal/combat/ecm_test.go
+++ b/go-broker/internal/combat/ecm_test.go
@@ -1,6 +1,11 @@
 package combat
 
-import "testing"
+import (
+	"math"
+	"reflect"
+	"testing"
+	"time"
+)
 
 func TestSeedForOutcomeDeterministic(t *testing.T) {
 	seedA := SeedForOutcome("match-123", "missile-9", "target-4")
@@ -28,5 +33,109 @@ func TestShouldDecoyBreakProbabilityBounds(t *testing.T) {
 	}
 	if !ShouldDecoyBreak("s", "m", "t", 1.5) {
 		t.Fatalf("probability >= 1 should always break")
+	}
+}
+
+func TestDefaultECMProbabilityWindowCurve(t *testing.T) {
+	window := DefaultECMProbabilityWindow()
+	//1.- Validate the plateau phase stays at 65% for the first half of the window.
+	early := window.ProbabilityAt(500 * time.Millisecond)
+	if math.Abs(early-defaultECMInitialProbability) > 1e-9 {
+		t.Fatalf("expected early probability %.2f, got %.6f", defaultECMInitialProbability, early)
+	}
+	midpoint := window.ProbabilityAt(2250 * time.Millisecond)
+	//2.- Midpoint should interpolate halfway between the initial and final probabilities.
+	expectedMid := defaultECMInitialProbability + (defaultECMFinalProbability-defaultECMInitialProbability)/2
+	if math.Abs(midpoint-expectedMid) > 1e-9 {
+		t.Fatalf("expected midpoint probability %.6f, got %.6f", expectedMid, midpoint)
+	}
+	late := window.ProbabilityAt(4 * time.Second)
+	//3.- After the decay window the probability stabilises at the final 20%% value.
+	if math.Abs(late-defaultECMFinalProbability) > 1e-9 {
+		t.Fatalf("expected late probability %.2f, got %.6f", defaultECMFinalProbability, late)
+	}
+}
+
+func TestMissileECMTrackerDeterministicTimeline(t *testing.T) {
+	tracker := NewMissileECMTracker()
+	window := DefaultECMProbabilityWindow()
+	matchSeed := "seed"
+	missileID := "missile-7"
+	targetID := "target-3"
+	samples := []time.Duration{250 * time.Millisecond, 1500 * time.Millisecond, 2250 * time.Millisecond, 3600 * time.Millisecond}
+	firstRun := make([]bool, len(samples))
+	//1.- Capture the deterministic timeline for the missile across the probability window.
+	for idx, elapsed := range samples {
+		firstRun[idx] = tracker.Resolve(matchSeed, missileID, targetID, elapsed, window)
+	}
+	repeat := tracker.Resolve(matchSeed, missileID, targetID, samples[len(samples)-1], window)
+	if repeat != firstRun[len(firstRun)-1] {
+		t.Fatalf("expected repeated query to reuse cached outcome")
+	}
+	tracker.Reset()
+	secondRun := make([]bool, len(samples))
+	//2.- Resetting the tracker should reproduce the identical deterministic sequence.
+	for idx, elapsed := range samples {
+		secondRun[idx] = tracker.Resolve(matchSeed, missileID, targetID, elapsed, window)
+	}
+	if !reflect.DeepEqual(firstRun, secondRun) {
+		t.Fatalf("expected identical outcomes after reset, got %v and %v", firstRun, secondRun)
+	}
+}
+
+func TestMissileECMTrackerMultipleMissiles(t *testing.T) {
+	tracker := NewMissileECMTracker()
+	window := DefaultECMProbabilityWindow()
+	//1.- Resolve two missiles to ensure their RNG streams remain isolated.
+	missileA := []bool{
+		tracker.Resolve("seed", "missile-A", "target-1", time.Second, window),
+		tracker.Resolve("seed", "missile-A", "target-1", 2600*time.Millisecond, window),
+	}
+	missileB := []bool{
+		tracker.Resolve("seed", "missile-B", "target-2", time.Second, window),
+		tracker.Resolve("seed", "missile-B", "target-2", 2600*time.Millisecond, window),
+	}
+	tracker.Reset()
+	missileARepeat := []bool{
+		tracker.Resolve("seed", "missile-A", "target-1", time.Second, window),
+		tracker.Resolve("seed", "missile-A", "target-1", 2600*time.Millisecond, window),
+	}
+	missileBRepeat := []bool{
+		tracker.Resolve("seed", "missile-B", "target-2", time.Second, window),
+		tracker.Resolve("seed", "missile-B", "target-2", 2600*time.Millisecond, window),
+	}
+	//2.- Each missile should reproduce the same deterministic sequence irrespective of others.
+	if !reflect.DeepEqual(missileA, missileARepeat) {
+		t.Fatalf("missile A sequence drifted: %v vs %v", missileA, missileARepeat)
+	}
+	if !reflect.DeepEqual(missileB, missileBRepeat) {
+		t.Fatalf("missile B sequence drifted: %v vs %v", missileB, missileBRepeat)
+	}
+}
+
+func TestMissileECMTrackerRepeatedEngagements(t *testing.T) {
+	tracker := NewMissileECMTracker()
+	window := DefaultECMProbabilityWindow()
+	matchSeed := "seed"
+	missileID := "missile-r"
+	targetID := "target-x"
+	//1.- Run the initial engagement timeline for the missile.
+	initial := []bool{
+		tracker.Resolve(matchSeed, missileID, targetID, time.Second, window),
+		tracker.Resolve(matchSeed, missileID, targetID, 2800*time.Millisecond, window),
+	}
+	tracker.Release(matchSeed, missileID, targetID)
+	//2.- A new engagement should restart from the original deterministic rolls.
+	repeat := []bool{
+		tracker.Resolve(matchSeed, missileID, targetID, time.Second, window),
+		tracker.Resolve(matchSeed, missileID, targetID, 2800*time.Millisecond, window),
+	}
+	if !reflect.DeepEqual(initial, repeat) {
+		t.Fatalf("expected identical outcomes after release, got %v and %v", initial, repeat)
+	}
+	//3.- Querying an earlier timestamp reuses the cached outcome from the latest evaluation.
+	earlier := tracker.Resolve(matchSeed, missileID, targetID, time.Second, window)
+	if earlier != repeat[0] {
+		t.Fatalf("expected cached outcome %v, got %v", repeat[0], earlier)
 	}
 }


### PR DESCRIPTION
## Summary
- add an ECMProbabilityWindow profile and MissileECMTracker to manage decaying spoof odds with deterministic RNG streams
- document the new time-windowed ECM flow for the combat subsystem
- extend the combat test suite to cover the probability curve, concurrent missiles, and repeated engagements

## Testing
- GOTOOLCHAIN=local go test ./internal/combat

------
https://chatgpt.com/codex/tasks/task_e_68df2e9010388329befdb99aa6a0431a