### PR TITLE
Add modular HUD metrics and scoreboard overlay

### DIFF
--- a/tunnelcave_sandbox_web/src/hud/connectionMetric.ts
+++ b/tunnelcave_sandbox_web/src/hud/connectionMetric.ts
@@ -1,0 +1,46 @@
+import type { ConnectionStatus } from '../networking/WebSocketClient'
+import { HudMetric } from './hudMetric'
+
+export interface ConnectionMetricOptions {
+  //1.- WebSocketClient exposes connection lifecycle transitions for the metric.
+  client: EventTarget & { getConnectionStatus(): ConnectionStatus }
+}
+
+export class ConnectionMetric {
+  private readonly metric: HudMetric
+  private readonly onStatusChange: (event: Event) => void
+  private readonly client: ConnectionMetricOptions['client']
+
+  constructor(root: HTMLElement, options: ConnectionMetricOptions) {
+    this.client = options.client
+    //1.- Seed the metric with the client's current status to avoid an empty render.
+    this.metric = new HudMetric(root, {
+      label: 'Connection',
+      description: 'Server connection status',
+      initialValue: formatStatus(this.client.getConnectionStatus()),
+    })
+    this.onStatusChange = (event: Event) => {
+      const detail = (event as CustomEvent<ConnectionStatus>).detail
+      const status = detail ?? this.client.getConnectionStatus()
+      this.metric.update(formatStatus(status))
+    }
+    this.client.addEventListener('status', this.onStatusChange as EventListener)
+  }
+
+  dispose(): void {
+    //1.- Remove the event listener so reconnect cycles do not leak DOM references.
+    this.client.removeEventListener('status', this.onStatusChange as EventListener)
+  }
+}
+
+function formatStatus(status: ConnectionStatus): string {
+  //1.- Present human readable copy for each status case.
+  switch (status) {
+    case 'connected':
+      return 'Online'
+    case 'connecting':
+      return 'Syncing'
+    default:
+      return 'Offline'
+  }
+}

--- a/tunnelcave_sandbox_web/src/hud/controller.ts
+++ b/tunnelcave_sandbox_web/src/hud/controller.ts
@@ -1,0 +1,57 @@
+import type { EventStreamClient } from '../../../typescript-client/src/eventStream'
+import type { ConnectionStatus } from '../networking/WebSocketClient'
+import { ConnectionMetric } from './connectionMetric'
+import { CorrectionMetric } from './correctionMetric'
+import { PlaybackMetric } from './playbackMetric'
+import { ScoreboardAggregator } from './scoreboardAggregator'
+import { ScoreboardOverlay } from './scoreboardOverlay'
+
+export interface HudControllerOptions {
+  //1.- DOM node that will host the metric widgets and overlays.
+  root: HTMLElement
+  //2.- Connected WebSocket client providing interpolation telemetry.
+  client: EventTarget & {
+    getConnectionStatus(): ConnectionStatus
+    getPlaybackBufferMs(): number
+  }
+  //3.- Optional event stream client for scoreboard updates.
+  eventStream?: EventStreamClient
+}
+
+export class HudController {
+  private readonly connectionMetric: ConnectionMetric
+  private readonly playbackMetric: PlaybackMetric
+  private readonly correctionMetric: CorrectionMetric
+  private readonly scoreboardAggregator: ScoreboardAggregator
+  private readonly scoreboardOverlay: ScoreboardOverlay
+  private unbindStream?: () => void
+
+  constructor(options: HudControllerOptions) {
+    const { root, client, eventStream } = options
+    //1.- Instantiate modular metrics so each concern remains individually testable.
+    this.connectionMetric = new ConnectionMetric(root, { client })
+    this.playbackMetric = new PlaybackMetric(root, { client })
+    this.correctionMetric = new CorrectionMetric(root, { client })
+    this.scoreboardAggregator = new ScoreboardAggregator()
+    this.scoreboardOverlay = new ScoreboardOverlay(root, this.scoreboardAggregator)
+    if (eventStream) {
+      this.unbindStream = this.scoreboardAggregator.bindStream(eventStream)
+    }
+  }
+
+  aggregator(): ScoreboardAggregator {
+    //1.- Expose the scoreboard aggregator for manual event injection in tests.
+    return this.scoreboardAggregator
+  }
+
+  dispose(): void {
+    //1.- Tear down metrics and stream bindings so hot reloads do not leak timers.
+    if (this.unbindStream) {
+      this.unbindStream()
+    }
+    this.scoreboardOverlay.dispose()
+    this.playbackMetric.dispose()
+    this.correctionMetric.dispose()
+    this.connectionMetric.dispose()
+  }
+}

