### PR TITLE
Implement loadout-aware radar scanning and HUD tracking

### DIFF
--- a/go-broker/internal/gameplay/config_test.go
+++ b/go-broker/internal/gameplay/config_test.go
@@ -73,4 +73,15 @@ func TestSkiffLoadoutsExposeSelectableCatalog(t *testing.T) {
 	if id := DefaultSkiffLoadoutID(); id != "skiff-strike" {
 		t.Fatalf("unexpected default loadout %q", id)
 	}
+
+	//5.- Radar range helper must respect the tuning window per loadout configuration.
+	if rng := LoadoutRadarRange("skiff-raider"); rng != 900 {
+		t.Fatalf("unexpected raider radar range %.2f", rng)
+	}
+	if rng := LoadoutRadarRange("skiff-strike"); rng != 720 {
+		t.Fatalf("unexpected strike radar range %.2f", rng)
+	}
+	if rng := LoadoutRadarRange("unknown"); rng != 600 {
+		t.Fatalf("unknown loadout should fall back to minimum range, got %.2f", rng)
+	}
 }

--- a/go-broker/internal/gameplay/loadouts.go
+++ b/go-broker/internal/gameplay/loadouts.go
@@ -30,6 +30,7 @@ type VehicleLoadoutConfig struct {
 	Selectable       bool             `json:"selectable"`
 	Weapons          []WeaponConfig   `json:"weapons"`
 	PassiveModifiers PassiveModifiers `json:"passiveModifiers"`
+	RadarRangeMeters float64          `json:"radarRangeMeters"`
 }
 
 type skiffLoadoutFile struct {
@@ -118,6 +119,33 @@ func LoadoutDamageMultiplier(loadoutID string) float64 {
 		}
 	}
 	return 1
+}
+
+// LoadoutRadarRange returns the tuned radar detection radius for the requested loadout.
+func LoadoutRadarRange(loadoutID string) float64 {
+	const (
+		minimumRange = 600.0
+		maximumRange = 900.0
+	)
+	//1.- Clamp the configured range to the supported envelope so gameplay tuning remains safe.
+	clamp := func(value float64) float64 {
+		if value < minimumRange {
+			return minimumRange
+		}
+		if value > maximumRange {
+			return maximumRange
+		}
+		return value
+	}
+	for _, loadout := range SkiffLoadouts() {
+		if loadout.ID == loadoutID {
+			if loadout.RadarRangeMeters > 0 {
+				return clamp(loadout.RadarRangeMeters)
+			}
+			break
+		}
+	}
+	return minimumRange
 }
 
 // DefaultSkiffLoadoutID returns the first selectable loadout identifier.

--- a/go-broker/internal/gameplay/skiff_loadouts.json
+++ b/go-broker/internal/gameplay/skiff_loadouts.json
@@ -15,7 +15,8 @@
         "agilityMultiplier": 1.0,
         "damageMultiplier": 1.0,
         "boostCooldownScale": 1.0
-      }
+      },
+      "radarRangeMeters": 720
     },
     {
       "id": "skiff-raider",
@@ -32,7 +33,8 @@
         "agilityMultiplier": 0.85,
         "damageMultiplier": 0.9,
         "boostCooldownScale": 0.85
-      }
+      },
+      "radarRangeMeters": 900
     },
     {
       "id": "skiff-tank",
@@ -49,7 +51,8 @@
         "agilityMultiplier": 0.8,
         "damageMultiplier": 1.25,
         "boostCooldownScale": 1.15
-      }
+      },
+      "radarRangeMeters": 600
     }
   ]
 }

