### PR TITLE
Add responsive chase camera and director behaviours

### DIFF
--- a/tunnelcave_sandbox_web/src/camera/cameraDirector.test.ts
+++ b/tunnelcave_sandbox_web/src/camera/cameraDirector.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CountdownSpectatorCamera, CameraRig } from './countdownSpectator'
+import { CameraDirector } from './cameraDirector'
+import { ChaseCameraController, ChaseCameraRuntimeOptions, VehicleTransform } from './chaseCamera'
+
+function createSpectatorCamera() {
+  const rig: CameraRig = {
+    //1.- No-op rig methods because the countdown camera handles its own math in tests.
+    setPosition: vi.fn(),
+    lookAt: vi.fn(),
+  }
+  const focus = { x: 0, y: 0, z: 0 }
+  const camera = new CountdownSpectatorCamera(rig, {
+    orbitRadius: 5,
+    orbitHeight: 2,
+    rotationSpeed: Math.PI,
+    focus,
+  })
+  const update = vi.spyOn(camera, 'update')
+  return { camera, update }
+}
+
+function createChaseCameraStub() {
+  const update = vi.fn()
+  const trigger = vi.fn()
+  const stub: ChaseCameraController = {
+    //1.- Defer to spies so tests can ensure the director delegates correctly.
+    update: update.mockImplementation(() => {}),
+    //2.- Defer to spies so tests can ensure the director forwards events.
+    trigger: trigger.mockImplementation(() => {}),
+  }
+  return { stub, update, trigger }
+}
+
+describe('CameraDirector', () => {
+  const vehicle: VehicleTransform = {
+    position: { x: 1, y: 0, z: 0 },
+    forward: { x: 0, y: 0, z: 1 },
+  }
+
+  it('delegates chase updates when following a vehicle', () => {
+    const { stub, update } = createChaseCameraStub()
+    const { camera } = createSpectatorCamera()
+    const director = new CameraDirector(stub, camera, {
+      respawn: { duration: 1, overrides: {} },
+    })
+
+    director.follow(vehicle)
+    director.update(0.016)
+
+    expect(update).toHaveBeenCalledWith(0.016, vehicle, {})
+  })
+
+  it('uses respawn overrides for the configured duration', () => {
+    const { stub, update } = createChaseCameraStub()
+    const { camera } = createSpectatorCamera()
+    const overrides: Partial<ChaseCameraRuntimeOptions> = {
+      offsets: {
+        position: { x: 0, y: 8, z: -10 },
+        lookAt: { x: 0, y: 2, z: 6 },
+      },
+    }
+    const director = new CameraDirector(stub, camera, {
+      respawn: { duration: 0.5, overrides },
+    })
+
+    director.follow(vehicle)
+    director.startRespawn()
+    //1.- Step twice to deplete the respawn timer.
+    director.update(0.25)
+    director.update(0.25)
+
+    expect(update).toHaveBeenCalledWith(0.25, vehicle, overrides)
+    expect(update).toHaveBeenLastCalledWith(0.25, vehicle, {})
+  })
+
+  it('drives the spectator camera during countdowns', () => {
+    const { stub } = createChaseCameraStub()
+    const { camera, update: spectatorUpdate } = createSpectatorCamera()
+    const director = new CameraDirector(stub, camera, {
+      respawn: { duration: 1, overrides: {} },
+    })
+
+    director.enterSpectator(3)
+    director.update(0.5)
+
+    expect(spectatorUpdate).toHaveBeenCalledWith(0.5, 3)
+  })
+
+  it('forwards combat events to the chase camera for FX handling', () => {
+    const { stub, trigger } = createChaseCameraStub()
+    const { camera } = createSpectatorCamera()
+    const director = new CameraDirector(stub, camera, {
+      respawn: { duration: 1, overrides: {} },
+    })
+
+    director.trigger('boost')
+
+    expect(trigger).toHaveBeenCalledWith('boost')
+  })
+})