--- a/tunnelcave_sandbox_web/src/hud/correctionMetric.ts
+++ b/tunnelcave_sandbox_web/src/hud/correctionMetric.ts
@@ -1,0 +1,57 @@
+import type { CorrectionEventDetail } from '../networking/WebSocketClient'
+import { HudMetric } from './hudMetric'
+
+export interface CorrectionMetricOptions {
+  //1.- Client surfaces correction events for reconciliation telemetry.
+  client: EventTarget
+  //2.- Window length determines how long corrections remain in the rolling count.
+  windowMs?: number
+  //3.- Optional clock injection for deterministic tests.
+  now?: () => number
+}
+
+export class CorrectionMetric {
+  private readonly metric: HudMetric
+  private readonly corrections: number[] = []
+  private readonly windowMs: number
+  private readonly now: () => number
+  private readonly listener: (event: Event) => void
+  private readonly timer: number
+  private readonly client: EventTarget
+
+  constructor(root: HTMLElement, options: CorrectionMetricOptions) {
+    this.client = options.client
+    this.windowMs = Math.max(1000, options.windowMs ?? 60_000)
+    this.now = options.now ?? (() => Date.now())
+    this.metric = new HudMetric(root, {
+      label: 'Corrections',
+      description: 'Authoritative corrections in the last minute',
+      initialValue: '0',
+    })
+    this.listener = (event: Event) => {
+      const detail = (event as CustomEvent<CorrectionEventDetail>).detail
+      this.corrections.push(this.now())
+      this.trim()
+      this.metric.update(String(this.corrections.length))
+    }
+    options.client.addEventListener('correction', this.listener as EventListener)
+    this.timer = window.setInterval(() => {
+      this.trim()
+      this.metric.update(String(this.corrections.length))
+    }, Math.min(this.windowMs / 4, 5_000))
+  }
+
+  dispose(): void {
+    //1.- Release timers and listeners so repeated instantiations remain lightweight.
+    this.client.removeEventListener('correction', this.listener as EventListener)
+    window.clearInterval(this.timer)
+  }
+
+  private trim(): void {
+    //1.- Drop corrections outside the rolling window while preserving order.
+    const cutoff = this.now() - this.windowMs
+    while (this.corrections.length > 0 && this.corrections[0] < cutoff) {
+      this.corrections.shift()
+    }
+  }
+}

