### PR TITLE
Add keybinding remap UI and accessibility persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ The Tunnelcave sandbox web client ships with the following keyboard layout. Each
 
 Accessibility settings allow players to rebind any action while still displaying the original defaults for reference. The in-game help overlay lists the current key along with the default so customised layouts remain easy to share during cooperative play.
 
+### Accessibility Features
+
+- **Rebind controls in-game** — The sandbox includes a keybinding menu that listens for the next key press and stores overrides locally so every session honours player preferences.
+- **Colour-safe radar palettes** — Switch between the classic high-contrast palette and a deuteranopia-friendly variant; the HUD updates immediately without a reload.
+- **Reduced-motion mode** — Toggle calmer interface animations to assist players sensitive to rapid movement.
+- Accessibility preferences persist to the browser's local storage and can be reset by clearing the stored data.
+
 ## Development
 
 Run the unit tests to validate protocol handling and configuration parsing:

--- a/tunnelcave_sandbox_web/src/hud/radarPalettes.test.ts
+++ b/tunnelcave_sandbox_web/src/hud/radarPalettes.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { RadarPaletteController, RADAR_PALETTES } from './radarPalettes'
+
+describe('RadarPaletteController', () => {
+  it('applies the palette as custom properties on the document root', () => {
+    //1.- Create a controller bound to the current document to validate CSS property updates.
+    const controller = new RadarPaletteController(document)
+    controller.apply('colorSafe')
+    const root = document.documentElement
+    expect(root.dataset.radarPalette).toBe('colorSafe')
+    const palette = RADAR_PALETTES.find((entry) => entry.id === 'colorSafe')!
+    expect(root.style.getPropertyValue('--radar-background')).toBe(palette.background)
+    expect(root.style.getPropertyValue('--radar-friendly')).toBe(palette.friendly)
+    expect(root.style.getPropertyValue('--radar-hostile')).toBe(palette.hostile)
+    expect(root.style.getPropertyValue('--radar-neutral')).toBe(palette.neutral)
+  })
+})

--- a/tunnelcave_sandbox_web/src/hud/radarPalettes.ts
+++ b/tunnelcave_sandbox_web/src/hud/radarPalettes.ts
@@ -1,0 +1,71 @@
+import { RadarPaletteId } from '../input/accessibilityOptions'
+
+export interface RadarPaletteDefinition {
+  //1.- Stable identifier persisted in settings and reflected in data attributes.
+  id: RadarPaletteId
+  //2.- Human readable label surfaced inside accessibility menus.
+  label: string
+  //3.- Background fill colour used by the radar sweep canvas.
+  background: string
+  //4.- Contact colour for friendly actors.
+  friendly: string
+  //5.- Contact colour for hostile actors.
+  hostile: string
+  //6.- Colour used for neutral or unknown contacts.
+  neutral: string
+}
+
+export const RADAR_PALETTES: RadarPaletteDefinition[] = [
+  {
+    id: 'classic',
+    label: 'Classic High Contrast',
+    background: '#08111f',
+    friendly: '#67fdd0',
+    hostile: '#ff4f6d',
+    neutral: '#f5f7ff',
+  },
+  {
+    id: 'colorSafe',
+    label: 'Colour-Safe (Deuteranopia)',
+    background: '#0c1320',
+    friendly: '#2dd6f7',
+    hostile: '#ffd166',
+    neutral: '#f2f4f8',
+  },
+]
+
+export class RadarPaletteController {
+  private readonly target: Document | ShadowRoot
+
+  constructor(target: Document | ShadowRoot = document) {
+    //1.- Keep a reference to the DOM scope that should receive the palette styling.
+    this.target = target
+  }
+
+  apply(paletteId: RadarPaletteId): void {
+    //1.- Resolve the palette definition, defaulting to the classic theme when unknown.
+    const palette = RADAR_PALETTES.find((entry) => entry.id === paletteId) ?? RADAR_PALETTES[0]
+    const root = this.resolveRootElement()
+    if (!root) {
+      return
+    }
+    //2.- Expose the palette identifier for CSS selectors and analytics.
+    root.dataset.radarPalette = palette.id
+    //3.- Set custom properties so canvas renderers and CSS can consume the palette.
+    root.style.setProperty('--radar-background', palette.background)
+    root.style.setProperty('--radar-friendly', palette.friendly)
+    root.style.setProperty('--radar-hostile', palette.hostile)
+    root.style.setProperty('--radar-neutral', palette.neutral)
+  }
+
+  private resolveRootElement(): HTMLElement | null {
+    //1.- Support both top-level documents and shadow roots when applying the palette.
+    if ('documentElement' in this.target && this.target.documentElement) {
+      return this.target.documentElement
+    }
+    if ('host' in this.target && this.target.host instanceof HTMLElement) {
+      return this.target.host
+    }
+    return null
+  }
+}