--- a/go-broker/internal/radar/scanner.go
+++ b/go-broker/internal/radar/scanner.go
@@ -1,0 +1,367 @@
+package radar
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"driftpursuit/broker/internal/gameplay"
+	pb "driftpursuit/broker/internal/proto/pb"
+	"driftpursuit/broker/internal/simulation"
+)
+
+const (
+	defaultScanFrequencyHz = 4.0
+	defaultFrameSchema     = "radar.v1"
+)
+
+// vehicleSource exposes the subset of vehicle store behaviour needed by the scanner.
+type vehicleSource interface {
+	Snapshot() []*pb.VehicleState
+	LoadoutFor(vehicleID string) string
+}
+
+// Options configure how the scanner samples the authoritative world state.
+type Options struct {
+	Vehicles     vehicleSource
+	Field        simulation.SignedDistanceField
+	Handler      func(*pb.RadarFrame)
+	Interval     time.Duration
+	LastKnownTTL time.Duration
+	Now          func() time.Time
+}
+
+type trackedContact struct {
+	entry  *pb.RadarContactEntry
+	seenAt time.Time
+}
+
+// Scanner periodically sweeps the vehicle roster and emits synthetic radar frames.
+type Scanner struct {
+	mu           sync.Mutex
+	vehicles     vehicleSource
+	field        simulation.SignedDistanceField
+	handler      func(*pb.RadarFrame)
+	interval     time.Duration
+	lastKnownTTL time.Duration
+	now          func() time.Time
+	frameID      uint64
+	lastContacts map[string]map[string]*trackedContact
+	cancel       context.CancelFunc
+	running      bool
+	done         chan struct{}
+}
+
+// NewScanner wires the radar sweep pipeline using the provided configuration.
+func NewScanner(opts Options) *Scanner {
+	interval := opts.Interval
+	if interval <= 0 {
+		//1.- Convert the desired frequency into a tick interval while guarding against zero.
+		interval = time.Duration(float64(time.Second) / defaultScanFrequencyHz)
+		if interval <= 0 {
+			interval = time.Second / 4
+		}
+	}
+	ttl := opts.LastKnownTTL
+	if ttl <= 0 {
+		//2.- Retain stale contacts for a short window so HUDs can present last known tracks.
+		ttl = 6 * time.Second
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	handler := opts.Handler
+	if handler == nil {
+		handler = func(*pb.RadarFrame) {}
+	}
+	return &Scanner{
+		vehicles:     opts.Vehicles,
+		field:        opts.Field,
+		handler:      handler,
+		interval:     interval,
+		lastKnownTTL: ttl,
+		now:          now,
+		lastContacts: make(map[string]map[string]*trackedContact),
+	}
+}
+
+// Start begins ticking radar sweeps until the context is cancelled or Stop is invoked.
+func (s *Scanner) Start(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ticker := time.NewTicker(s.interval)
+	derived, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	s.cancel = cancel
+	s.done = done
+	s.running = true
+	s.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-derived.Done():
+				return
+			case <-ticker.C:
+				//1.- Perform a sweep on every tick to honour the 4 Hz cadence.
+				s.sweep()
+			}
+		}
+	}()
+}
+
+// Stop cancels the radar sweep loop and waits for the worker to exit.
+func (s *Scanner) Stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.cancel
+	done := s.done
+	s.cancel = nil
+	s.done = nil
+	s.running = false
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (s *Scanner) sweep() {
+	frame := s.buildFrame()
+	if frame != nil {
+		s.handler(frame)
+	}
+}
+
+func (s *Scanner) buildFrame() *pb.RadarFrame {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.vehicles == nil {
+		return nil
+	}
+
+	now := s.now()
+	states := s.vehicles.Snapshot()
+	if len(states) == 0 {
+		//1.- Purge stale contacts when no observers are present in the world snapshot.
+		s.pruneExpiredLocked(now)
+		return nil
+	}
+
+	contacts := make([]*pb.RadarContact, 0, len(states))
+	for _, observer := range states {
+		if observer == nil || observer.VehicleId == "" || observer.GetPosition() == nil {
+			continue
+		}
+		entries := s.collectEntriesLocked(observer, states, now)
+		if len(entries) == 0 {
+			continue
+		}
+		contact := &pb.RadarContact{
+			SchemaVersion:  defaultFrameSchema,
+			SourceEntityId: observer.VehicleId,
+			Entries:        entries,
+		}
+		contacts = append(contacts, contact)
+	}
+
+	if len(contacts) == 0 {
+		s.pruneExpiredLocked(now)
+		return nil
+	}
+
+	s.frameID++
+	frame := &pb.RadarFrame{
+		SchemaVersion: defaultFrameSchema,
+		FrameId:       s.frameID,
+		CapturedAtMs:  now.UTC().UnixMilli(),
+		Contacts:      contacts,
+	}
+	//2.- Trim any contact memory that exceeded the retention budget after building the frame.
+	s.pruneExpiredLocked(now)
+	return frame
+}
+
+func (s *Scanner) collectEntriesLocked(observer *pb.VehicleState, states []*pb.VehicleState, now time.Time) []*pb.RadarContactEntry {
+	observerID := observer.GetVehicleId()
+	if observerID == "" {
+		return nil
+	}
+	tracked := s.ensureTrackerLocked(observerID)
+	rangeMeters := gameplay.LoadoutRadarRange(s.vehicles.LoadoutFor(observerID))
+	origin := toVec3(observer.GetPosition())
+	entries := make([]*pb.RadarContactEntry, 0)
+	touched := make(map[string]struct{})
+
+	for _, target := range states {
+		if target == nil || target.GetVehicleId() == "" {
+			continue
+		}
+		if target.GetVehicleId() == observerID {
+			continue
+		}
+		position := target.GetPosition()
+		if position == nil {
+			continue
+		}
+		delta := toVec3(position).Sub(origin)
+		distance := delta.Length()
+		if distance <= rangeMeters && !s.isOccluded(origin, toVec3(position), distance) {
+			//1.- Track a freshly visible contact with maximum confidence.
+			entry := s.buildLiveEntry(target)
+			entries = append(entries, entry)
+			tracked[target.GetVehicleId()] = &trackedContact{entry: cloneRadarEntry(entry), seenAt: now}
+			touched[target.GetVehicleId()] = struct{}{}
+			continue
+		}
+		if contact := tracked[target.GetVehicleId()]; contact != nil {
+			if now.Sub(contact.seenAt) > s.lastKnownTTL {
+				continue
+			}
+			//2.- Surface the cached last known state flagged as occluded or out of range.
+			entry := cloneRadarEntry(contact.entry)
+			if entry == nil {
+				continue
+			}
+			entry.Occluded = true
+			entry.Confidence = s.confidenceForAge(now.Sub(contact.seenAt))
+			entries = append(entries, entry)
+			touched[target.GetVehicleId()] = struct{}{}
+		}
+	}
+
+	for targetID, contact := range tracked {
+		if _, ok := touched[targetID]; ok {
+			continue
+		}
+		if now.Sub(contact.seenAt) > s.lastKnownTTL {
+			delete(tracked, targetID)
+			continue
+		}
+		//3.- Preserve dormant contacts so HUDs can retain situational awareness overlays.
+		entry := cloneRadarEntry(contact.entry)
+		if entry == nil {
+			continue
+		}
+		entry.Occluded = true
+		entry.Confidence = s.confidenceForAge(now.Sub(contact.seenAt))
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+func (s *Scanner) ensureTrackerLocked(observerID string) map[string]*trackedContact {
+	tracker, ok := s.lastContacts[observerID]
+	if !ok {
+		tracker = make(map[string]*trackedContact)
+		s.lastContacts[observerID] = tracker
+	}
+	return tracker
+}
+
+func (s *Scanner) pruneExpiredLocked(now time.Time) {
+	ttl := s.lastKnownTTL
+	for observer, tracker := range s.lastContacts {
+		for target, contact := range tracker {
+			if contact == nil {
+				delete(tracker, target)
+				continue
+			}
+			if now.Sub(contact.seenAt) > ttl {
+				delete(tracker, target)
+			}
+		}
+		if len(tracker) == 0 {
+			delete(s.lastContacts, observer)
+		}
+	}
+}
+
+func (s *Scanner) confidenceForAge(age time.Duration) float64 {
+	ttl := s.lastKnownTTL
+	if ttl <= 0 {
+		return 0
+	}
+	ratio := 1 - age.Seconds()/ttl.Seconds()
+	if ratio <= 0 {
+		return 0.1
+	}
+	return math.Max(0.1, ratio)
+}
+
+func (s *Scanner) buildLiveEntry(target *pb.VehicleState) *pb.RadarContactEntry {
+	//1.- Clone position and velocity vectors to avoid aliasing shared protobuf instances.
+	var position *pb.Vector3
+	if target.GetPosition() != nil {
+		position = &pb.Vector3{X: target.GetPosition().GetX(), Y: target.GetPosition().GetY(), Z: target.GetPosition().GetZ()}
+	}
+	var velocity *pb.Vector3
+	if target.GetVelocity() != nil {
+		velocity = &pb.Vector3{X: target.GetVelocity().GetX(), Y: target.GetVelocity().GetY(), Z: target.GetVelocity().GetZ()}
+	}
+	return &pb.RadarContactEntry{
+		TargetEntityId: target.GetVehicleId(),
+		Position:       position,
+		Velocity:       velocity,
+		Confidence:     1,
+		Occluded:       false,
+		SuggestedTier:  pb.InterestTier_INTEREST_TIER_RADAR,
+	}
+}
+
+func (s *Scanner) isOccluded(origin, target simulation.Vec3, distance float64) bool {
+	if s.field == nil {
+		return false
+	}
+	hit, hitDistance, _ := simulation.Raycast(s.field, origin, target.Sub(origin), distance, 64, 0.25)
+	if !hit {
+		return false
+	}
+	//1.- Treat any intersection before the target range as an occluder.
+	return hitDistance < distance-0.25
+}
+
+func toVec3(v *pb.Vector3) simulation.Vec3 {
+	if v == nil {
+		return simulation.Vec3{}
+	}
+	return simulation.Vec3{X: v.GetX(), Y: v.GetY(), Z: v.GetZ()}
+}
+
+func cloneRadarEntry(entry *pb.RadarContactEntry) *pb.RadarContactEntry {
+	if entry == nil {
+		return nil
+	}
+	clone := &pb.RadarContactEntry{
+		TargetEntityId: entry.GetTargetEntityId(),
+		Confidence:     entry.GetConfidence(),
+		Occluded:       entry.GetOccluded(),
+		SuggestedTier:  entry.GetSuggestedTier(),
+	}
+	if entry.GetPosition() != nil {
+		clone.Position = &pb.Vector3{X: entry.GetPosition().GetX(), Y: entry.GetPosition().GetY(), Z: entry.GetPosition().GetZ()}
+	}
+	if entry.GetVelocity() != nil {
+		clone.Velocity = &pb.Vector3{X: entry.GetVelocity().GetX(), Y: entry.GetVelocity().GetY(), Z: entry.GetVelocity().GetZ()}
+	}
+	return clone
+}

--- a/go-broker/internal/radar/scanner_test.go
+++ b/go-broker/internal/radar/scanner_test.go
@@ -1,0 +1,193 @@
+package radar
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	pb "driftpursuit/broker/internal/proto/pb"
+	"driftpursuit/broker/internal/simulation"
+)
+
+type stubVehicles struct {
+	mu       sync.Mutex
+	states   []*pb.VehicleState
+	loadouts map[string]string
+}
+
+func (s *stubVehicles) Snapshot() []*pb.VehicleState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	//1.- Clone the stored states to emulate the production vehicle store behaviour.
+	clones := make([]*pb.VehicleState, 0, len(s.states))
+	for _, state := range s.states {
+		if state == nil {
+			continue
+		}
+		clones = append(clones, protoClone(state))
+	}
+	return clones
+}
+
+func (s *stubVehicles) LoadoutFor(vehicleID string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.loadouts == nil {
+		return ""
+	}
+	return s.loadouts[vehicleID]
+}
+
+func protoClone(state *pb.VehicleState) *pb.VehicleState {
+	if state == nil {
+		return nil
+	}
+	//1.- Copy scalar fields and duplicate the nested vectors that the scanner reads.
+	clone := *state
+	if state.Position != nil {
+		clone.Position = &pb.Vector3{X: state.Position.X, Y: state.Position.Y, Z: state.Position.Z}
+	}
+	if state.Velocity != nil {
+		clone.Velocity = &pb.Vector3{X: state.Velocity.X, Y: state.Velocity.Y, Z: state.Velocity.Z}
+	}
+	return &clone
+}
+
+func TestScannerEmitsVisibleContacts(t *testing.T) {
+	//1.- Seed a simple world with an observer and target inside the configured radar range.
+	vehicles := &stubVehicles{
+		states: []*pb.VehicleState{
+			{VehicleId: "observer", Position: &pb.Vector3{X: 0, Y: 0, Z: 0}},
+			{VehicleId: "target", Position: &pb.Vector3{X: 500, Y: 0, Z: 0}},
+		},
+		loadouts: map[string]string{"observer": "skiff-raider"},
+	}
+
+	var frames []*pb.RadarFrame
+	//2.- Capture emitted frames so assertions can inspect the synthetic contacts.
+	scanner := NewScanner(Options{Vehicles: vehicles, Handler: func(frame *pb.RadarFrame) {
+		frames = append(frames, frame)
+	}, Now: func() time.Time { return time.UnixMilli(0) }})
+
+	scanner.sweep()
+
+	if len(frames) != 1 {
+		t.Fatalf("expected one frame, got %d", len(frames))
+	}
+	var observerContact *pb.RadarContact
+	for _, contact := range frames[0].GetContacts() {
+		if contact.GetSourceEntityId() == "observer" {
+			observerContact = contact
+			break
+		}
+	}
+	if observerContact == nil {
+		t.Fatalf("expected observer contact bundle")
+	}
+	if len(observerContact.GetEntries()) != 1 {
+		t.Fatalf("expected single entry for observer, got %d", len(observerContact.GetEntries()))
+	}
+	entry := observerContact.GetEntries()[0]
+	if entry.GetTargetEntityId() != "target" {
+		t.Fatalf("unexpected target id %q", entry.GetTargetEntityId())
+	}
+	if entry.GetOccluded() {
+		t.Fatalf("visible contact should not be occluded")
+	}
+	if entry.GetConfidence() != 1 {
+		t.Fatalf("expected full confidence, got %.2f", entry.GetConfidence())
+	}
+}
+
+func TestScannerMaintainsLastKnownWhenOccluded(t *testing.T) {
+	now := time.UnixMilli(0)
+	//1.- Start with the target visible so the scanner records an initial last known position.
+	vehicles := &stubVehicles{
+		states: []*pb.VehicleState{
+			{VehicleId: "observer", Position: &pb.Vector3{X: 0, Y: 0, Z: 0}},
+			{VehicleId: "target", Position: &pb.Vector3{X: 500, Y: 0, Z: 0}},
+		},
+		loadouts: map[string]string{"observer": "skiff-strike"},
+	}
+	var frames []*pb.RadarFrame
+	field := simulation.SphereField{Center: simulation.Vec3{X: 250, Y: 0, Z: 0}, Radius: 25}
+	//2.- Inject an occluding SDF on the second sweep to force reliance on the cached contact.
+	scanner := NewScanner(Options{Vehicles: vehicles, Handler: func(frame *pb.RadarFrame) {
+		frames = append(frames, frame)
+	}, Now: func() time.Time { return now }})
+
+	scanner.sweep()
+	if len(frames) == 0 {
+		t.Fatalf("expected initial frame")
+	}
+	frames = frames[:0]
+
+	now = now.Add(250 * time.Millisecond)
+	scanner.field = field
+	scanner.sweep()
+
+	if len(frames) != 1 {
+		t.Fatalf("expected occluded frame, got %d", len(frames))
+	}
+	var occludedEntry *pb.RadarContactEntry
+	for _, contact := range frames[0].GetContacts() {
+		if contact.GetSourceEntityId() != "observer" {
+			continue
+		}
+		if len(contact.GetEntries()) == 0 {
+			continue
+		}
+		occludedEntry = contact.GetEntries()[0]
+		break
+	}
+	if occludedEntry == nil {
+		t.Fatalf("expected occluded entry for observer")
+	}
+	if !occludedEntry.GetOccluded() {
+		t.Fatalf("expected occluded flag to be set")
+	}
+	if occludedEntry.GetConfidence() >= 1 {
+		t.Fatalf("expected degraded confidence, got %.2f", occludedEntry.GetConfidence())
+	}
+	if occludedEntry.GetPosition().GetX() != 500 {
+		t.Fatalf("last known position should be retained, got %.2f", occludedEntry.GetPosition().GetX())
+	}
+}
+
+func TestScannerExpiresDormantContacts(t *testing.T) {
+	now := time.UnixMilli(0)
+	//1.- Configure the scanner with a short retention window to simplify the expiry check.
+	vehicles := &stubVehicles{
+		states: []*pb.VehicleState{
+			{VehicleId: "observer", Position: &pb.Vector3{X: 0, Y: 0, Z: 0}},
+			{VehicleId: "target", Position: &pb.Vector3{X: 500, Y: 0, Z: 0}},
+		},
+		loadouts: map[string]string{"observer": "skiff-strike"},
+	}
+	field := simulation.SphereField{Center: simulation.Vec3{X: 250, Y: 0, Z: 0}, Radius: 25}
+	var frames []*pb.RadarFrame
+	scanner := NewScanner(Options{Vehicles: vehicles, Handler: func(frame *pb.RadarFrame) {
+		frames = append(frames, frame)
+	}, LastKnownTTL: 500 * time.Millisecond, Now: func() time.Time { return now }})
+
+	scanner.sweep()
+	frames = frames[:0]
+
+	now = now.Add(100 * time.Millisecond)
+	scanner.field = field
+	scanner.sweep()
+	if len(frames) != 1 {
+		t.Fatalf("expected occluded frame before expiry")
+	}
+	frames = frames[:0]
+
+	now = now.Add(time.Second)
+	vehicles.mu.Lock()
+	vehicles.states = vehicles.states[:1]
+	vehicles.mu.Unlock()
+	scanner.sweep()
+
+	if len(frames) != 0 {
+		t.Fatalf("expected no frames after last known expiry, got %d", len(frames))
+	}
+}