--- a/tunnelcave_sandbox_web/src/hud/hudController.test.ts
+++ b/tunnelcave_sandbox_web/src/hud/hudController.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ConnectionStatus, CorrectionEventDetail } from '../networking/WebSocketClient'
+import { HudController } from './controller'
+
+declare global {
+  interface Window {
+    setInterval(handler: TimerHandler, timeout?: number, ...arguments: unknown[]): number
+  }
+}
+
+class MockClient extends EventTarget {
+  private status: ConnectionStatus = 'disconnected'
+  private bufferMs = 250
+
+  //1.- getConnectionStatus mirrors the WebSocket client API expected by the controller.
+  getConnectionStatus(): ConnectionStatus {
+    return this.status
+  }
+
+  getPlaybackBufferMs(): number {
+    return this.bufferMs
+  }
+
+  setStatus(status: ConnectionStatus): void {
+    this.status = status
+    this.dispatchEvent(new CustomEvent<ConnectionStatus>('status', { detail: status }))
+  }
+
+  setBufferMs(bufferMs: number): void {
+    this.bufferMs = bufferMs
+  }
+
+  emitCorrection(tickId: number): void {
+    const detail: CorrectionEventDetail = {
+      entityId: 'alpha',
+      positionError: 1,
+      orientationError: 1,
+      tickId,
+    }
+    this.dispatchEvent(new CustomEvent('correction', { detail }))
+  }
+}
+
+describe('HudController', () => {
+  it('renders live metrics and toggles the scoreboard overlay', () => {
+    //1.- Use fake timers so polling intervals advance deterministically in tests.
+    vi.useFakeTimers()
+    const root = document.createElement('div')
+    document.body.append(root)
+    const client = new MockClient()
+    const controller = new HudController({ root, client })
+    const metrics = root.querySelectorAll('.hud-metric')
+    expect(metrics).toHaveLength(3)
+
+    //2.- Connection status metric should react to lifecycle events.
+    client.setStatus('connected')
+    const connectionValue = metrics[0]?.querySelector('.hud-metric__value')?.textContent
+    expect(connectionValue).toBe('Online')
+
+    //3.- Playback buffer metric polls periodically so advance the timer to update the text.
+    client.setBufferMs(1500)
+    vi.advanceTimersByTime(600)
+    const playbackValue = metrics[1]?.querySelector('.hud-metric__value')?.textContent
+    expect(playbackValue).toBe('1.5 s')
+
+    //4.- Correction metric increments when reconciliation events fire.
+    vi.setSystemTime(10_000)
+    client.emitCorrection(1)
+    vi.advanceTimersByTime(100)
+    const correctionValue = metrics[2]?.querySelector('.hud-metric__value')?.textContent
+    expect(correctionValue).toBe('1')
+
+    //5.- Inject scoreboard data and verify the overlay renders dynamic columns.
+    controller
+      .aggregator()
+      .ingest({
+        schemaVersion: '1.0.0',
+        eventId: 'score-1',
+        occurredAtMs: 10_000,
+        type: 5,
+        primaryEntityId: 'pilot',
+        relatedEntityIds: [],
+        metadata: {
+          score_player_id: 'pilot',
+          score_display_name: 'Pilot One',
+          score_kills: '4',
+          score_assists: '3',
+        },
+      })
+    const table = root.querySelector('.hud-scoreboard__table')
+    expect(table?.querySelectorAll('tbody tr')).toHaveLength(1)
+    expect(table?.textContent).toContain('Pilot One')
+    expect(table?.textContent).toContain('4')
+
+    //6.- Scoreboard remains hidden until Tab is pressed.
+    const overlay = root.querySelector('.hud-scoreboard') as HTMLElement
+    expect(overlay.dataset.visible).not.toBe('true')
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }))
+    expect(overlay.dataset.visible).toBe('true')
+
+    controller.dispose()
+    vi.useRealTimers()
+  })
+})

--- a/tunnelcave_sandbox_web/src/hud/hudMetric.ts
+++ b/tunnelcave_sandbox_web/src/hud/hudMetric.ts
@@ -1,0 +1,45 @@
+import { ensureHudStyles } from './hudStyles'
+
+export interface HudMetricOptions {
+  //1.- label describes the semantic metric for assistive technologies.
+  label: string
+  //2.- Optional description used for aria-live announcements.
+  description?: string
+  //3.- Initial value rendered before live updates arrive.
+  initialValue?: string
+}
+
+export class HudMetric {
+  private readonly container: HTMLElement
+  private readonly valueNode: HTMLElement
+
+  constructor(root: HTMLElement, options: HudMetricOptions) {
+    ensureHudStyles(root.ownerDocument ?? document)
+    //1.- Materialise a semantic metric block with label and value spans.
+    this.container = root.ownerDocument?.createElement('section') ?? document.createElement('section')
+    this.container.className = 'hud-metric'
+    this.container.setAttribute('role', 'group')
+    this.container.setAttribute('aria-label', options.label)
+    if (options.description) {
+      this.container.setAttribute('aria-description', options.description)
+    }
+    const labelNode = this.container.ownerDocument.createElement('span')
+    labelNode.className = 'hud-metric__label'
+    labelNode.textContent = options.label
+    this.valueNode = this.container.ownerDocument.createElement('span')
+    this.valueNode.className = 'hud-metric__value'
+    this.valueNode.textContent = options.initialValue ?? '--'
+    this.container.append(labelNode, this.valueNode)
+    root.append(this.container)
+  }
+
+  update(value: string): void {
+    //1.- Update the live region text to surface the latest metric value.
+    this.valueNode.textContent = value
+  }
+
+  element(): HTMLElement {
+    //1.- Expose the container for layout orchestration by higher level controllers.
+    return this.container
+  }
+}