--- a/tunnelcave_sandbox_web/src/input/accessibilityOptions.test.ts
+++ b/tunnelcave_sandbox_web/src/input/accessibilityOptions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { AccessibilityOptions } from './accessibilityOptions'
+import {
+  AccessibilityOptions,
+  DEFAULT_ACCESSIBILITY_TOGGLES,
+} from './accessibilityOptions'
 
 describe('AccessibilityOptions', () => {
   it('exposes summaries that include default bindings', () => {
@@ -22,5 +25,17 @@ describe('AccessibilityOptions', () => {
     //2.- The current configuration should now resolve the override when queried.
     const binding = options.currentConfiguration().findByKey('ArrowUp')
     expect(binding?.action).toBe('Accelerate')
+  })
+
+  it('tracks toggle state and merges incremental updates', () => {
+    //1.- Start with the default toggle state to verify the cloning behaviour.
+    const options = new AccessibilityOptions()
+    expect(options.toggleState()).toEqual(DEFAULT_ACCESSIBILITY_TOGGLES)
+    //2.- Apply a single reduced-motion override while leaving the palette intact.
+    options.applyToggles({ reducedMotion: true })
+    expect(options.toggleState()).toEqual({ radarPalette: 'classic', reducedMotion: true })
+    //3.- Switching palettes should retain the previously toggled reduced-motion flag.
+    options.applyToggles({ radarPalette: 'colorSafe' })
+    expect(options.toggleState()).toEqual({ radarPalette: 'colorSafe', reducedMotion: true })
   })
 })

--- a/tunnelcave_sandbox_web/src/input/accessibilityOptions.ts
+++ b/tunnelcave_sandbox_web/src/input/accessibilityOptions.ts
@@ -5,12 +5,34 @@ import {
   createKeybindingConfiguration,
 } from './keybindings'
 
+export type RadarPaletteId = 'classic' | 'colorSafe'
+
+export interface AccessibilityToggleState {
+  //1.- Track the selected radar palette so HUD systems can adjust their themes.
+  radarPalette: RadarPaletteId
+  //2.- Flag whether motion-heavy elements should tone down their animation cadence.
+  reducedMotion: boolean
+}
+
+export const DEFAULT_ACCESSIBILITY_TOGGLES: AccessibilityToggleState = {
+  //1.- Default to the high-contrast classic palette until the player opts into the colour-safe variant.
+  radarPalette: 'classic',
+  //2.- Assume standard motion until the user expresses a preference for calmer effects.
+  reducedMotion: false,
+}
+
 export class AccessibilityOptions {
   private config: KeybindingConfiguration
+  private toggles: AccessibilityToggleState
 
-  constructor(config: KeybindingConfiguration = createKeybindingConfiguration()) {
+  constructor(
+    config: KeybindingConfiguration = createKeybindingConfiguration(),
+    toggles: AccessibilityToggleState = DEFAULT_ACCESSIBILITY_TOGGLES,
+  ) {
     //1.- Retain a mutable configuration that can be reissued when overrides are applied.
     this.config = config
+    //2.- Persist the current accessibility toggles so multiple menus stay in sync.
+    this.toggles = { ...toggles }
   }
 
   summaries(): AccessibilitySummary[] {
@@ -26,5 +48,15 @@ export class AccessibilityOptions {
   currentConfiguration(): KeybindingConfiguration {
     //1.- Expose the latest keybinding table for other systems such as overlays.
     return this.config
+  }
+
+  toggleState(): AccessibilityToggleState {
+    //1.- Provide a defensive copy so callers cannot mutate internal state accidentally.
+    return { ...this.toggles }
+  }
+
+  applyToggles(update: Partial<AccessibilityToggleState>): void {
+    //1.- Merge the supplied flags with the existing state to honour incremental updates.
+    this.toggles = { ...this.toggles, ...update }
   }
 }

--- a/tunnelcave_sandbox_web/src/ui/settings/accessibilityPreferenceStore.test.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/accessibilityPreferenceStore.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AccessibilityToggleState,
+  DEFAULT_ACCESSIBILITY_TOGGLES,
+} from '../../input/accessibilityOptions'
+import { AccessibilityPreferenceStore, ACCESSIBILITY_STORAGE_KEY } from './accessibilityPreferenceStore'
+
+class MemoryStorage implements Storage {
+  //1.- Provide a deterministic in-memory storage implementation for tests.
+  private store = new Map<string, string>()
+
+  get length(): number {
+    return this.store.size
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value)
+  }
+}
+
+describe('AccessibilityPreferenceStore', () => {
+  it('loads previously persisted payloads', () => {
+    //1.- Pre-seed the storage with an override payload to ensure hydration works.
+    const storage = new MemoryStorage()
+    storage.setItem(
+      ACCESSIBILITY_STORAGE_KEY,
+      JSON.stringify({ keybindings: { Accelerate: { key: 'ArrowUp' } } }),
+    )
+    const store = new AccessibilityPreferenceStore(storage)
+    expect(store.keybindingOverrides()).toEqual({ Accelerate: { key: 'ArrowUp' } })
+    expect(store.toggleState()).toEqual(DEFAULT_ACCESSIBILITY_TOGGLES)
+  })
+
+  it('persists keybinding overrides and toggle state updates', () => {
+    //1.- Apply both keybinding overrides and toggle updates to validate persistence.
+    const storage = new MemoryStorage()
+    const store = new AccessibilityPreferenceStore(storage)
+    store.saveKeybindings({ Boost: { key: 'KeyF' } })
+    const toggles: AccessibilityToggleState = { radarPalette: 'colorSafe', reducedMotion: true }
+    store.saveToggles(toggles)
+    //2.- Reload the store from the backing storage to confirm round-trip fidelity.
+    const reloaded = new AccessibilityPreferenceStore(storage)
+    expect(reloaded.keybindingOverrides()).toEqual({ Boost: { key: 'KeyF' } })
+    expect(reloaded.toggleState()).toEqual(toggles)
+  })
+})

--- a/tunnelcave_sandbox_web/src/ui/settings/accessibilityPreferenceStore.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/accessibilityPreferenceStore.ts
@@ -1,0 +1,75 @@
+import {
+  AccessibilityToggleState,
+  DEFAULT_ACCESSIBILITY_TOGGLES,
+} from '../../input/accessibilityOptions'
+import { KeybindingOverrides } from '../../input/keybindings'
+
+export interface StoredAccessibilityPreferences {
+  //1.- Serialised keybinding overrides keyed by the gameplay action name.
+  keybindings?: KeybindingOverrides
+  //2.- Persisted toggle values that complement the override information.
+  toggles?: AccessibilityToggleState
+}
+
+export const ACCESSIBILITY_STORAGE_KEY = 'driftpursuit.accessibility'
+
+export class AccessibilityPreferenceStore {
+  private readonly storage: Storage
+  private cache: StoredAccessibilityPreferences
+
+  constructor(storage: Storage) {
+    //1.- Remember the storage implementation so preferences can be written back immediately.
+    this.storage = storage
+    //2.- Attempt to hydrate the cache using the previously saved JSON payload.
+    this.cache = this.read()
+  }
+
+  preferences(): StoredAccessibilityPreferences {
+    //1.- Return a structured clone to avoid accidental external mutation of the cache.
+    const keybindings = this.cache.keybindings ? { ...this.cache.keybindings } : undefined
+    const toggles = this.cache.toggles ? { ...this.cache.toggles } : undefined
+    return { keybindings, toggles }
+  }
+
+  keybindingOverrides(): KeybindingOverrides {
+    //1.- Fallback to an empty object when no keybinding overrides were previously saved.
+    return this.cache.keybindings ? { ...this.cache.keybindings } : {}
+  }
+
+  toggleState(): AccessibilityToggleState {
+    //1.- Merge the cached toggles with the defaults to guarantee a full state shape.
+    return { ...DEFAULT_ACCESSIBILITY_TOGGLES, ...this.cache.toggles }
+  }
+
+  saveKeybindings(overrides: KeybindingOverrides): void {
+    //1.- Update the cache and synchronise it with persistent storage.
+    this.cache = { ...this.cache, keybindings: { ...overrides } }
+    this.write()
+  }
+
+  saveToggles(toggles: AccessibilityToggleState): void {
+    //1.- Record the latest toggle state so reloading the menu preserves accessibility choices.
+    this.cache = { ...this.cache, toggles: { ...toggles } }
+    this.write()
+  }
+
+  private read(): StoredAccessibilityPreferences {
+    //1.- Attempt to parse stored JSON while handling malformed payloads gracefully.
+    try {
+      const raw = this.storage.getItem(ACCESSIBILITY_STORAGE_KEY)
+      if (!raw) {
+        return {}
+      }
+      const parsed = JSON.parse(raw) as StoredAccessibilityPreferences
+      return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  private write(): void {
+    //1.- Persist the cache in a deterministic JSON shape for debugging clarity.
+    const payload = JSON.stringify(this.cache)
+    this.storage.setItem(ACCESSIBILITY_STORAGE_KEY, payload)
+  }
+}

--- a/tunnelcave_sandbox_web/src/ui/settings/accessibilityTogglesMenu.test.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/accessibilityTogglesMenu.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { AccessibilityOptions } from '../../input/accessibilityOptions'
+import { RadarPaletteController } from '../../hud/radarPalettes'
+import {
+  AccessibilityPreferenceStore,
+  ACCESSIBILITY_STORAGE_KEY,
+} from './accessibilityPreferenceStore'
+import { AccessibilityTogglesMenu } from './accessibilityTogglesMenu'
+
+class MemoryStorage implements Storage {
+  //1.- Provide a deterministic storage stub to validate persistence behaviour.
+  private store = new Map<string, string>()
+
+  get length(): number {
+    return this.store.size
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value)
+  }
+}
+
+describe('AccessibilityTogglesMenu', () => {
+  it('loads stored toggle preferences on initial render', () => {
+    //1.- Seed a stored toggle payload so the UI honours persisted preferences.
+    const storage = new MemoryStorage()
+    storage.setItem(
+      ACCESSIBILITY_STORAGE_KEY,
+      JSON.stringify({ toggles: { radarPalette: 'colorSafe', reducedMotion: true } }),
+    )
+    const root = document.createElement('div')
+    document.body.append(root)
+    const options = new AccessibilityOptions()
+    const store = new AccessibilityPreferenceStore(storage)
+    const controller = new RadarPaletteController(document)
+    new AccessibilityTogglesMenu(root, options, store, controller)
+    //2.- Validate both the DOM controls and global dataset reflect the stored choices.
+    const select = root.querySelector('select') as HTMLSelectElement
+    expect(select.value).toBe('colorSafe')
+    const checkbox = root.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(true)
+    expect(document.documentElement.dataset.reducedMotion).toBe('true')
+  })
+
+  it('persists toggle changes and applies visual updates', () => {
+    //1.- Render with defaults and flip both toggles to ensure persistence occurs.
+    const storage = new MemoryStorage()
+    const root = document.createElement('div')
+    document.body.append(root)
+    const options = new AccessibilityOptions()
+    const store = new AccessibilityPreferenceStore(storage)
+    const controller = new RadarPaletteController(document)
+    new AccessibilityTogglesMenu(root, options, store, controller)
+    const select = root.querySelector('select') as HTMLSelectElement
+    select.value = 'colorSafe'
+    select.dispatchEvent(new Event('change'))
+    const checkbox = root.querySelector('input[type="checkbox"]') as HTMLInputElement
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change'))
+    //2.- The dataset and storage should now reflect the new accessibility choices.
+    expect(document.documentElement.dataset.reducedMotion).toBe('true')
+    const payload = storage.getItem(ACCESSIBILITY_STORAGE_KEY)
+    expect(payload).toBeTruthy()
+    const parsed = JSON.parse(payload!)
+    expect(parsed.toggles).toEqual({ radarPalette: 'colorSafe', reducedMotion: true })
+    expect(parsed.keybindings ?? {}).toEqual({})
+    //3.- The accessibility options object should now report the updated state to other systems.
+    expect(options.toggleState()).toEqual({ radarPalette: 'colorSafe', reducedMotion: true })
+  })
+})

--- a/tunnelcave_sandbox_web/src/ui/settings/accessibilityTogglesMenu.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/accessibilityTogglesMenu.ts
@@ -1,0 +1,104 @@
+import {
+  AccessibilityOptions,
+  AccessibilityToggleState,
+} from '../../input/accessibilityOptions'
+import { RADAR_PALETTES, RadarPaletteController } from '../../hud/radarPalettes'
+import { AccessibilityPreferenceStore } from './accessibilityPreferenceStore'
+
+export class AccessibilityTogglesMenu {
+  private readonly container: HTMLElement
+  private readonly options: AccessibilityOptions
+  private readonly store: AccessibilityPreferenceStore
+  private readonly radarPalettes: RadarPaletteController
+  private readonly ownerDocument: Document
+
+  constructor(
+    root: HTMLElement,
+    options: AccessibilityOptions,
+    store: AccessibilityPreferenceStore,
+    radarPalettes: RadarPaletteController,
+    ownerDocument: Document = document,
+  ) {
+    //1.- Persist collaborators to keep the UI in sync with gameplay systems and storage.
+    this.options = options
+    this.store = store
+    this.radarPalettes = radarPalettes
+    this.ownerDocument = ownerDocument
+    //2.- Hydrate the toggle state from storage before rendering UI controls.
+    const toggles = this.store.toggleState()
+    this.options.applyToggles(toggles)
+    this.applyVisuals(toggles)
+    //3.- Build the settings section so players can adjust the toggles interactively.
+    this.container = ownerDocument.createElement('section')
+    this.container.className = 'accessibility-toggles'
+    const heading = ownerDocument.createElement('h3')
+    heading.textContent = 'Accessibility Preferences'
+    this.container.append(heading)
+    this.render(toggles)
+    root.append(this.container)
+  }
+
+  private render(state: AccessibilityToggleState): void {
+    //1.- Render the radar palette selector list.
+    const paletteLabel = this.ownerDocument.createElement('label')
+    paletteLabel.textContent = 'Radar Palette'
+    const paletteSelect = this.ownerDocument.createElement('select')
+    paletteSelect.className = 'accessibility-toggles__palette'
+    for (const palette of RADAR_PALETTES) {
+      const option = this.ownerDocument.createElement('option')
+      option.value = palette.id
+      option.textContent = palette.label
+      if (palette.id === state.radarPalette) {
+        option.selected = true
+      }
+      paletteSelect.append(option)
+    }
+    paletteSelect.addEventListener('change', () => {
+      const next = { ...this.options.toggleState(), radarPalette: paletteSelect.value as typeof state.radarPalette }
+      this.commitToggleState(next)
+    })
+    const paletteWrapper = this.ownerDocument.createElement('div')
+    paletteWrapper.className = 'accessibility-toggles__row'
+    paletteWrapper.append(paletteLabel, paletteSelect)
+
+    //2.- Render the reduced motion checkbox so UI elements can tone down animation.
+    const reducedMotionWrapper = this.ownerDocument.createElement('div')
+    reducedMotionWrapper.className = 'accessibility-toggles__row'
+    const reducedMotionLabel = this.ownerDocument.createElement('label')
+    reducedMotionLabel.textContent = 'Reduced Motion'
+    const reducedMotionCheckbox = this.ownerDocument.createElement('input')
+    reducedMotionCheckbox.type = 'checkbox'
+    reducedMotionCheckbox.checked = state.reducedMotion
+    reducedMotionCheckbox.addEventListener('change', () => {
+      const next = { ...this.options.toggleState(), reducedMotion: reducedMotionCheckbox.checked }
+      this.commitToggleState(next)
+    })
+    reducedMotionWrapper.append(reducedMotionLabel, reducedMotionCheckbox)
+
+    const list = this.ownerDocument.createElement('div')
+    list.className = 'accessibility-toggles__list'
+    list.append(paletteWrapper, reducedMotionWrapper)
+
+    const existing = this.container.querySelector('.accessibility-toggles__list')
+    if (existing) {
+      existing.replaceWith(list)
+    } else {
+      this.container.append(list)
+    }
+  }
+
+  private commitToggleState(state: AccessibilityToggleState): void {
+    //1.- Persist the toggles locally and push them into the gameplay options.
+    this.options.applyToggles(state)
+    this.store.saveToggles(state)
+    this.applyVisuals(state)
+  }
+
+  private applyVisuals(state: AccessibilityToggleState): void {
+    //1.- Apply the selected radar palette so the HUD updates instantly.
+    this.radarPalettes.apply(state.radarPalette)
+    //2.- Reflect the reduced motion preference for CSS animations to observe.
+    const root = this.ownerDocument.documentElement
+    root.dataset.reducedMotion = state.reducedMotion ? 'true' : 'false'
+  }
+}

--- a/tunnelcave_sandbox_web/src/ui/settings/keybindingMenu.test.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/keybindingMenu.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AccessibilityOptions } from '../../input/accessibilityOptions'
+import { createKeybindingConfiguration } from '../../input/keybindings'
+import {
+  AccessibilityPreferenceStore,
+  ACCESSIBILITY_STORAGE_KEY,
+} from './accessibilityPreferenceStore'
+import { KeybindingMenu } from './keybindingMenu'
+
+class MemoryStorage implements Storage {
+  //1.- Provide a deterministic in-memory storage implementation for repeatable tests.
+  private store = new Map<string, string>()
+
+  get length(): number {
+    return this.store.size
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value)
+  }
+}
+
+describe('KeybindingMenu', () => {
+  let storage: MemoryStorage
+
+  beforeEach(() => {
+    storage = new MemoryStorage()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders overrides loaded from storage', () => {
+    //1.- Seed storage so the menu initialises with a remapped accelerate action.
+    storage.setItem(
+      ACCESSIBILITY_STORAGE_KEY,
+      JSON.stringify({ keybindings: { Accelerate: { key: 'ArrowUp' } } }),
+    )
+    const root = document.createElement('div')
+    document.body.append(root)
+    const options = new AccessibilityOptions(createKeybindingConfiguration())
+    const store = new AccessibilityPreferenceStore(storage)
+    new KeybindingMenu(root, options, store)
+    //2.- Inspect the rendered entries to confirm the override surfaced in the UI.
+    const entries = Array.from(root.querySelectorAll('dd button')).map((node) => node.textContent)
+    expect(entries).toContain('Arrow Up')
+  })
+
+  it('captures keyboard input and saves overrides to storage', () => {
+    //1.- Render the menu with the default configuration to capture a new binding.
+    const root = document.createElement('div')
+    document.body.append(root)
+    const options = new AccessibilityOptions(createKeybindingConfiguration())
+    const store = new AccessibilityPreferenceStore(storage)
+    const menu = new KeybindingMenu(root, options, store, document)
+    const accelerateButton = root.querySelector('button[data-action="Accelerate"]') as HTMLButtonElement
+    accelerateButton.click()
+    //2.- Dispatch a simulated keydown to trigger the rebinding workflow.
+    const event = new KeyboardEvent('keydown', { code: 'ArrowUp' })
+    document.dispatchEvent(event)
+    menu.destroy()
+    const payload = storage.getItem(ACCESSIBILITY_STORAGE_KEY)
+    expect(payload).toBeTruthy()
+    expect(JSON.parse(payload!)).toEqual({ keybindings: { Accelerate: { key: 'ArrowUp' } } })
+    //3.- The button text should now reflect the captured key for visual confirmation.
+    expect(accelerateButton.textContent).toBe('Arrow Up')
+  })
+})

--- a/tunnelcave_sandbox_web/src/ui/settings/keybindingMenu.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/keybindingMenu.ts
@@ -1,0 +1,152 @@
+import { AccessibilityOptions } from '../../input/accessibilityOptions'
+import { formatKeyLabel } from '../../input/keyLabels'
+import {
+  Keybinding,
+  KeybindingConfiguration,
+  KeybindingOverrides,
+} from '../../input/keybindings'
+import { AccessibilityPreferenceStore } from './accessibilityPreferenceStore'
+
+type KeybindingCaptureHandler = (event: KeyboardEvent) => void
+
+export class KeybindingMenu {
+  private readonly container: HTMLElement
+  private readonly options: AccessibilityOptions
+  private readonly store: AccessibilityPreferenceStore
+  private readonly ownerDocument: Document
+  private captureAction: string | null = null
+  private captureHandler: KeybindingCaptureHandler | null = null
+
+  constructor(
+    root: HTMLElement,
+    options: AccessibilityOptions,
+    store: AccessibilityPreferenceStore,
+    ownerDocument: Document = document,
+  ) {
+    //1.- Persist collaborators so the UI can mutate accessibility state and storage.
+    this.options = options
+    this.store = store
+    this.ownerDocument = ownerDocument
+    //2.- Hydrate the keybinding configuration with any previously saved overrides.
+    const overrides = this.store.keybindingOverrides()
+    if (Object.keys(overrides).length > 0) {
+      this.options.apply(overrides)
+    }
+    //3.- Render the menu container immediately so the call site receives visible controls.
+    this.container = ownerDocument.createElement('section')
+    this.container.className = 'accessibility-keybindings'
+    const heading = ownerDocument.createElement('h3')
+    heading.textContent = 'Keybindings'
+    this.container.append(heading)
+    root.append(this.container)
+    this.render()
+  }
+
+  destroy(): void {
+    //1.- Remove the capture listener to avoid leaking closures when the menu is torn down.
+    if (this.captureHandler) {
+      this.ownerDocument.removeEventListener('keydown', this.captureHandler, true)
+    }
+  }
+
+  private render(): void {
+    //1.- Rebuild the bindings list so overrides immediately surface to the player.
+    const list = this.ownerDocument.createElement('dl')
+    list.className = 'accessibility-keybindings__list'
+    const bindings = this.options.currentConfiguration().describe()
+    for (const binding of bindings) {
+      this.appendEntry(list, binding)
+    }
+    //2.- Swap the previous list to ensure the DOM stays in sync with the latest state.
+    const existingList = this.container.querySelector('dl')
+    if (existingList) {
+      existingList.replaceWith(list)
+    } else {
+      this.container.append(list)
+    }
+  }
+
+  private appendEntry(list: HTMLElement, binding: Keybinding): void {
+    //1.- Create the definition list entry for the supplied binding.
+    const term = this.ownerDocument.createElement('dt')
+    term.textContent = binding.action
+    const value = this.ownerDocument.createElement('dd')
+    const button = this.ownerDocument.createElement('button')
+    button.type = 'button'
+    button.dataset.action = binding.action
+    button.className = 'accessibility-keybindings__control'
+    button.textContent = formatKeyLabel(binding.key)
+    button.addEventListener('click', () => this.beginCapture(binding.action, button))
+    const defaultLabel = this.ownerDocument.createElement('small')
+    defaultLabel.className = 'accessibility-keybindings__default'
+    defaultLabel.textContent = `Default: ${formatKeyLabel(binding.defaultKey)}`
+    value.append(button, defaultLabel)
+    list.append(term, value)
+  }
+
+  private beginCapture(action: string, button: HTMLButtonElement): void {
+    //1.- Prevent multiple capture sessions from running simultaneously.
+    this.endCapture()
+    this.captureAction = action
+    button.dataset.capturing = 'true'
+    button.textContent = 'Press a key...'
+    this.captureHandler = (event: KeyboardEvent) => this.completeCapture(event, button)
+    this.ownerDocument.addEventListener('keydown', this.captureHandler, true)
+  }
+
+  private endCapture(): void {
+    //1.- Stop listening for keydown events and reset UI affordances.
+    if (this.captureHandler) {
+      this.ownerDocument.removeEventListener('keydown', this.captureHandler, true)
+    }
+    this.captureHandler = null
+    this.captureAction = null
+    const active = this.container.querySelector('button[data-capturing="true"]')
+    if (active instanceof HTMLButtonElement) {
+      active.dataset.capturing = 'false'
+      const binding = this.lookupBinding(active.dataset.action)
+      if (binding) {
+        active.textContent = formatKeyLabel(binding.key)
+      }
+    }
+  }
+
+  private completeCapture(event: KeyboardEvent, button: HTMLButtonElement): void {
+    //1.- Ignore repeated events to reduce accidental duplicate registrations.
+    if (event.repeat || !this.captureAction) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    const key = event.code
+    const action = this.captureAction
+    this.options.apply({ [action]: { key } })
+    this.persistOverrides()
+    button.dataset.capturing = 'false'
+    button.textContent = formatKeyLabel(key)
+    this.captureAction = null
+    this.endCapture()
+  }
+
+  private persistOverrides(): void {
+    //1.- Collect the current overrides so they can be written back to persistent storage.
+    const overrides: KeybindingOverrides = {}
+    const config: KeybindingConfiguration = this.options.currentConfiguration()
+    for (const binding of config.describe()) {
+      if (binding.key !== binding.defaultKey) {
+        overrides[binding.action] = { key: binding.key }
+      }
+    }
+    this.store.saveKeybindings(overrides)
+    //2.- Re-render the list to refresh default annotations after saving.
+    this.render()
+  }
+
+  private lookupBinding(action?: string): Keybinding | undefined {
+    //1.- Resolve the binding so we can refresh button labels when cancelling capture state.
+    if (!action) {
+      return undefined
+    }
+    return this.options.currentConfiguration().describe().find((entry) => entry.action === action)
+  }
+}


### PR DESCRIPTION
## Summary
- add keybinding menu, toggle menu, and persistence helpers for accessibility settings
- introduce radar palette controller and update accessibility options to manage toggle state
- document the new accessibility capabilities for the web client

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df4494ba308329a9e5d4f08ac4fa78