--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts && ts-node src/hud/damageFeed.test.ts"
+    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts && ts-node src/hud/damageFeed.test.ts && ts-node src/hud/radarContacts.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/typescript-client/src/hud/radarContacts.test.ts
+++ b/typescript-client/src/hud/radarContacts.test.ts
@@ -1,0 +1,75 @@
+import { RadarContactTracker } from "./radarContacts";
+
+function vector(x: number, y: number, z: number) {
+  return { x, y, z };
+}
+
+function expect(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+//1.- Visible contacts should be surfaced immediately with full fidelity.
+const tracker = new RadarContactTracker(500);
+tracker.ingest(
+  {
+    sourceEntityId: "observer",
+    entries: [
+      {
+        targetEntityId: "target",
+        position: vector(100, 0, 0),
+        velocity: vector(10, 0, 0),
+        confidence: 1,
+        occluded: false,
+      },
+    ],
+  },
+  0,
+);
+let snapshot = tracker.snapshot(0);
+expect(snapshot.visible.length === 1, "expected one visible contact");
+expect(snapshot.lastKnown.length === 0, "expected no last known contacts yet");
+expect(snapshot.visible[0].position?.x === 100, "expected position to match last ping");
+
+//2.- When the contact becomes occluded the tracker should retain the last known data.
+tracker.ingest(
+  {
+    sourceEntityId: "observer",
+    entries: [
+      {
+        targetEntityId: "target",
+        occluded: true,
+        confidence: 0.5,
+      },
+    ],
+  },
+  100,
+);
+snapshot = tracker.snapshot(200);
+expect(snapshot.visible.length === 0, "expected contact to move into last known bucket");
+expect(snapshot.lastKnown.length === 1, "expected retained last known contact");
+expect(snapshot.lastKnown[0].position?.x === 100, "expected last known position to remain frozen");
+expect(snapshot.lastKnown[0].confidence === 0.5, "expected occlusion confidence to match payload");
+
+//3.- Contacts should expire after the retention window to avoid stale HUD markers.
+snapshot = tracker.snapshot(600);
+expect(snapshot.lastKnown.length === 0, "expected last known contact to expire after retention");
+
+//4.- Occluded contacts without prior visibility should be ignored.
+tracker.ingest(
+  {
+    sourceEntityId: "observer",
+    entries: [
+      {
+        targetEntityId: "ghost",
+        occluded: true,
+      },
+    ],
+  },
+  700,
+);
+snapshot = tracker.snapshot(700);
+expect(snapshot.visible.length === 0, "occluded ghost should not create visible contact");
+expect(snapshot.lastKnown.length === 0, "occluded ghost should not create last known contact");
+

--- a/typescript-client/src/hud/radarContacts.ts
+++ b/typescript-client/src/hud/radarContacts.ts
@@ -1,0 +1,171 @@
+export interface RadarVector {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export interface RadarContactEntryPayload {
+  readonly targetEntityId: string;
+  readonly position?: RadarVector;
+  readonly velocity?: RadarVector;
+  readonly confidence?: number;
+  readonly occluded?: boolean;
+}
+
+export interface RadarContactPayload {
+  readonly sourceEntityId?: string;
+  readonly entries?: RadarContactEntryPayload[];
+}
+
+export interface HudRadarContact {
+  readonly id: string;
+  readonly source: string;
+  readonly occluded: boolean;
+  readonly confidence: number;
+  readonly lastSeenMs: number;
+  readonly ageMs: number;
+  readonly position?: RadarVector;
+  readonly velocity?: RadarVector;
+}
+
+export interface HudRadarSnapshot {
+  readonly visible: HudRadarContact[];
+  readonly lastKnown: HudRadarContact[];
+}
+
+interface TrackedContact {
+  readonly id: string;
+  readonly source: string;
+  position?: RadarVector;
+  velocity?: RadarVector;
+  confidence: number;
+  occluded: boolean;
+  lastSeenMs: number;
+  updatedMs: number;
+}
+
+function makeKey(source: string, target: string): string {
+  return `${source}:${target}`;
+}
+
+function cloneVector(vector?: RadarVector): RadarVector | undefined {
+  if (!vector) {
+    return undefined;
+  }
+  return { x: vector.x, y: vector.y, z: vector.z };
+}
+
+export class RadarContactTracker {
+  private readonly contacts = new Map<string, TrackedContact>();
+
+  constructor(private readonly retentionMs: number = 6000) {}
+
+  ingest(contact: RadarContactPayload | undefined, timestampMs: number): void {
+    if (!contact || !contact.entries || contact.entries.length === 0) {
+      return;
+    }
+    const source = contact.sourceEntityId ?? "unknown";
+    //1.- Normalise each entry and refresh the tracking map in-place.
+    for (const entry of contact.entries) {
+      if (!entry || !entry.targetEntityId) {
+        continue;
+      }
+      const key = makeKey(source, entry.targetEntityId);
+      const tracked = this.contacts.get(key);
+      const occluded = entry.occluded === true;
+      if (!tracked) {
+        if (occluded && !entry.position) {
+          //2.- Ignore occluded entries without a last known state to avoid fabricating targets.
+          continue;
+        }
+        this.contacts.set(key, {
+          id: entry.targetEntityId,
+          source,
+          position: cloneVector(entry.position),
+          velocity: cloneVector(entry.velocity),
+          confidence: entry.confidence ?? 1,
+          occluded,
+          lastSeenMs: timestampMs,
+          updatedMs: timestampMs,
+        });
+        continue;
+      }
+      if (!occluded && entry.position) {
+        //3.- Visible updates refresh the last known kinematics immediately.
+        tracked.position = cloneVector(entry.position);
+      }
+      if (!occluded && entry.velocity) {
+        tracked.velocity = cloneVector(entry.velocity);
+      }
+      if (!occluded) {
+        tracked.lastSeenMs = timestampMs;
+      }
+      tracked.occluded = occluded;
+      tracked.updatedMs = timestampMs;
+      if (typeof entry.confidence === "number") {
+        tracked.confidence = entry.confidence;
+      } else if (occluded) {
+        //4.- Estimate confidence decay when the server omits an explicit value.
+        tracked.confidence = this.estimateConfidence(tracked, timestampMs);
+      } else {
+        tracked.confidence = 1;
+      }
+    }
+    this.expire(timestampMs);
+  }
+
+  snapshot(nowMs: number): HudRadarSnapshot {
+    this.expire(nowMs);
+    const visible: HudRadarContact[] = [];
+    const lastKnown: HudRadarContact[] = [];
+    //5.- Materialise deterministic HUD datasets so widgets can render stable ordering.
+    for (const tracked of this.contacts.values()) {
+      const contact: HudRadarContact = {
+        id: tracked.id,
+        source: tracked.source,
+        occluded: tracked.occluded,
+        confidence: tracked.confidence,
+        lastSeenMs: tracked.lastSeenMs,
+        ageMs: Math.max(0, nowMs - tracked.lastSeenMs),
+        position: cloneVector(tracked.position),
+        velocity: cloneVector(tracked.velocity),
+      };
+      if (tracked.occluded) {
+        lastKnown.push(contact);
+      } else {
+        visible.push(contact);
+      }
+    }
+    visible.sort((a, b) => a.id.localeCompare(b.id));
+    lastKnown.sort((a, b) => a.id.localeCompare(b.id));
+    return { visible, lastKnown };
+  }
+
+  private estimateConfidence(tracked: TrackedContact, nowMs: number): number {
+    if (this.retentionMs <= 0) {
+      return 0.1;
+    }
+    const elapsed = nowMs - tracked.lastSeenMs;
+    if (elapsed <= 0) {
+      return Math.max(tracked.confidence, 0.1);
+    }
+    const ratio = 1 - elapsed / this.retentionMs;
+    if (ratio <= 0) {
+      return 0.1;
+    }
+    return Math.max(0.1, Math.min(1, ratio));
+  }
+
+  private expire(nowMs: number): void {
+    if (this.retentionMs <= 0) {
+      return;
+    }
+    for (const [key, tracked] of this.contacts.entries()) {
+      if (nowMs - tracked.updatedMs >= this.retentionMs) {
+        //6.- Drop stale contacts once they exceed the retention window to avoid ghost blips.
+        this.contacts.delete(key);
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add per-loadout radar range configuration and helper
- introduce a 4 Hz radar scanner with occlusion-aware last known tracking and broker integration
- extend the HUD client with radar contact tracking utilities and tests

## Testing
- go test ./...
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df347550408329a2f7245acfdc0a31