--- a/tunnelcave_sandbox_web/src/hud/hudStyles.ts
+++ b/tunnelcave_sandbox_web/src/hud/hudStyles.ts
@@ -1,0 +1,129 @@
+const STYLE_ELEMENT_ID = 'hud-style-sheet'
+
+//1.- ensureHudStyles injects responsive, high-contrast styles exactly once per document.
+export function ensureHudStyles(target: Document | ShadowRoot = document): void {
+  if (!('querySelector' in target)) {
+    return
+  }
+  const ownerDocument = 'ownerDocument' in target && target.ownerDocument ? target.ownerDocument : document
+  const existing = ownerDocument.getElementById(STYLE_ELEMENT_ID)
+  if (existing) {
+    return
+  }
+  const style = ownerDocument.createElement('style')
+  style.id = STYLE_ELEMENT_ID
+  style.textContent = `
+    :root {
+      color-scheme: light dark;
+    }
+
+    .hud-metric {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.25rem 0.5rem;
+      align-items: baseline;
+      background: rgba(12, 17, 28, 0.78);
+      color: #f5f7ff;
+      padding: 0.75rem 1rem;
+      border-radius: 0.5rem;
+      font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.3);
+      min-width: 14rem;
+      margin: 0.25rem 0;
+    }
+
+    .hud-metric__label {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      color: #9ad0ff;
+    }
+
+    .hud-metric__value {
+      font-size: 1.5rem;
+      font-weight: 600;
+      justify-self: end;
+      color: #ffffff;
+    }
+
+    .hud-scoreboard {
+      position: fixed;
+      inset: 5vh 5vw auto 5vw;
+      background: rgba(5, 8, 12, 0.9);
+      border: 2px solid rgba(154, 208, 255, 0.6);
+      border-radius: 0.75rem;
+      color: #f3f6ff;
+      padding: 1rem;
+      z-index: 1000;
+      display: none;
+      max-height: 90vh;
+      overflow: auto;
+    }
+
+    .hud-scoreboard[data-visible='true'] {
+      display: block;
+    }
+
+    .hud-scoreboard__title {
+      margin: 0 0 0.75rem 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #9ad0ff;
+    }
+
+    .hud-scoreboard__table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.95rem;
+    }
+
+    .hud-scoreboard__table th,
+    .hud-scoreboard__table td {
+      border-bottom: 1px solid rgba(154, 208, 255, 0.2);
+      padding: 0.5rem 0.75rem;
+      text-align: left;
+    }
+
+    .hud-scoreboard__table th {
+      background: rgba(27, 39, 58, 0.8);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      color: #ffffff;
+    }
+
+    .hud-scoreboard__table tbody tr:nth-child(even) {
+      background: rgba(13, 20, 31, 0.6);
+    }
+
+    @media (max-width: 900px) {
+      .hud-scoreboard {
+        inset: 2vh 2vw auto 2vw;
+        padding: 0.75rem;
+      }
+
+      .hud-scoreboard__table th,
+      .hud-scoreboard__table td {
+        padding: 0.4rem 0.5rem;
+        font-size: 0.85rem;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .hud-metric {
+        grid-template-columns: 1fr;
+        text-align: center;
+        min-width: 10rem;
+      }
+
+      .hud-metric__value {
+        justify-self: center;
+      }
+
+      .hud-scoreboard__table {
+        font-size: 0.8rem;
+      }
+    }
+  `
+  ownerDocument.head.append(style)
+}

