### PR TITLE
Add WebSocket smoothness packet loss test

### DIFF
--- a/.github/workflows/websocket-smoothness.yml
+++ b/.github/workflows/websocket-smoothness.yml
@@ -1,0 +1,26 @@
+name: WebSocket smoothness
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  packet-loss-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: tunnelcave_sandbox_web
+
+      - name: Run smoothness harness
+        run: npm test
+        working-directory: tunnelcave_sandbox_web


### PR DESCRIPTION
## Summary
- add a deterministic packet loss harness to the WebSocket client test suite and check interpolation smoothness
- measure jitter via velocity deviations under 2% packet loss to fail when smoothness regresses
- add a GitHub Actions workflow to run the smoothness harness after merges to main

## Testing
- npm test (tunnelcave_sandbox_web)


------
https://chatgpt.com/codex/tasks/task_e_68df59c80b408329aec1ccf3b26b5933