### PR TITLE
Add replay retention cleanup job and metrics

### DIFF
--- a/go-broker/internal/config/config_test.go
+++ b/go-broker/internal/config/config_test.go
@@ -26,6 +26,8 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("BROKER_REPLAY_DUMP_WINDOW", "")
 	t.Setenv("BROKER_REPLAY_DUMP_BURST", "")
 	t.Setenv("BROKER_REPLAY_DIR", "")
+	t.Setenv("BROKER_REPLAY_MAX_MATCHES", "")
+	t.Setenv("BROKER_REPLAY_MAX_AGE_DAYS", "")
 	t.Setenv("BROKER_MATCH_SEED", "")
 	t.Setenv("BROKER_TERRAIN_PARAMS", "")
 	t.Setenv("BROKER_STATE_PATH", "")
@@ -77,6 +79,12 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.ReplayDirectory != "" {
 		t.Fatalf("expected replay directory to default to empty string")
+	}
+	if cfg.ReplayRetentionMatches != DefaultReplayRetentionMatches {
+		t.Fatalf("expected default replay retention matches %d, got %d", DefaultReplayRetentionMatches, cfg.ReplayRetentionMatches)
+	}
+	if cfg.ReplayRetentionDays != DefaultReplayRetentionDays {
+		t.Fatalf("expected default replay retention days %d, got %d", DefaultReplayRetentionDays, cfg.ReplayRetentionDays)
 	}
 	if cfg.MatchSeed != "" {
 		t.Fatalf("expected match seed to default to empty string")
@@ -144,6 +152,8 @@ func TestLoadOverrides(t *testing.T) {
 	t.Setenv("BROKER_REPLAY_DUMP_WINDOW", "2m")
 	t.Setenv("BROKER_REPLAY_DUMP_BURST", "3")
 	t.Setenv("BROKER_REPLAY_DIR", "/var/run/replays")
+	t.Setenv("BROKER_REPLAY_MAX_MATCHES", "7")
+	t.Setenv("BROKER_REPLAY_MAX_AGE_DAYS", "14")
 	t.Setenv("BROKER_MATCH_SEED", "seed-42")
 	t.Setenv("BROKER_TERRAIN_PARAMS", "{\"roughness\":0.7}")
 	t.Setenv("BROKER_STATE_PATH", "/var/run/broker/state.json")
@@ -220,6 +230,12 @@ func TestLoadOverrides(t *testing.T) {
 	if cfg.ReplayDirectory != "/var/run/replays" {
 		t.Fatalf("expected replay directory override, got %q", cfg.ReplayDirectory)
 	}
+	if cfg.ReplayRetentionMatches != 7 {
+		t.Fatalf("expected replay retention matches 7, got %d", cfg.ReplayRetentionMatches)
+	}
+	if cfg.ReplayRetentionDays != 14 {
+		t.Fatalf("expected replay retention days 14, got %d", cfg.ReplayRetentionDays)
+	}
 	if cfg.MatchSeed != "seed-42" {
 		t.Fatalf("expected match seed override, got %q", cfg.MatchSeed)
 	}
@@ -261,6 +277,8 @@ func TestLoadReturnsValidationErrors(t *testing.T) {
 	t.Setenv("BROKER_LOG_COMPRESS", "notabool")
 	t.Setenv("BROKER_REPLAY_DUMP_WINDOW", "-")
 	t.Setenv("BROKER_REPLAY_DUMP_BURST", "0")
+	t.Setenv("BROKER_REPLAY_MAX_MATCHES", "-1")
+	t.Setenv("BROKER_REPLAY_MAX_AGE_DAYS", "-2")
 	t.Setenv("BROKER_TERRAIN_PARAMS", "not-json")
 	t.Setenv("BROKER_STATE_INTERVAL", "-1s")
 	t.Setenv("BROKER_WS_AUTH_MODE", "invalid")
@@ -282,6 +300,8 @@ func TestLoadReturnsValidationErrors(t *testing.T) {
 		"BROKER_LOG_COMPRESS",
 		"BROKER_REPLAY_DUMP_WINDOW",
 		"BROKER_REPLAY_DUMP_BURST",
+		"BROKER_REPLAY_MAX_MATCHES",
+		"BROKER_REPLAY_MAX_AGE_DAYS",
 		"BROKER_STATE_INTERVAL",
 		"BROKER_WS_AUTH_MODE",
 		"BROKER_GRPC_AUTH_MODE",

--- a/go-broker/internal/http/handlers_test.go
+++ b/go-broker/internal/http/handlers_test.go
@@ -146,15 +146,20 @@ func TestMetricsHandlerOutputsPrometheusFormat(t *testing.T) {
 	replayStats := func() replay.Stats {
 		return replay.Stats{BufferedFrames: 3, BufferedBytes: 2048, Dumps: 2}
 	}
+	replayStorage := func() replay.StorageStats {
+		return replay.StorageStats{Matches: 5, Headers: 5, Bytes: 12345, LastSweep: time.Unix(1700000000, 0)}
+	}
+
 	handlers := NewHandlerSet(Options{
 		Logger:    logging.NewTestLogger(),
 		Readiness: readiness,
 		Stats: func() (int, int) {
 			return 4, 2
 		},
-		Snapshots:   metrics,
-		Bandwidth:   bandwidth,
-		ReplayStats: replayStats,
+		Snapshots:     metrics,
+		Bandwidth:     bandwidth,
+		ReplayStats:   replayStats,
+		ReplayStorage: replayStorage,
 	})
 
 	rr := httptest.NewRecorder()
@@ -176,6 +181,10 @@ func TestMetricsHandlerOutputsPrometheusFormat(t *testing.T) {
 		"broker_bandwidth_denied_total{client=\"client-1\"} 1",
 		"broker_replay_buffer_frames 3",
 		"broker_replay_dumps_total 2",
+		"broker_replay_storage_matches 5",
+		"broker_replay_storage_bytes 12345",
+		"broker_replay_storage_headers 5",
+		"broker_replay_storage_last_sweep_timestamp_seconds 1700000000",
 	} {
 		if !strings.Contains(body, substr) {
 			t.Fatalf("metrics missing %q:\n%s", substr, body)

--- a/go-broker/internal/replay/cleaner.go
+++ b/go-broker/internal/replay/cleaner.go
@@ -1,0 +1,247 @@
+package replay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"driftpursuit/broker/internal/logging"
+)
+
+// RetentionPolicy defines how many replay artefacts are retained on disk.
+type RetentionPolicy struct {
+	MaxMatches int
+	MaxAge     time.Duration
+}
+
+// StorageStats summarises the disk footprint of persisted replays.
+type StorageStats struct {
+	Matches   int
+	Headers   int
+	Bytes     int64
+	LastSweep time.Time
+}
+
+// Cleaner periodically prunes replay artefacts according to a retention policy.
+type Cleaner struct {
+	mu     sync.RWMutex
+	dir    string
+	policy RetentionPolicy
+	log    *logging.Logger
+	now    func() time.Time
+	stats  StorageStats
+}
+
+// NewCleaner constructs a cleaner for the provided replay directory.
+func NewCleaner(dir string, policy RetentionPolicy, logger *logging.Logger) *Cleaner {
+	if logger == nil {
+		logger = logging.L()
+	}
+	return &Cleaner{dir: dir, policy: policy, log: logger, now: time.Now}
+}
+
+// Run executes retention sweeps until the context is cancelled.
+func (c *Cleaner) Run(ctx context.Context, interval time.Duration) {
+	if c == nil || ctx == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	//1.- Perform an eager sweep so retention applies immediately on startup.
+	c.sweep()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			//2.- Trigger periodic sweeps while the context remains active.
+			c.sweep()
+		}
+	}
+}
+
+// RunOnce performs a single retention sweep, primarily used for tests.
+func (c *Cleaner) RunOnce() {
+	if c == nil {
+		return
+	}
+	//1.- Delegate to sweep so tests exercise identical logic as the background loop.
+	c.sweep()
+}
+
+// Stats returns the last recorded storage statistics.
+func (c *Cleaner) Stats() StorageStats {
+	if c == nil {
+		return StorageStats{}
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	//1.- Return a copy so callers cannot mutate internal state.
+	return c.stats
+}
+
+type artefact struct {
+	name    string
+	paths   []string
+	headers []string
+	size    int64
+	modTime time.Time
+	isDir   bool
+}
+
+func (c *Cleaner) sweep() {
+	if c == nil || strings.TrimSpace(c.dir) == "" {
+		return
+	}
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		c.log.Warn("replay retention scan failed", logging.Error(err), logging.String("directory", c.dir))
+		return
+	}
+	//1.- Collapse the directory contents into logical matches before sorting.
+	artefacts := c.collect(entries)
+	now := c.now()
+	kept := 0
+	stats := StorageStats{LastSweep: now}
+	for _, art := range artefacts {
+		shouldRemove, reasons := c.shouldRemove(art, now, kept)
+		if shouldRemove {
+			if err := c.remove(art); err != nil {
+				c.log.Warn("replay retention removal failed", logging.Error(err), logging.String("match", art.name))
+				stats.Matches++
+				stats.Headers += len(art.headers)
+				stats.Bytes += art.size
+				kept++
+			} else {
+				c.log.Info("replay retention removed artefact", logging.String("match", art.name), logging.String("reason", reasons))
+			}
+			continue
+		}
+		kept++
+		stats.Matches++
+		stats.Headers += len(art.headers)
+		stats.Bytes += art.size
+	}
+	c.mu.Lock()
+	//2.- Publish the refreshed statistics so metrics handlers can report storage usage.
+	c.stats = stats
+	c.mu.Unlock()
+}
+
+func (c *Cleaner) collect(entries []os.DirEntry) []*artefact {
+	artefacts := make(map[string]*artefact, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		base := name
+		isHeader := false
+		if strings.HasSuffix(name, ".header.json") {
+			base = strings.TrimSuffix(name, ".header.json")
+			isHeader = true
+		}
+		path := filepath.Join(c.dir, name)
+		info, err := entry.Info()
+		if err != nil {
+			c.log.Warn("replay retention stat failed", logging.Error(err), logging.String("path", path))
+			continue
+		}
+		art := artefacts[base]
+		if art == nil {
+			art = &artefact{name: base, modTime: info.ModTime(), isDir: entry.IsDir()}
+			artefacts[base] = art
+		}
+		if info.ModTime().After(art.modTime) {
+			art.modTime = info.ModTime()
+		}
+		if entry.IsDir() {
+			size, err := directorySize(path)
+			if err != nil {
+				c.log.Warn("replay retention size failed", logging.Error(err), logging.String("path", path))
+				continue
+			}
+			//1.- Treat directories as single artefacts so nested files move together.
+			art.paths = append(art.paths, path)
+			art.size += size
+			continue
+		}
+		if isHeader {
+			art.headers = append(art.headers, path)
+		} else {
+			//2.- Track primary artefact files separately from companion headers.
+			art.paths = append(art.paths, path)
+		}
+		art.size += info.Size()
+	}
+	list := make([]*artefact, 0, len(artefacts))
+	for _, art := range artefacts {
+		list = append(list, art)
+	}
+	//3.- Sort newest-first so retention limits favour recent matches.
+	sort.Slice(list, func(i, j int) bool { return list[i].modTime.After(list[j].modTime) })
+	return list
+}
+
+func (c *Cleaner) shouldRemove(art *artefact, now time.Time, kept int) (bool, string) {
+	reasons := make([]string, 0, 2)
+	if c.policy.MaxAge > 0 && now.Sub(art.modTime) > c.policy.MaxAge {
+		//1.- Flag artefacts that exceeded the configured age budget.
+		reasons = append(reasons, fmt.Sprintf("age>%s", c.policy.MaxAge))
+	}
+	if c.policy.MaxMatches > 0 && kept >= c.policy.MaxMatches {
+		//2.- Enforce the maximum retained match count after accounting for age removals.
+		reasons = append(reasons, fmt.Sprintf(">=%d matches", c.policy.MaxMatches))
+	}
+	return len(reasons) > 0, strings.Join(reasons, ", ")
+}
+
+func (c *Cleaner) remove(art *artefact) error {
+	var errs error
+	for _, path := range art.paths {
+		if art.isDir {
+			//1.- Remove directories recursively so manifests and frames disappear together.
+			if err := os.RemoveAll(path); err != nil {
+				errs = errors.Join(errs, err)
+			}
+			continue
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			//2.- Ignore already-missing artefacts so repeated sweeps stay idempotent.
+			errs = errors.Join(errs, err)
+		}
+	}
+	for _, path := range art.headers {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			errs = errors.Join(errs, err)
+		}
+	}
+	return errs
+}
+
+func directorySize(root string) (int64, error) {
+	var total int64
+	walkErr := filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		//1.- Accumulate file sizes to compute the directory footprint for metrics.
+		total += info.Size()
+		return nil
+	})
+	return total, walkErr
+}

--- a/go-broker/internal/replay/cleaner_test.go
+++ b/go-broker/internal/replay/cleaner_test.go
@@ -1,0 +1,141 @@
+package replay
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"driftpursuit/broker/internal/logging"
+)
+
+func TestCleanerEnforcesMaxMatches(t *testing.T) {
+	tmp := t.TempDir()
+	now := time.Date(2024, 7, 15, 12, 0, 0, 0, time.UTC)
+	//1.- Seed three synthetic replays so the cleaner has artefacts to prune.
+	writeReplayFiles(t, tmp, "alpha", now.Add(-3*time.Hour), 64)
+	writeReplayFiles(t, tmp, "bravo", now.Add(-2*time.Hour), 32)
+	writeReplayFiles(t, tmp, "charlie", now.Add(-time.Hour), 48)
+
+	cleaner := NewCleaner(tmp, RetentionPolicy{MaxMatches: 2}, logging.NewTestLogger())
+	cleaner.now = func() time.Time { return now }
+	//2.- Trigger a single sweep to enforce the retention policy immediately.
+	cleaner.RunOnce()
+
+	remaining := listReplayBases(t, tmp)
+	if len(remaining) != 2 {
+		t.Fatalf("expected 2 matches retained, got %d (%v)", len(remaining), remaining)
+	}
+	expected := []string{"bravo.json.gz", "charlie.json.gz"}
+	if remaining[0] != expected[0] || remaining[1] != expected[1] {
+		t.Fatalf("unexpected retained matches: %v", remaining)
+	}
+
+	stats := cleaner.Stats()
+	if stats.Matches != 2 {
+		t.Fatalf("expected stats to report 2 matches, got %d", stats.Matches)
+	}
+	if stats.Headers != 2 {
+		t.Fatalf("expected stats to report 2 headers, got %d", stats.Headers)
+	}
+	if stats.Bytes != int64(48+32+2+2) {
+		t.Fatalf("expected byte total 84, got %d", stats.Bytes)
+	}
+	if stats.LastSweep.IsZero() {
+		t.Fatalf("expected last sweep timestamp to be recorded")
+	}
+}
+
+func TestCleanerPrunesByAgeIncludingDirectories(t *testing.T) {
+	tmp := t.TempDir()
+	now := time.Date(2024, 7, 16, 9, 0, 0, 0, time.UTC)
+	//1.- Mix file- and directory-based replays to ensure both formats are handled.
+	writeReplayFiles(t, tmp, "delta", now.Add(-48*time.Hour), 16)
+	writeReplayDirectory(t, tmp, "echo-20240714T080000Z", now.Add(-72*time.Hour), 3)
+	writeReplayDirectory(t, tmp, "foxtrot-20240716T070000Z", now.Add(-time.Hour), 5)
+
+	cleaner := NewCleaner(tmp, RetentionPolicy{MaxAge: 36 * time.Hour, MaxMatches: 5}, logging.NewTestLogger())
+	cleaner.now = func() time.Time { return now }
+	//2.- Execute a sweep so the age threshold applies to the seeded artefacts.
+	cleaner.RunOnce()
+
+	remaining := listReplayBases(t, tmp)
+	for _, name := range remaining {
+		if name == "delta.json.gz" {
+			t.Fatalf("expected delta replay to be pruned due to age")
+		}
+		if name == "echo-20240714T080000Z" {
+			t.Fatalf("expected echo directory to be pruned due to age")
+		}
+	}
+	foundFoxtrot := false
+	for _, name := range remaining {
+		if name == "foxtrot-20240716T070000Z" {
+			foundFoxtrot = true
+		}
+	}
+	if !foundFoxtrot {
+		t.Fatalf("expected foxtrot directory to remain: %v", remaining)
+	}
+}
+
+func writeReplayFiles(t *testing.T, dir, base string, mod time.Time, payload int) {
+	t.Helper()
+	//1.- Prepare deterministic payload bytes so size calculations are predictable.
+	data := make([]byte, payload)
+	basePath := filepath.Join(dir, base+".json.gz")
+	if err := os.WriteFile(basePath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	headerPath := basePath + ".header.json"
+	if err := os.WriteFile(headerPath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile header: %v", err)
+	}
+	if err := os.Chtimes(basePath, mod, mod); err != nil {
+		t.Fatalf("Chtimes base: %v", err)
+	}
+	if err := os.Chtimes(headerPath, mod, mod); err != nil {
+		t.Fatalf("Chtimes header: %v", err)
+	}
+}
+
+func writeReplayDirectory(t *testing.T, dir, name string, mod time.Time, files int) {
+	t.Helper()
+	matchDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(matchDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for i := 0; i < files; i++ {
+		path := filepath.Join(matchDir, fmt.Sprintf("frame-%d.bin", i))
+		if err := os.WriteFile(path, []byte{byte(i)}, 0o644); err != nil {
+			t.Fatalf("WriteFile frame: %v", err)
+		}
+		if err := os.Chtimes(path, mod, mod); err != nil {
+			t.Fatalf("Chtimes frame: %v", err)
+		}
+	}
+	if err := os.Chtimes(matchDir, mod, mod); err != nil {
+		t.Fatalf("Chtimes dir: %v", err)
+	}
+}
+
+func listReplayBases(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, ".header.json") {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Summary
- add configurable replay retention limits to the broker configuration and validation tests
- implement a replay directory cleaner that enforces retention, logs pruning actions, and tracks storage statistics
- wire the cleaner into the broker startup and metrics endpoint to expose storage usage gauges

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df56fa7cdc8329b167830dd08974e6