--- a/tunnelcave_sandbox_web/src/hud/playbackMetric.ts
+++ b/tunnelcave_sandbox_web/src/hud/playbackMetric.ts
@@ -1,0 +1,44 @@
+import { HudMetric } from './hudMetric'
+
+export interface PlaybackMetricOptions {
+  //1.- Source client exposes playback buffer duration sampling.
+  client: { getPlaybackBufferMs(): number }
+  //2.- Interval controls how frequently the HUD polls for updates.
+  intervalMs?: number
+}
+
+export class PlaybackMetric {
+  private readonly metric: HudMetric
+  private readonly timer: number
+  private readonly client: PlaybackMetricOptions['client']
+
+  constructor(root: HTMLElement, options: PlaybackMetricOptions) {
+    this.client = options.client
+    //1.- Render initial buffer value so the HUD reflects startup conditions.
+    const initialMs = this.client.getPlaybackBufferMs()
+    this.metric = new HudMetric(root, {
+      label: 'Buffer',
+      description: 'Snapshot playback delay',
+      initialValue: formatBuffer(initialMs),
+    })
+    const intervalMs = Math.max(100, options.intervalMs ?? 500)
+    this.timer = window.setInterval(() => {
+      const bufferMs = this.client.getPlaybackBufferMs()
+      this.metric.update(formatBuffer(bufferMs))
+    }, intervalMs)
+  }
+
+  dispose(): void {
+    //1.- Clear the polling timer so tests and teardown flows can exit promptly.
+    window.clearInterval(this.timer)
+  }
+}
+
+function formatBuffer(bufferMs: number): string {
+  //1.- Express buffer duration in milliseconds with one decimal seconds as context.
+  const safeMs = Number.isFinite(bufferMs) ? bufferMs : 0
+  if (safeMs >= 1_000) {
+    return `${(safeMs / 1000).toFixed(1)} s`
+  }
+  return `${Math.round(safeMs)} ms`
+}

--- a/tunnelcave_sandbox_web/src/hud/scoreboardAggregator.test.ts
+++ b/tunnelcave_sandbox_web/src/hud/scoreboardAggregator.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GameEvent } from '../../../typescript-client/src/generated/events'
+import { EventStreamClient, MemoryEventStore } from '../../../typescript-client/src/eventStream'
+import { ScoreboardAggregator } from './scoreboardAggregator'
+
+function createScoreEvent(overrides: Partial<GameEvent> = {}): GameEvent {
+  //1.- Provide a deterministic base payload mirroring broker score updates.
+  return {
+    schemaVersion: '1.0.0',
+    eventId: overrides.eventId ?? 'evt-1',
+    occurredAtMs: overrides.occurredAtMs ?? 1_000,
+    type: overrides.type ?? 5,
+    primaryEntityId: overrides.primaryEntityId ?? 'player-1',
+    relatedEntityIds: overrides.relatedEntityIds ?? [],
+    metadata: overrides.metadata ?? {
+      score_player_id: 'player-1',
+      score_display_name: 'Alpha',
+      score_kills: '3',
+      score_assists: '1',
+    },
+  }
+}
+
+describe('ScoreboardAggregator', () => {
+  it('aggregates score metadata and emits ordered entries', () => {
+    //1.- Ingest two score events and verify the resulting table snapshot ordering.
+    const aggregator = new ScoreboardAggregator({ now: () => 2_000 })
+    const updates: string[][] = []
+    aggregator.addEventListener('entries', (event) => {
+      const entries = (event as CustomEvent).detail as ReturnType<typeof aggregator.listEntries>
+      updates.push(entries.map((entry) => `${entry.displayName}:${entry.metrics.kills}`))
+    })
+    aggregator.ingest(createScoreEvent())
+    aggregator.ingest(
+      createScoreEvent({
+        eventId: 'evt-2',
+        metadata: {
+          score_player_id: 'player-2',
+          score_display_name: 'Bravo',
+          score_kills: '5',
+          score_assists: '2',
+        },
+      }),
+    )
+    const entries = aggregator.listEntries()
+    expect(entries[0]?.displayName).toBe('Bravo')
+    expect(entries[0]?.metrics.kills).toBe(5)
+    expect(entries[1]?.displayName).toBe('Alpha')
+    expect(updates.length).toBe(2)
+    expect(aggregator.listMetricKeys()).toEqual(['assists', 'kills'])
+  })
+
+  it('binds to an event stream and drains pending events', () => {
+    //1.- Leverage the real event stream client to ensure polling works under timers.
+    vi.useFakeTimers()
+    const sent: string[] = []
+    const stream = new EventStreamClient(
+      'hud',
+      { send: (data: string) => sent.push(data) },
+      new MemoryEventStore(),
+    )
+    const aggregator = new ScoreboardAggregator()
+    aggregator.bindStream(stream, 100)
+    stream.ingest([
+      {
+        sequence: 1,
+        kind: 'lifecycle',
+        payload: createScoreEvent({ eventId: 'evt-stream' }),
+      },
+    ])
+    vi.advanceTimersByTime(150)
+    const entries = aggregator.listEntries()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.displayName).toBe('Alpha')
+    expect(sent).toContainEqual(
+      JSON.stringify({ type: 'event_ack', subscriber: 'hud', sequence: 1 }),
+    )
+    vi.useRealTimers()
+  })
+})