--- a/tunnelcave_sandbox_web/src/camera/cameraDirector.ts
+++ b/tunnelcave_sandbox_web/src/camera/cameraDirector.ts
@@ -1,0 +1,92 @@
+import { CountdownSpectatorCamera } from './countdownSpectator'
+import {
+  ChaseCameraController,
+  ChaseCameraRuntimeOptions,
+  ChaseCameraEvent,
+  VehicleTransform,
+} from './chaseCamera'
+
+export type CameraMode = 'idle' | 'chase' | 'spectator' | 'respawn'
+
+export interface RespawnCameraProfile {
+  //1.- Overrides tweak the chase camera while the respawn transition plays.
+  overrides: Partial<ChaseCameraRuntimeOptions>
+  //2.- Duration specifies how long the respawn blend should last.
+  duration: number
+}
+
+export interface CameraDirectorOptions {
+  //1.- Respawn behavior customizes offsets and damping during recovery.
+  respawn: RespawnCameraProfile
+}
+
+export class CameraDirector {
+  private mode: CameraMode = 'idle'
+  private vehicle: VehicleTransform | undefined
+  private respawnTimer = 0
+  private spectatorCountdown = 0
+
+  constructor(
+    private readonly chaseCamera: ChaseCameraController,
+    private readonly spectatorCamera: CountdownSpectatorCamera,
+    private readonly options: CameraDirectorOptions,
+  ) {}
+
+  follow(transform: VehicleTransform): void {
+    //1.- Update the transform reference so chase updates always have fresh data.
+    this.vehicle = transform
+    if (this.mode === 'idle') {
+      this.mode = 'chase'
+    }
+  }
+
+  enterSpectator(countdownSeconds: number): void {
+    //1.- Switch into spectator mode and seed the remaining countdown.
+    this.mode = 'spectator'
+    this.spectatorCountdown = countdownSeconds
+  }
+
+  startRespawn(): void {
+    //1.- Begin the respawn transition and preload the timer from config.
+    this.mode = 'respawn'
+    this.respawnTimer = this.options.respawn.duration
+  }
+
+  trigger(event: ChaseCameraEvent): void {
+    //1.- Forward gameplay events to the chase camera so shake/FX still occur.
+    this.chaseCamera.trigger(event)
+  }
+
+  update(deltaSeconds: number): void {
+    switch (this.mode) {
+      case 'spectator':
+        //1.- Drive the orbiting spectator camera until the countdown ends.
+        this.spectatorCamera.update(deltaSeconds, this.spectatorCountdown)
+        this.spectatorCountdown = Math.max(0, this.spectatorCountdown - deltaSeconds)
+        break
+      case 'respawn':
+        //1.- Blend back to gameplay using the respawn overrides for a brief period.
+        this.respawnTimer = Math.max(0, this.respawnTimer - deltaSeconds)
+        const overrides = this.respawnTimer > 0 ? this.options.respawn.overrides : {}
+        this.updateChase(deltaSeconds, overrides)
+        if (this.respawnTimer <= 0) {
+          this.mode = 'chase'
+        }
+        break
+      case 'chase':
+        //1.- Maintain the standard chase behavior for active gameplay.
+        this.updateChase(deltaSeconds)
+        break
+      default:
+        //1.- Remain idle until a vehicle is assigned.
+        break
+    }
+  }
+
+  private updateChase(deltaSeconds: number, overrides: Partial<ChaseCameraRuntimeOptions> = {}): void {
+    if (!this.vehicle) {
+      return
+    }
+    this.chaseCamera.update(deltaSeconds, this.vehicle, overrides)
+  }
+}

