### PR TITLE
Add damage resolution with telemetry metadata

### DIFF
--- a/go-broker/internal/combat/damage.go
+++ b/go-broker/internal/combat/damage.go
@@ -1,0 +1,185 @@
+package combat
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"driftpursuit/broker/internal/events"
+	"driftpursuit/broker/internal/logging"
+)
+
+// DamageSource enumerates the supported origins of combat damage for breakdowns.
+type DamageSource string
+
+const (
+	// DamageSourceDirect captures weapon projectiles or beams that strike the target.
+	DamageSourceDirect DamageSource = "direct"
+	// DamageSourceSplash represents radial splash or area-of-effect contributions.
+	DamageSourceSplash DamageSource = "splash"
+	// DamageSourceCollision accounts for damage caused by terrain or environmental impacts.
+	DamageSourceCollision DamageSource = "collision"
+)
+
+// DamageProfile describes the configurable magnitudes used by the resolver.
+type DamageProfile struct {
+	//1.- DirectDamage applies when DirectHit is true in the impact context.
+	DirectDamage float64
+	//2.- SplashDamage is the maximum splash value applied at the impact epicentre.
+	SplashDamage float64
+	//3.- SplashRadius defines the maximum radius in meters for splash falloff calculations.
+	SplashRadius float64
+	//4.- SplashFalloffExponent tunes how aggressively splash damage fades with distance.
+	SplashFalloffExponent float64
+	//5.- CollisionScale converts post-threshold impact speed into damage units.
+	CollisionScale float64
+	//6.- CollisionThresholdMps sets the minimum speed required before collision damage accrues.
+	CollisionThresholdMps float64
+}
+
+// ImpactContext captures the runtime parameters required to resolve a hit.
+type ImpactContext struct {
+	//1.- DirectHit flags that the projectile or beam intersected the target directly.
+	DirectHit bool
+	//2.- DistanceMeters conveys the separation between the splash epicentre and target.
+	DistanceMeters float64
+	//3.- ImpactSpeedMps communicates the relative impact speed against the environment.
+	ImpactSpeedMps float64
+	//4.- TerrainHardness scales collision damage to represent softer or harder surfaces.
+	TerrainHardness float64
+}
+
+// DamageResult collates the resolved totals alongside metadata helpers.
+type DamageResult struct {
+	//1.- TotalDamage provides the aggregate damage value combining all sources.
+	TotalDamage float64
+	//2.- Breakdown exposes the per-source contribution used by HUDs and logs.
+	Breakdown map[DamageSource]float64
+	//3.- InstantDestroy reports whether the impact mandates immediate destruction.
+	InstantDestroy bool
+}
+
+const instantKillSpeedThreshold = 30.0
+
+// ResolveDamage evaluates the configured profile against the impact context and returns the breakdown.
+func ResolveDamage(profile DamageProfile, ctx ImpactContext) DamageResult {
+	//1.- Allocate the breakdown map lazily so zero-damage contexts remain empty.
+	breakdown := make(map[DamageSource]float64, 3)
+
+	if profile.DirectDamage > 0 && ctx.DirectHit {
+		breakdown[DamageSourceDirect] = profile.DirectDamage
+	}
+
+	if profile.SplashDamage > 0 && profile.SplashRadius > 0 {
+		distance := ctx.DistanceMeters
+		if !(distance > 0) {
+			distance = 0
+		}
+		if distance <= profile.SplashRadius {
+			normalized := distance / profile.SplashRadius
+			if normalized < 0 {
+				normalized = 0
+			} else if normalized > 1 {
+				normalized = 1
+			}
+			falloffExponent := profile.SplashFalloffExponent
+			if !(falloffExponent > 0) {
+				falloffExponent = 1
+			}
+			multiplier := math.Pow(1-normalized, falloffExponent)
+			if multiplier > 0 {
+				breakdown[DamageSourceSplash] = profile.SplashDamage * multiplier
+			}
+		}
+	}
+
+	if profile.CollisionScale > 0 && ctx.ImpactSpeedMps > 0 && ctx.TerrainHardness > 0 {
+		overSpeed := ctx.ImpactSpeedMps - profile.CollisionThresholdMps
+		if overSpeed < 0 {
+			overSpeed = 0
+		}
+		if overSpeed > 0 {
+			hardness := ctx.TerrainHardness
+			if hardness < 0 {
+				hardness = 0
+			}
+			collisionDamage := overSpeed * profile.CollisionScale * hardness
+			if collisionDamage > 0 {
+				breakdown[DamageSourceCollision] = collisionDamage
+			}
+		}
+	}
+
+	total := 0.0
+	for _, value := range breakdown {
+		total += value
+	}
+
+	//2.- Instant destruction triggers when the impact speed crosses the configured threshold.
+	instant := ctx.ImpactSpeedMps >= instantKillSpeedThreshold
+
+	return DamageResult{TotalDamage: total, Breakdown: breakdown, InstantDestroy: instant}
+}
+
+// AttachMetadata merges the per-source breakdown into the provided metadata map using stable keys.
+func (r DamageResult) AttachMetadata(metadata map[string]string) map[string]string {
+	//1.- Clone the input map so callers keep ownership of their original reference.
+	clone := make(map[string]string, len(metadata)+len(r.Breakdown)+3)
+	for key, value := range metadata {
+		clone[key] = value
+	}
+
+	//2.- Emit deterministic keys to simplify HUD rendering and log inspection.
+	sources := make([]DamageSource, 0, len(r.Breakdown))
+	for source := range r.Breakdown {
+		sources = append(sources, source)
+	}
+	sort.Slice(sources, func(i, j int) bool { return sources[i] < sources[j] })
+	for _, source := range sources {
+		amount := r.Breakdown[source]
+		clone[fmt.Sprintf("damage_%s", source)] = formatDamageValue(amount)
+	}
+
+	clone["damage_total"] = formatDamageValue(r.TotalDamage)
+	clone["damage_instant_kill"] = fmt.Sprintf("%t", r.InstantDestroy)
+	return clone
+}
+
+// LoggingFields returns structured logging fields describing the resolved damage.
+func (r DamageResult) LoggingFields() []logging.Field {
+	//1.- Collect per-source entries to maintain deterministic ordering in logs.
+	keys := make([]DamageSource, 0, len(r.Breakdown))
+	for source := range r.Breakdown {
+		keys = append(keys, source)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	fields := make([]logging.Field, 0, len(keys)+2)
+	for _, source := range keys {
+		fields = append(fields, logging.Field{Key: fmt.Sprintf("damage_%s", source), Value: r.Breakdown[source]})
+	}
+	fields = append(fields, logging.Field{Key: "damage_total", Value: r.TotalDamage})
+	fields = append(fields, logging.Bool("damage_instant_kill", r.InstantDestroy))
+	return fields
+}
+
+// ApplyToTelemetry copies the damage totals and metadata onto the provided telemetry snapshot.
+func (r DamageResult) ApplyToTelemetry(telemetry *events.CombatTelemetry, damageType string) {
+	if telemetry == nil {
+		return
+	}
+	//1.- Update the numeric damage summary delivered to clients.
+	telemetry.Damage.Amount = r.TotalDamage
+	telemetry.Damage.Type = damageType
+	telemetry.Damage.Critical = r.InstantDestroy
+	//2.- Merge the per-source breakdown into the metadata channel for HUD consumption.
+	telemetry.Metadata = r.AttachMetadata(telemetry.Metadata)
+}
+
+func formatDamageValue(amount float64) string {
+	//1.- Clamp extremely small floating point noise to zero for readability.
+	if math.Abs(amount) < 1e-6 {
+		amount = 0
+	}
+	return fmt.Sprintf("%.2f", amount)
+}

--- a/go-broker/internal/combat/damage_test.go
+++ b/go-broker/internal/combat/damage_test.go
@@ -1,0 +1,83 @@
+package combat
+
+import (
+	"testing"
+	"time"
+
+	"driftpursuit/broker/internal/events"
+)
+
+func TestResolveDamageDirectHit(t *testing.T) {
+	//1.- Configure a profile with direct damage to ensure direct hits apply full value.
+	profile := DamageProfile{DirectDamage: 120}
+	result := ResolveDamage(profile, ImpactContext{DirectHit: true})
+	if result.TotalDamage != 120 {
+		t.Fatalf("expected total damage 120, got %.2f", result.TotalDamage)
+	}
+	if result.Breakdown[DamageSourceDirect] != 120 {
+		t.Fatalf("expected direct breakdown 120, got %.2f", result.Breakdown[DamageSourceDirect])
+	}
+	if result.InstantDestroy {
+		t.Fatalf("direct hit without velocity should not force instant destruction")
+	}
+}
+
+func TestResolveDamageSplashFalloff(t *testing.T) {
+	//1.- Define a splash profile so distance influences the resulting amount.
+	profile := DamageProfile{SplashDamage: 90, SplashRadius: 30, SplashFalloffExponent: 2}
+	center := ResolveDamage(profile, ImpactContext{DistanceMeters: 0})
+	edge := ResolveDamage(profile, ImpactContext{DistanceMeters: 25})
+	if center.Breakdown[DamageSourceSplash] <= edge.Breakdown[DamageSourceSplash] {
+		t.Fatalf("expected splash damage to fall off with distance: center %.2f edge %.2f", center.Breakdown[DamageSourceSplash], edge.Breakdown[DamageSourceSplash])
+	}
+	if center.TotalDamage <= edge.TotalDamage {
+		t.Fatalf("total damage should reflect the same falloff behaviour")
+	}
+}
+
+func TestResolveDamageTerrainScaling(t *testing.T) {
+	//1.- Use a collision profile to validate terrain hardness scaling.
+	profile := DamageProfile{CollisionScale: 2, CollisionThresholdMps: 5}
+	result := ResolveDamage(profile, ImpactContext{ImpactSpeedMps: 20, TerrainHardness: 0.5})
+	expected := (20 - 5) * 2 * 0.5
+	if result.Breakdown[DamageSourceCollision] != expected {
+		t.Fatalf("unexpected collision damage %.2f, expected %.2f", result.Breakdown[DamageSourceCollision], expected)
+	}
+	if result.TotalDamage != expected {
+		t.Fatalf("expected total damage %.2f, got %.2f", expected, result.TotalDamage)
+	}
+}
+
+func TestResolveDamageInstantKillTelemetryIntegration(t *testing.T) {
+	//1.- Arrange a combined impact exceeding the instant kill threshold.
+	profile := DamageProfile{DirectDamage: 40, SplashDamage: 20, SplashRadius: 10}
+	ctx := ImpactContext{DirectHit: true, DistanceMeters: 5, ImpactSpeedMps: 42, TerrainHardness: 1}
+	result := ResolveDamage(profile, ctx)
+	if !result.InstantDestroy {
+		t.Fatalf("expected instant destruction when impact speed >= 30 m/s")
+	}
+
+	//2.- Apply the breakdown to a combat telemetry snapshot and validate metadata propagation.
+	telemetry := &events.CombatTelemetry{
+		EventID:    "evt-damage",
+		OccurredAt: time.UnixMilli(1234),
+		Metadata:   map[string]string{"weapon": "gravity-well"},
+	}
+	result.ApplyToTelemetry(telemetry, "kinetic")
+
+	if telemetry.Damage.Amount <= 0 {
+		t.Fatalf("expected damage amount to be populated")
+	}
+	if !telemetry.Damage.Critical {
+		t.Fatalf("critical flag should mirror instant destruction")
+	}
+	if telemetry.Metadata["damage_total"] == "" {
+		t.Fatalf("expected damage_total metadata entry")
+	}
+	if telemetry.Metadata["damage_instant_kill"] != "true" {
+		t.Fatalf("expected instant kill metadata to read true, got %q", telemetry.Metadata["damage_instant_kill"])
+	}
+	if telemetry.Metadata["weapon"] != "gravity-well" {
+		t.Fatalf("existing metadata should be preserved")
+	}
+}

--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts"
+    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts && ts-node src/hud/damageFeed.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/typescript-client/src/hud/damageFeed.test.ts
+++ b/typescript-client/src/hud/damageFeed.test.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from "node:assert";
+
+import { extractDamageBreakdown, formatDamageSummary } from "./damageFeed";
+
+(() => {
+  //1.- Provide metadata resembling the broker payload to exercise extraction and formatting.
+  const metadata = {
+    damage_direct: "150.50",
+    damage_splash: "25.25",
+    damage_collision: "10.00",
+    damage_total: "185.75",
+    damage_instant_kill: "true",
+  } as Record<string, string>;
+
+  const breakdown = extractDamageBreakdown(metadata);
+  assert.equal(breakdown.length, 3);
+  assert.equal(breakdown[0].source, "direct");
+  assert.ok(breakdown[0].amount > breakdown[1].amount);
+
+  const summary = formatDamageSummary(metadata);
+  assert.deepEqual(summary[0], "Total 185.75");
+  assert.ok(summary.includes("INSTANT KILL"));
+  assert.ok(summary.some((line) => line.startsWith("DIRECT")));
+})();

--- a/typescript-client/src/hud/damageFeed.ts
+++ b/typescript-client/src/hud/damageFeed.ts
@@ -1,0 +1,43 @@
+export interface DamageBreakdownEntry {
+  source: string;
+  amount: number;
+}
+
+const damagePrefix = "damage_";
+
+//1.- extractDamageBreakdown maps metadata entries into structured breakdown entries for HUD widgets.
+export function extractDamageBreakdown(metadata: Record<string, string>): DamageBreakdownEntry[] {
+  const entries: DamageBreakdownEntry[] = [];
+  Object.entries(metadata)
+    .filter(([key]) => key.startsWith(damagePrefix) && key !== "damage_total" && key !== "damage_instant_kill")
+    .forEach(([key, value]) => {
+      const amount = Number.parseFloat(value);
+      if (Number.isNaN(amount)) {
+        return;
+      }
+      const source = key.substring(damagePrefix.length);
+      if (!source) {
+        return;
+      }
+      entries.push({ source, amount });
+    });
+  //2.- Sort descending so the HUD emphasises the largest contributor first.
+  entries.sort((a, b) => b.amount - a.amount || a.source.localeCompare(b.source));
+  return entries;
+}
+
+//2.- formatDamageSummary converts the breakdown into human readable HUD strings.
+export function formatDamageSummary(metadata: Record<string, string>): string[] {
+  const breakdown = extractDamageBreakdown(metadata);
+  if (breakdown.length === 0) {
+    return [];
+  }
+  const total = metadata["damage_total"] ?? "0";
+  const header = `Total ${total}`;
+  const lines = breakdown.map((entry) => `${entry.source.toUpperCase()} ${entry.amount.toFixed(2)}`);
+  lines.unshift(header);
+  if (metadata["damage_instant_kill"] === "true") {
+    lines.push("INSTANT KILL");
+  }
+  return lines;
+}


### PR DESCRIPTION
## Summary
- add a dedicated combat damage resolver that supports direct, splash, and terrain collision calculations while exporting HUD metadata and logging fields
- surface instant kill detection on telemetry metadata so combat events expose source totals to clients
- extend the TypeScript HUD helpers to render the damage breakdown and wire the new test into the project script

## Testing
- go test ./...
- npm test --prefix typescript-client

------
https://chatgpt.com/codex/tasks/task_e_68df30c7edb0832982ced16acae588ae