--- a/tunnelcave_sandbox_web/src/hud/scoreboardAggregator.ts
+++ b/tunnelcave_sandbox_web/src/hud/scoreboardAggregator.ts
@@ -1,0 +1,137 @@
+import type { GameEvent } from '../../../typescript-client/src/generated/events'
+import { EventStreamClient, type EventEnvelope } from '../../../typescript-client/src/eventStream'
+
+export interface ScoreboardEntry {
+  //1.- Stable identifier used for deduplicating rows.
+  playerId: string
+  //2.- Friendly display name shown in the overlay.
+  displayName: string
+  //3.- Numeric metrics keyed by canonical metric identifiers.
+  metrics: Record<string, number>
+  //4.- Last broker timestamp propagated with the update.
+  lastUpdateMs: number
+}
+
+export interface ScoreboardAggregatorOptions {
+  //1.- Optional clock override for deterministic tests.
+  now?: () => number
+}
+
+const SCORE_PREFIX = 'score_'
+const STRING_KEYS = new Set(['score_player_id', 'score_display_name', 'score_name'])
+
+export class ScoreboardAggregator extends EventTarget {
+  private readonly entries = new Map<string, ScoreboardEntry>()
+  private readonly metrics = new Set<string>()
+  private readonly now: () => number
+
+  constructor(options: ScoreboardAggregatorOptions = {}) {
+    super()
+    this.now = options.now ?? (() => Date.now())
+  }
+
+  ingest(event: GameEvent): void {
+    //1.- Only lifecycle score updates propagate into the scoreboard snapshot.
+    if (event.type !== 5 /* EVENT_TYPE_SCORE_UPDATE */) {
+      return
+    }
+    const metadata = event.metadata ?? {}
+    const playerId = metadata['score_player_id'] ?? event.primaryEntityId
+    if (!playerId) {
+      return
+    }
+    const displayName = metadata['score_display_name'] ?? metadata['score_name'] ?? playerId
+    const metrics: Record<string, number> = {}
+    for (const [key, value] of Object.entries(metadata)) {
+      if (!key.startsWith(SCORE_PREFIX) || STRING_KEYS.has(key)) {
+        continue
+      }
+      const metricKey = key.substring(SCORE_PREFIX.length)
+      const numericValue = Number.parseFloat(value)
+      if (Number.isNaN(numericValue)) {
+        continue
+      }
+      metrics[metricKey] = numericValue
+      this.metrics.add(metricKey)
+    }
+    const lastUpdateMs = event.occurredAtMs || this.now()
+    const existing = this.entries.get(playerId)
+    const merged: ScoreboardEntry = {
+      playerId,
+      displayName,
+      metrics: { ...(existing?.metrics ?? {}), ...metrics },
+      lastUpdateMs,
+    }
+    this.entries.set(playerId, merged)
+    this.publish()
+  }
+
+  listEntries(): ScoreboardEntry[] {
+    //1.- Materialise a stable ordering that prefers higher scoring players first.
+    const values = Array.from(this.entries.values())
+    values.sort((a, b) => {
+      const aMax = maxMetricValue(a.metrics)
+      const bMax = maxMetricValue(b.metrics)
+      if (aMax !== bMax) {
+        return bMax - aMax
+      }
+      if (a.displayName !== b.displayName) {
+        return a.displayName.localeCompare(b.displayName)
+      }
+      return a.playerId.localeCompare(b.playerId)
+    })
+    return values
+  }
+
+  listMetricKeys(): string[] {
+    //1.- Expose the union of metrics so the overlay can build the table header.
+    return Array.from(this.metrics).sort((a, b) => a.localeCompare(b))
+  }
+
+  bindStream(stream: EventStreamClient, intervalMs = 200): () => void {
+    //1.- Poll the event stream backlog until exhausted, acknowledging processed frames.
+    const timer = window.setInterval(() => {
+      let processed = false
+      while (true) {
+        const next = stream.nextPending()
+        if (!next) {
+          break
+        }
+        if (isGameEventEnvelope(next)) {
+          this.ingest(next.payload)
+        }
+        stream.ackLatest()
+        processed = true
+      }
+      if (!processed) {
+        return
+      }
+    }, Math.max(50, intervalMs))
+    return () => window.clearInterval(timer)
+  }
+
+  private publish(): void {
+    //1.- Emit a CustomEvent so DOM overlays can reactively render.
+    this.dispatchEvent(new CustomEvent('entries', { detail: this.listEntries() }))
+  }
+}
+
+function maxMetricValue(metrics: Record<string, number>): number {
+  //1.- Determine the dominant metric to drive descending sorting.
+  let max = -Infinity
+  for (const value of Object.values(metrics)) {
+    if (value > max) {
+      max = value
+    }
+  }
+  return Number.isFinite(max) ? max : 0
+}
+
+function isGameEventEnvelope(envelope: EventEnvelope): envelope is EventEnvelope & { payload: GameEvent } {
+  //1.- Defensive runtime guard verifying the envelope carries a score update payload.
+  if (!envelope || envelope.kind !== 'lifecycle') {
+    return false
+  }
+  const payload = envelope.payload as Partial<GameEvent>
+  return typeof payload === 'object' && payload !== null && typeof payload.type === 'number'
+}