--- a/tunnelcave_sandbox_web/src/camera/chaseCamera.test.ts
+++ b/tunnelcave_sandbox_web/src/camera/chaseCamera.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CameraRig, Vector3 } from './countdownSpectator'
+import {
+  CameraFxPlayer,
+  ChaseCamera,
+  ChaseCameraOptions,
+  ChaseCameraRuntimeOptions,
+  VehicleTransform,
+} from './chaseCamera'
+
+function createRig(): { rig: CameraRig; positions: Vector3[]; lookAts: Vector3[] } {
+  const positions: Vector3[] = []
+  const lookAts: Vector3[] = []
+  return {
+    rig: {
+      //1.- Capture the latest camera position for assertions.
+      setPosition(position: Vector3) {
+        positions.push(position)
+      },
+      //2.- Capture the latest look-at vector for assertions.
+      lookAt(target: Vector3) {
+        lookAts.push(target)
+      },
+    },
+    positions,
+    lookAts,
+  }
+}
+
+function createFxPlayer() {
+  const playVisualFx = vi.fn()
+  const playAudioFx = vi.fn()
+  const player: CameraFxPlayer = {
+    //1.- Forward calls to Vitest spies so we can validate invocations.
+    playVisualFx: playVisualFx.mockImplementation(() => {}),
+    //2.- Forward calls to Vitest spies so we can validate invocations.
+    playAudioFx: playAudioFx.mockImplementation(() => {}),
+  }
+  return { player, playVisualFx, playAudioFx }
+}
+
+describe('ChaseCamera', () => {
+  const baseOptions: ChaseCameraOptions = {
+    offsets: {
+      position: { x: 0, y: 3, z: -6 },
+      lookAt: { x: 0, y: 1, z: 5 },
+    },
+    damping: {
+      position: 12,
+      lookAt: 10,
+    },
+    eventFx: {
+      boost: {
+        shake: { amplitude: 1.2, frequency: 6, duration: 1 },
+        visualFx: 'boost_flash',
+        audioFx: 'boost_whoosh',
+      },
+      hit: {
+        shake: { amplitude: 2, frequency: 4, duration: 0.6 },
+        visualFx: 'impact_flash',
+        audioFx: 'impact_thud',
+      },
+      nearMiss: {
+        shake: { amplitude: 0.8, frequency: 8, duration: 0.4 },
+        visualFx: 'near_miss_glow',
+        audioFx: 'near_miss_ping',
+      },
+    },
+  }
+
+  const transform: VehicleTransform = {
+    position: { x: 10, y: 1, z: 5 },
+    forward: { x: 0, y: 0, z: 1 },
+  }
+
+  it('smoothly follows the vehicle with configurable damping', () => {
+    const { rig, positions, lookAts } = createRig()
+    const { player } = createFxPlayer()
+    const camera = new ChaseCamera(rig, player, baseOptions)
+
+    //1.- Initialize the camera at the baseline offset.
+    camera.update(0.016, transform)
+    //2.- Move the vehicle forward and sample another frame to observe damping.
+    const movedTransform: VehicleTransform = {
+      position: { x: 10, y: 1, z: 10 },
+      forward: transform.forward,
+    }
+    camera.update(0.016, movedTransform)
+
+    expect(positions.length).toBe(2)
+    const firstPosition = positions[0]
+    const secondPosition = positions[1]
+    //3.- Confirm the second frame is in between the start and goal due to damping.
+    expect(secondPosition.z).toBeGreaterThan(firstPosition.z)
+    expect(secondPosition.z).toBeLessThan(4)
+    const lastLookAt = lookAts[lookAts.length - 1]
+    expect(lastLookAt.z).toBeGreaterThan(9)
+  })
+
+  it('applies runtime overrides for respawn or cinematic moments', () => {
+    const { rig, positions } = createRig()
+    const { player } = createFxPlayer()
+    const camera = new ChaseCamera(rig, player, baseOptions)
+
+    const overrides: Partial<ChaseCameraRuntimeOptions> = {
+      offsets: {
+        position: { x: 0, y: 10, z: -12 },
+        lookAt: { x: 0, y: 2, z: 4 },
+      },
+      damping: {
+        position: 20,
+        lookAt: 18,
+      },
+    }
+
+    //1.- Apply an override for a single update to confirm the effect takes hold.
+    camera.update(0.016, transform, overrides)
+
+    expect(positions[0].y).toBeGreaterThan(5)
+    expect(positions[0].z).toBeLessThan(-4)
+  })
+
+  it('triggers shakes and FX cues when events fire', () => {
+    const { rig, positions } = createRig()
+    const { player, playAudioFx, playVisualFx } = createFxPlayer()
+    const camera = new ChaseCamera(rig, player, baseOptions)
+
+    //1.- Fire the hit event which should start a shake and trigger both FX outputs.
+    camera.trigger('hit')
+    camera.update(0.016, transform)
+    camera.update(0.016, transform)
+
+    expect(playVisualFx).toHaveBeenCalledWith('impact_flash')
+    expect(playAudioFx).toHaveBeenCalledWith('impact_thud')
+    //2.- Verify the shake displaced the camera from its base offset at least once.
+    const shakenFrame = positions.find((position) => position.x !== positions[0].x)
+    expect(shakenFrame).toBeDefined()
+  })
+})

