### PR TITLE
Add replay headers and catalog tooling

### DIFF
--- a/docs/replay_format.md
+++ b/docs/replay_format.md
@@ -1,9 +1,27 @@
 # High-Frequency Replay Format
 
 ## Bundle Layout
+- `header.json` — JSON header describing match metadata for catalogue tooling.
 - `manifest.json` — JSON manifest describing paths and cadence metadata.
 - `events.jsonl.sz` — Snappy-compressed JSON lines, each describing a gameplay event.
 - `frames.bin.zst` — Zstandard-compressed binary stream containing cadence-controlled frame blobs.
+
+## Header Schema
+```json
+{
+  "schema_version": 1,
+  "match_seed": "deterministic match seed",
+  "terrain_params": {
+    "roughness": 0.5
+  },
+  "file_pointer": "manifest.json"
+}
+```
+
+1. The `schema_version` tracks compatibility for consumers parsing the header.
+2. The `match_seed` captures the deterministic RNG seed broadcast at match start.
+3. `terrain_params` stores numeric terrain tuning metadata when available.
+4. `file_pointer` references the replay entry point relative to the header file.
 
 ## Manifest Schema
 ```json

--- a/go-broker/internal/config/config.go
+++ b/go-broker/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -66,6 +67,8 @@ type Config struct {
 	ReplayDumpWindow      time.Duration
 	ReplayDumpBurst       int
 	ReplayDirectory       string
+	MatchSeed             string
+	TerrainParams         map[string]float64
 	Logging               LoggingConfig
 	StateSnapshotPath     string
 	StateSnapshotInterval time.Duration
@@ -106,6 +109,7 @@ func Load() (*Config, error) {
 		ReplayDumpWindow: DefaultReplayDumpWindow,
 		ReplayDumpBurst:  DefaultReplayDumpBurst,
 		ReplayDirectory:  strings.TrimSpace(os.Getenv("BROKER_REPLAY_DIR")),
+		MatchSeed:        strings.TrimSpace(os.Getenv("BROKER_MATCH_SEED")),
 		Logging: LoggingConfig{
 			Level:      strings.TrimSpace(getString("BROKER_LOG_LEVEL", DefaultLogLevel)),
 			Path:       strings.TrimSpace(getString("BROKER_LOG_PATH", DefaultLogPath)),
@@ -190,6 +194,15 @@ func Load() (*Config, error) {
 			problems = append(problems, fmt.Sprintf("BROKER_BOT_TARGET must be a non-negative integer, got %q", raw))
 		} else {
 			cfg.BotTargetPopulation = value
+		}
+	}
+
+	if raw := strings.TrimSpace(os.Getenv("BROKER_TERRAIN_PARAMS")); raw != "" {
+		var parsed map[string]float64
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			problems = append(problems, fmt.Sprintf("BROKER_TERRAIN_PARAMS must be JSON object of numeric values, got %q", raw))
+		} else {
+			cfg.TerrainParams = parsed
 		}
 	}
 

--- a/go-broker/internal/replay/header.go
+++ b/go-broker/internal/replay/header.go
@@ -1,0 +1,84 @@
+package replay
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HeaderSchemaVersion tracks the schema version for replay header documents.
+const HeaderSchemaVersion = 1
+
+// TerrainParameters captures configurable terrain tuning metadata for the match.
+type TerrainParameters map[string]float64
+
+// Clone returns a defensive copy of the terrain parameters map.
+func (p TerrainParameters) Clone() TerrainParameters {
+	if len(p) == 0 {
+		return nil
+	}
+	//1.- Allocate a fresh map so callers can mutate clones without touching shared state.
+	clone := make(TerrainParameters, len(p))
+	for key, value := range p {
+		clone[key] = value
+	}
+	return clone
+}
+
+// Header represents the metadata persisted alongside a replay artefact.
+type Header struct {
+	SchemaVersion int               `json:"schema_version"`
+	MatchSeed     string            `json:"match_seed"`
+	TerrainParams TerrainParameters `json:"terrain_params,omitempty"`
+	FilePointer   string            `json:"file_pointer"`
+}
+
+// Validate ensures the header contains enough information for catalogue tooling.
+func (h Header) Validate() error {
+	if h.SchemaVersion <= 0 {
+		return fmt.Errorf("schema_version must be positive")
+	}
+	//1.- Ensure catalogue tooling can locate the replay artefact reliably.
+	if strings.TrimSpace(h.FilePointer) == "" {
+		return fmt.Errorf("file_pointer must not be empty")
+	}
+	return nil
+}
+
+// WriteHeader persists the supplied header to the provided file path.
+func WriteHeader(path string, header Header) error {
+	if err := header.Validate(); err != nil {
+		return err
+	}
+	//1.- Encode using indented JSON so manual inspection remains readable.
+	payload, err := json.MarshalIndent(header, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	//2.- Ensure the directory hierarchy exists even when tooling supplies nested paths.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	//3.- Terminate with a newline so POSIX tooling can append easily.
+	return os.WriteFile(path, append(payload, '\n'), 0o644)
+}
+
+// ReadHeader loads and decodes a replay header from disk.
+func ReadHeader(path string) (Header, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Header{}, err
+	}
+	var header Header
+	if err := json.Unmarshal(data, &header); err != nil {
+		return Header{}, err
+	}
+	//1.- Reuse validation so callers receive consistent error semantics.
+	if err := header.Validate(); err != nil {
+		return Header{}, err
+	}
+	return header, nil
+}

--- a/go-broker/internal/replay/header_test.go
+++ b/go-broker/internal/replay/header_test.go
@@ -1,0 +1,33 @@
+package replay
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteAndReadHeader(t *testing.T) {
+	dir := t.TempDir()
+	header := Header{
+		SchemaVersion: HeaderSchemaVersion,
+		MatchSeed:     "seed-9",
+		TerrainParams: TerrainParameters{"roughness": 0.5},
+		FilePointer:   "match.json.gz",
+	}
+	path := filepath.Join(dir, "example.header.json")
+	if err := WriteHeader(path, header); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	loaded, err := ReadHeader(path)
+	if err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	if loaded.SchemaVersion != header.SchemaVersion || loaded.MatchSeed != header.MatchSeed {
+		t.Fatalf("unexpected header values: %+v", loaded)
+	}
+	if loaded.TerrainParams["roughness"] != 0.5 {
+		t.Fatalf("unexpected terrain params: %#v", loaded.TerrainParams)
+	}
+	if loaded.FilePointer != header.FilePointer {
+		t.Fatalf("unexpected file pointer: %q", loaded.FilePointer)
+	}
+}

--- a/go-broker/internal/replay/loader_test.go
+++ b/go-broker/internal/replay/loader_test.go
@@ -18,6 +18,7 @@ func TestLoaderReplayOrdering(t *testing.T) {
 		t.Fatalf("NewRecorder: %v", err)
 	}
 
+	recorder.SetHeaderMetadata("seed-beta", nil)
 	recorder.RecordEvent(5, 900, []byte(`{"event":"late"}`))
 	recorder.RecordWorldFrame(3, 600, []byte(`{"frame":3}`))
 	recorder.RecordTick(1, 100, []byte(`{"tick":1}`))
@@ -25,13 +26,16 @@ func TestLoaderReplayOrdering(t *testing.T) {
 	recorder.RecordWorldFrame(2, 400, []byte(`{"frame":2}`))
 	recorder.RecordTick(2, 300, []byte(`{"tick":2}`))
 
-	path, err := recorder.Roll("beta")
+	path, headerPath, err := recorder.Roll("beta")
 	if err != nil {
 		t.Fatalf("Roll: %v", err)
 	}
 
 	if filepath.Ext(path) != ".gz" {
 		t.Fatalf("expected gzip artefact, got %s", path)
+	}
+	if filepath.Ext(headerPath) != ".json" {
+		t.Fatalf("expected json header, got %s", headerPath)
 	}
 
 	loader, err := Load(path)

--- a/go-broker/internal/replay/writer_test.go
+++ b/go-broker/internal/replay/writer_test.go
@@ -25,6 +25,8 @@ func TestWriterAppendAndFlushCadence(t *testing.T) {
 		t.Fatalf("create writer: %v", err)
 	}
 
+	writer.SetHeaderMetadata("seed-abc", TerrainParameters{"roughness": 0.6})
+
 	if manifest.FrameIntervalMs != 200 {
 		t.Fatalf("expected frame interval 200 ms, got %d", manifest.FrameIntervalMs)
 	}
@@ -134,6 +136,20 @@ func TestWriterAppendAndFlushCadence(t *testing.T) {
 			t.Fatalf("unexpected frame payload size: %d", len(fr.Payload))
 		}
 	}
+
+	header, err := ReadHeader(filepath.Join(writer.Directory(), "header.json"))
+	if err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	if header.MatchSeed != "seed-abc" {
+		t.Fatalf("unexpected header seed: %q", header.MatchSeed)
+	}
+	if header.FilePointer != "manifest.json" {
+		t.Fatalf("unexpected header file pointer: %q", header.FilePointer)
+	}
+	if header.TerrainParams["roughness"] != 0.6 {
+		t.Fatalf("unexpected header terrain params: %#v", header.TerrainParams)
+	}
 }
 
 func TestWriterManualFlush(t *testing.T) {
@@ -146,6 +162,8 @@ func TestWriterManualFlush(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create writer: %v", err)
 	}
+
+	writer.SetHeaderMetadata("seed-manual", TerrainParameters{"roughness": 0.3})
 
 	payload := []byte{0xAA, 0xBB}
 
@@ -183,6 +201,14 @@ func TestWriterManualFlush(t *testing.T) {
 	frames := decodeFrameBlobs(frameBytes)
 	if len(frames) != 2 {
 		t.Fatalf("expected 2 frames, got %d", len(frames))
+	}
+
+	header, err := ReadHeader(filepath.Join(writer.Directory(), "header.json"))
+	if err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	if header.MatchSeed != "seed-manual" {
+		t.Fatalf("unexpected manual header seed: %q", header.MatchSeed)
 	}
 }
 

--- a/go-broker/tools/replay_catalog/catalog.go
+++ b/go-broker/tools/replay_catalog/catalog.go
@@ -1,0 +1,75 @@
+package replaycatalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"driftpursuit/broker/internal/replay"
+)
+
+// Entry captures a replay header alongside its resolved artefact path.
+type Entry struct {
+	HeaderPath string        `json:"header_path"`
+	ReplayPath string        `json:"replay_path"`
+	Header     replay.Header `json:"header"`
+}
+
+// List walks the directory tree and returns parsed replay headers.
+func List(root string) ([]Entry, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("root directory must be provided")
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root must be a directory")
+	}
+
+	var entries []Entry
+	//1.- Walk the directory tree searching for known header filenames.
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if name != "header.json" && !strings.HasSuffix(name, ".header.json") {
+			return nil
+		}
+		header, err := replay.ReadHeader(path)
+		if err != nil {
+			return err
+		}
+		replayPath := header.FilePointer
+		if !filepath.IsAbs(replayPath) {
+			replayPath = filepath.Join(filepath.Dir(path), replayPath)
+		}
+		entries = append(entries, Entry{HeaderPath: path, ReplayPath: replayPath, Header: header})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Header.MatchSeed == entries[j].Header.MatchSeed {
+			return entries[i].ReplayPath < entries[j].ReplayPath
+		}
+		return entries[i].Header.MatchSeed < entries[j].Header.MatchSeed
+	})
+	return entries, nil
+}
+
+// MarshalEntries produces a stable JSON representation of the entries for CLI output.
+func MarshalEntries(entries []Entry) ([]byte, error) {
+	//1.- Marshal with indentation to keep CLI output legible for operators.
+	return json.MarshalIndent(entries, "", "  ")
+}

--- a/go-broker/tools/replay_catalog/catalog_test.go
+++ b/go-broker/tools/replay_catalog/catalog_test.go
@@ -1,0 +1,51 @@
+package replaycatalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"driftpursuit/broker/internal/replay"
+)
+
+func TestListCollectsHeaders(t *testing.T) {
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "alpha")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	header := replay.Header{
+		SchemaVersion: replay.HeaderSchemaVersion,
+		MatchSeed:     "seed-alpha",
+		TerrainParams: replay.TerrainParameters{"roughness": 0.4},
+		FilePointer:   "match.json.gz",
+	}
+	headerPath := filepath.Join(dataDir, "header.json")
+	if err := replay.WriteHeader(headerPath, header); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+
+	entries, err := List(dir)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected single entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Header.MatchSeed != "seed-alpha" {
+		t.Fatalf("unexpected match seed: %q", entry.Header.MatchSeed)
+	}
+	if entry.ReplayPath != filepath.Join(dataDir, "match.json.gz") {
+		t.Fatalf("unexpected replay path: %q", entry.ReplayPath)
+	}
+
+	payload, err := MarshalEntries(entries)
+	if err != nil {
+		t.Fatalf("MarshalEntries: %v", err)
+	}
+	if len(payload) == 0 {
+		t.Fatalf("expected JSON payload to be non-empty")
+	}
+}

--- a/go-broker/tools/replay_catalog/cmd/replay_catalog/main.go
+++ b/go-broker/tools/replay_catalog/cmd/replay_catalog/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"driftpursuit/broker/tools/replay_catalog"
+)
+
+func main() {
+	root := flag.String("dir", ".", "directory containing replay headers")
+	jsonFlag := flag.Bool("json", false, "emit JSON instead of human-readable output")
+	flag.Parse()
+
+	entries, err := replaycatalog.List(*root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if *jsonFlag {
+		payload, err := replaycatalog.MarshalEntries(entries)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(string(payload))
+		return
+	}
+
+	for _, entry := range entries {
+		fmt.Printf("%s (schema %d)\n", entry.ReplayPath, entry.Header.SchemaVersion)
+		if entry.Header.MatchSeed != "" {
+			fmt.Printf("  seed: %s\n", entry.Header.MatchSeed)
+		}
+		if len(entry.Header.TerrainParams) > 0 {
+			keys := make([]string, 0, len(entry.Header.TerrainParams))
+			for key := range entry.Header.TerrainParams {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			fmt.Printf("  terrain:\n")
+			for _, key := range keys {
+				fmt.Printf("    %s: %.3f\n", key, entry.Header.TerrainParams[key])
+			}
+		}
+		fmt.Printf("  header: %s\n", entry.HeaderPath)
+	}
+}


### PR DESCRIPTION
## Summary
- add a replay header schema, persist it from the recorder and high-frequency writer, and document the layout
- plumb match seed and terrain metadata through configuration and broker shutdown so headers are populated and advertised
- introduce a replay catalog CLI with tests to enumerate headers and metadata from the filesystem

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df532fd2c48329991d52d01e02838b