--- a/tunnelcave_sandbox_web/src/hud/scoreboardOverlay.ts
+++ b/tunnelcave_sandbox_web/src/hud/scoreboardOverlay.ts
@@ -1,0 +1,112 @@
+import type { ScoreboardAggregator, ScoreboardEntry } from './scoreboardAggregator'
+import { ensureHudStyles } from './hudStyles'
+
+export interface ScoreboardOverlayOptions {
+  //1.- Keyboard key toggling the overlay visibility.
+  toggleKey?: string
+  //2.- Accessible title used for screen reader captioning.
+  title?: string
+}
+
+export class ScoreboardOverlay {
+  private readonly container: HTMLElement
+  private readonly table: HTMLTableElement
+  private readonly aggregator: ScoreboardAggregator
+  private readonly keyHandler: (event: KeyboardEvent) => void
+  private readonly entryListener: (event: Event) => void
+  private visible = false
+  private metricKeys: string[] = []
+
+  constructor(root: HTMLElement, aggregator: ScoreboardAggregator, options: ScoreboardOverlayOptions = {}) {
+    ensureHudStyles(root.ownerDocument ?? document)
+    this.aggregator = aggregator
+    this.container = root.ownerDocument?.createElement('section') ?? document.createElement('section')
+    this.container.className = 'hud-scoreboard'
+    this.container.setAttribute('aria-hidden', 'true')
+    const title = this.container.ownerDocument.createElement('h2')
+    title.className = 'hud-scoreboard__title'
+    title.textContent = options.title ?? 'Scoreboard'
+    this.table = this.container.ownerDocument.createElement('table')
+    this.table.className = 'hud-scoreboard__table'
+    this.table.createTHead()
+    this.table.createTBody()
+    const caption = this.container.ownerDocument.createElement('caption')
+    caption.textContent = title.textContent ?? 'Scoreboard'
+    caption.style.position = 'absolute'
+    caption.style.clip = 'rect(0 0 0 0)'
+    caption.style.width = '1px'
+    caption.style.height = '1px'
+    caption.style.overflow = 'hidden'
+    this.table.prepend(caption)
+    this.container.append(title, this.table)
+    root.append(this.container)
+    this.entryListener = (event: Event) => {
+      const entries = (event as CustomEvent<ScoreboardEntry[]>).detail
+      this.metricKeys = this.aggregator.listMetricKeys()
+      this.render(entries)
+    }
+    this.aggregator.addEventListener('entries', this.entryListener as EventListener)
+    const toggleKey = options.toggleKey ?? 'Tab'
+    this.keyHandler = (event: KeyboardEvent) => {
+      if (event.key !== toggleKey || event.defaultPrevented) {
+        return
+      }
+      if (event.altKey || event.ctrlKey || event.metaKey) {
+        return
+      }
+      event.preventDefault()
+      this.setVisible(!this.visible)
+    }
+    window.addEventListener('keydown', this.keyHandler)
+  }
+
+  dispose(): void {
+    //1.- Remove listeners so overlays do not accumulate when re-created.
+    window.removeEventListener('keydown', this.keyHandler)
+    this.aggregator.removeEventListener('entries', this.entryListener as EventListener)
+  }
+
+  private render(entries: ScoreboardEntry[]): void {
+    //1.- Rebuild the header to reflect new metric columns discovered at runtime.
+    const head = this.table.tHead ?? this.table.createTHead()
+    head.replaceChildren()
+    const headerRow = head.insertRow()
+    const nameHeader = this.container.ownerDocument.createElement('th')
+    nameHeader.scope = 'col'
+    nameHeader.textContent = 'Player'
+    headerRow.append(nameHeader)
+    for (const key of this.metricKeys) {
+      const cell = this.container.ownerDocument.createElement('th')
+      cell.scope = 'col'
+      cell.textContent = prettifyMetricKey(key)
+      headerRow.append(cell)
+    }
+    const body = this.table.tBodies[0] ?? this.table.createTBody()
+    body.replaceChildren()
+    for (const entry of entries) {
+      const row = body.insertRow()
+      const nameCell = row.insertCell()
+      nameCell.textContent = entry.displayName
+      for (const key of this.metricKeys) {
+        const valueCell = row.insertCell()
+        const value = entry.metrics[key]
+        valueCell.textContent = Number.isFinite(value) ? value.toFixed(Number.isInteger(value) ? 0 : 1) : '—'
+      }
+    }
+  }
+
+  private setVisible(visible: boolean): void {
+    //1.- Update ARIA and dataset attributes to mirror the visible state.
+    this.visible = visible
+    this.container.dataset.visible = visible ? 'true' : 'false'
+    this.container.setAttribute('aria-hidden', visible ? 'false' : 'true')
+  }
+}
+
+function prettifyMetricKey(key: string): string {
+  //1.- Expand snake_case metric identifiers into human readable labels.
+  return key
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}


### PR DESCRIPTION
## Summary
- add shared HUD metric and styling utilities for connection, buffer, and correction telemetry
- introduce a scoreboard aggregator and overlay that surfaces broker score updates with a Tab toggle
- wire the pieces together with a HUD controller and provide Vitest coverage for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df3f041b5c8329ae2285d8a4451f6b