--- a/tunnelcave_sandbox_web/src/camera/chaseCamera.ts
+++ b/tunnelcave_sandbox_web/src/camera/chaseCamera.ts
@@ -1,0 +1,203 @@
+import { CameraRig, Vector3 } from './countdownSpectator'
+
+export interface VehicleTransform {
+  position: Vector3
+  forward: Vector3
+}
+
+export interface ChaseCameraOffsets {
+  //1.- Position offset moves the rig relative to the vehicle's local axes.
+  position: Vector3
+  //2.- Look-at offset displaces the focal point in the vehicle's local space.
+  lookAt: Vector3
+}
+
+export interface ChaseCameraDamping {
+  //1.- Position damping controls interpolation speed for camera translation.
+  position: number
+  //2.- Look-at damping controls interpolation speed for the focus point.
+  lookAt: number
+}
+
+export interface CameraFxPlayer {
+  //1.- Trigger a named visual effect like bloom or chromatic aberration.
+  playVisualFx(name: string): void
+  //2.- Trigger an accompanying audio sting.
+  playAudioFx(name: string): void
+}
+
+export interface CameraShakeSettings {
+  //1.- Amplitude determines the maximum positional displacement in meters.
+  amplitude: number
+  //2.- Frequency controls the oscillation rate in hertz.
+  frequency: number
+  //3.- Duration indicates how long the shake should persist.
+  duration: number
+}
+
+export type ChaseCameraEvent = 'boost' | 'hit' | 'nearMiss'
+
+export interface ChaseCameraEventConfig {
+  //1.- Shake specifies how intense the response should feel.
+  shake: CameraShakeSettings
+  //2.- Visual FX names the screen-space effect to play.
+  visualFx: string
+  //3.- Audio FX names the sound cue to trigger.
+  audioFx: string
+}
+
+export interface ChaseCameraRuntimeOptions {
+  offsets: ChaseCameraOffsets
+  damping: ChaseCameraDamping
+}
+
+export interface ChaseCameraOptions extends ChaseCameraRuntimeOptions {
+  //1.- Event FX map event identifiers to their configuration.
+  eventFx: Partial<Record<ChaseCameraEvent, ChaseCameraEventConfig>>
+  //2.- World up allows custom up vectors for non-standard gravity.
+  worldUp?: Vector3
+}
+
+interface ActiveShake {
+  remaining: number
+  settings: CameraShakeSettings
+  phase: number
+}
+
+export interface ChaseCameraController {
+  update(
+    deltaSeconds: number,
+    transform: VehicleTransform,
+    overrides?: Partial<ChaseCameraRuntimeOptions>,
+  ): void
+  trigger(event: ChaseCameraEvent): void
+}
+
+export class ChaseCamera implements ChaseCameraController {
+  private currentPosition: Vector3 | undefined
+  private currentLookAt: Vector3 | undefined
+  private activeShake: ActiveShake | undefined
+
+  constructor(
+    private readonly rig: CameraRig,
+    private readonly fx: CameraFxPlayer,
+    private readonly options: ChaseCameraOptions,
+  ) {}
+
+  update(
+    deltaSeconds: number,
+    transform: VehicleTransform,
+    overrides: Partial<ChaseCameraRuntimeOptions> = {},
+  ): void {
+    //1.- Merge base options with any runtime overrides for contextual behavior.
+    const runtime: ChaseCameraRuntimeOptions = {
+      offsets: overrides.offsets ?? this.options.offsets,
+      damping: overrides.damping ?? this.options.damping,
+    }
+    //2.- Derive a stable local frame from the vehicle's forward axis.
+    const forward = normalize(transform.forward)
+    const worldUp = normalize(this.options.worldUp ?? { x: 0, y: 1, z: 0 })
+    const right = normalize(cross(worldUp, forward))
+    const up = cross(forward, right)
+    //3.- Translate offsets from local space into world coordinates.
+    const desiredPosition = applyOffset(transform.position, runtime.offsets.position, {
+      forward,
+      right,
+      up,
+    })
+    const desiredLookAt = applyOffset(transform.position, runtime.offsets.lookAt, {
+      forward,
+      right,
+      up,
+    })
+    //4.- Update and evaluate any active screen shake.
+    const shakenPosition = this.applyShake(deltaSeconds, desiredPosition)
+    //5.- Smoothly interpolate the camera rig using exponential damping.
+    this.currentPosition = damp(this.currentPosition, shakenPosition, runtime.damping.position, deltaSeconds)
+    this.currentLookAt = damp(this.currentLookAt, desiredLookAt, runtime.damping.lookAt, deltaSeconds)
+    //6.- Commit the smoothed transform to the underlying rig.
+    this.rig.setPosition(this.currentPosition)
+    this.rig.lookAt(this.currentLookAt)
+  }
+
+  trigger(event: ChaseCameraEvent): void {
+    const config = this.options.eventFx[event]
+    if (!config) {
+      return
+    }
+    //1.- Initialize a new shake envelope that decays over time.
+    this.activeShake = {
+      remaining: config.shake.duration,
+      settings: config.shake,
+      phase: 0,
+    }
+    //2.- Kick off the paired VFX and SFX cues.
+    this.fx.playVisualFx(config.visualFx)
+    this.fx.playAudioFx(config.audioFx)
+  }
+
+  private applyShake(deltaSeconds: number, basePosition: Vector3): Vector3 {
+    if (!this.activeShake) {
+      return basePosition
+    }
+    //1.- Advance the shake timer and gracefully finish once depleted.
+    this.activeShake.remaining = Math.max(0, this.activeShake.remaining - deltaSeconds)
+    this.activeShake.phase += deltaSeconds * this.activeShake.settings.frequency
+    if (this.activeShake.remaining <= 0) {
+      this.activeShake = undefined
+      return basePosition
+    }
+    //2.- Compute an intensity scalar that eases out as the shake ends.
+    const t = this.activeShake.remaining / this.activeShake.settings.duration
+    const intensity = this.activeShake.settings.amplitude * t * t
+    const angle = this.activeShake.phase * Math.PI * 2
+    //3.- Offset the position with orthogonal oscillations to emulate shake.
+    return {
+      x: basePosition.x + Math.sin(angle) * intensity,
+      y: basePosition.y + Math.cos(angle * 0.5) * intensity * 0.5,
+      z: basePosition.z + Math.sin(angle * 1.5) * intensity * 0.25,
+    }
+  }
+}
+
+function damp(current: Vector3 | undefined, target: Vector3, damping: number, deltaSeconds: number): Vector3 {
+  if (!current) {
+    return target
+  }
+  //1.- Clamp damping to ensure numerical stability across varying delta times.
+  const lambda = Math.max(0, Math.min(damping, 60))
+  const factor = 1 - Math.exp(-lambda * deltaSeconds)
+  return {
+    x: current.x + (target.x - current.x) * factor,
+    y: current.y + (target.y - current.y) * factor,
+    z: current.z + (target.z - current.z) * factor,
+  }
+}
+
+interface Basis {
+  forward: Vector3
+  right: Vector3
+  up: Vector3
+}
+
+function applyOffset(origin: Vector3, offset: Vector3, basis: Basis): Vector3 {
+  //1.- Combine the basis vectors scaled by the offset components.
+  return {
+    x: origin.x + basis.right.x * offset.x + basis.up.x * offset.y + basis.forward.x * offset.z,
+    y: origin.y + basis.right.y * offset.x + basis.up.y * offset.y + basis.forward.y * offset.z,
+    z: origin.z + basis.right.z * offset.x + basis.up.z * offset.y + basis.forward.z * offset.z,
+  }
+}
+
+function normalize(vector: Vector3): Vector3 {
+  const length = Math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z) || 1
+  return { x: vector.x / length, y: vector.y / length, z: vector.z / length }
+}
+
+function cross(a: Vector3, b: Vector3): Vector3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  }
+}


### PR DESCRIPTION
## Summary
- add a configurable chase camera controller with smoothing, offsets, and FX triggers
- introduce a camera director to coordinate chase, respawn, and spectator flows
- cover new behaviours with dedicated unit tests for chase and director logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3d546dc88329ba210e96f4ac362e