### PR TITLE
Add combat scenario simulation and tuning regression test

### DIFF
--- a/python-sim/physics/combat_scenarios.py
+++ b/python-sim/physics/combat_scenarios.py
@@ -1,0 +1,189 @@
+"""Utilities for scripting combat scenarios for regression testing."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+LOGGER = logging.getLogger("combat_scenarios")
+
+
+@dataclass(frozen=True)
+class WeaponSpec:
+    """Specification for a combat weapon."""
+
+    weapon_type: str
+    base_damage: float
+    accuracy: float
+    armor_penetration: float = 0.0
+    tracking: float = 0.0
+    beam_coherence: float = 0.0
+
+
+@dataclass(frozen=True)
+class DefenseProfile:
+    """Defensive characteristics of a target."""
+
+    shield_strength: float
+    armor_rating: float
+    evasion: float
+
+
+@dataclass(frozen=True)
+class CombatScenario:
+    """Complete description of a scripted combat encounter."""
+
+    name: str
+    weapon: WeaponSpec
+    defense: DefenseProfile
+    distance: float
+
+
+@dataclass
+class ReplaySnippet:
+    """Short collection of facts that help debug regressions."""
+
+    headline: str
+    details: Dict[str, float]
+
+
+@dataclass
+class SimulationResult:
+    """Result of a simulated combat scenario."""
+
+    scenario: CombatScenario
+    expected_damage: float
+    hit_probability: float
+    mitigation: float
+    logs: List[str]
+    replay_snippet: ReplaySnippet
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp *value* to the inclusive range [minimum, maximum]."""
+
+    # //1.- Ensure we never exceed physical probability bounds.
+    return max(minimum, min(maximum, value))
+
+
+def _simulate_missile(scenario: CombatScenario) -> SimulationResult:
+    """Simulate a missile strike against the provided scenario."""
+
+    # //1.- Calculate how guidance and target evasion influence hit chance.
+    guidance_bonus = 1.0 + scenario.weapon.tracking * 0.5
+    evasive_factor = 1.0 - scenario.defense.evasion
+    hit_probability = _clamp(scenario.weapon.accuracy * guidance_bonus * evasive_factor, 0.0, 1.0)
+
+    # //2.- Estimate how the shield and armor reduce incoming explosive force.
+    shield_mitigation = scenario.defense.shield_strength / (
+        scenario.defense.shield_strength + scenario.weapon.base_damage
+    )
+    shield_mitigation = _clamp(shield_mitigation, 0.0, 0.7)
+    armor_response = 1.0 - scenario.defense.armor_rating * (1.0 - scenario.weapon.armor_penetration)
+    armor_response = max(0.15, armor_response)
+    mitigation = (1.0 - shield_mitigation) * armor_response
+
+    # //3.- Apply range based falloff for missiles to reward close engagements.
+    range_penalty = _clamp(1.0 - scenario.distance * 0.002, 0.6, 1.0)
+
+    # //4.- Derive the final damage and capture detailed logs.
+    raw_damage = scenario.weapon.base_damage * hit_probability * mitigation * range_penalty
+    logs = [
+        f"Missile guidance bonus: {guidance_bonus:.3f}",
+        f"Missile hit probability: {hit_probability:.3f}",
+        f"Missile mitigation factor: {mitigation:.3f}",
+        f"Missile range penalty: {range_penalty:.3f}",
+        f"Missile damage output: {raw_damage:.3f}",
+    ]
+
+    for entry in logs:
+        LOGGER.info("%s - %s", scenario.name, entry)
+
+    return SimulationResult(
+        scenario=scenario,
+        expected_damage=raw_damage,
+        hit_probability=hit_probability,
+        mitigation=mitigation,
+        logs=logs,
+        replay_snippet=ReplaySnippet(
+            headline=f"Missile replay for {scenario.name}",
+            details={
+                "guidance_bonus": guidance_bonus,
+                "hit_probability": hit_probability,
+                "mitigation": mitigation,
+                "range_penalty": range_penalty,
+                "damage": raw_damage,
+            },
+        ),
+    )
+
+
+def _simulate_laser(scenario: CombatScenario) -> SimulationResult:
+    """Simulate a laser barrage against the provided scenario."""
+
+    # //1.- Evaluate the focusing quality of the beam after distance losses.
+    coherence_bonus = 1.0 + scenario.weapon.beam_coherence * 0.8
+    atmospheric_drag = _clamp(1.0 - scenario.distance * 0.0015, 0.65, 1.0)
+
+    # //2.- Determine the probability of sustained contact on the target.
+    focus_factor = _clamp(scenario.weapon.accuracy * (1.0 - scenario.defense.evasion * 0.5), 0.0, 1.0)
+
+    # //3.- Model shield bleed-through when the beam stays on target.
+    shield_bleed = 1.0 - _clamp(scenario.defense.shield_strength * 0.03, 0.0, 0.6)
+    armor_weakening = 1.0 + scenario.weapon.armor_penetration * 0.4
+    mitigation = shield_bleed * armor_weakening
+
+    # //4.- Compute final energy transfer and assemble logs for debugging.
+    raw_damage = scenario.weapon.base_damage * coherence_bonus * atmospheric_drag * focus_factor * mitigation
+    logs = [
+        f"Laser coherence bonus: {coherence_bonus:.3f}",
+        f"Laser atmospheric drag: {atmospheric_drag:.3f}",
+        f"Laser focus factor: {focus_factor:.3f}",
+        f"Laser mitigation factor: {mitigation:.3f}",
+        f"Laser damage output: {raw_damage:.3f}",
+    ]
+
+    for entry in logs:
+        LOGGER.info("%s - %s", scenario.name, entry)
+
+    return SimulationResult(
+        scenario=scenario,
+        expected_damage=raw_damage,
+        hit_probability=focus_factor,
+        mitigation=mitigation,
+        logs=logs,
+        replay_snippet=ReplaySnippet(
+            headline=f"Laser replay for {scenario.name}",
+            details={
+                "coherence_bonus": coherence_bonus,
+                "atmospheric_drag": atmospheric_drag,
+                "focus_factor": focus_factor,
+                "mitigation": mitigation,
+                "damage": raw_damage,
+            },
+        ),
+    )
+
+
+def simulate_combat_scenarios(scenarios: Iterable[CombatScenario]) -> Dict[str, SimulationResult]:
+    """Run combat simulations for every scenario in *scenarios*."""
+
+    # //1.- Iterate over each scripted scenario and dispatch to the weapon specific handler.
+    results: Dict[str, SimulationResult] = {}
+    for scenario in scenarios:
+        weapon_type = scenario.weapon.weapon_type.lower()
+        if weapon_type == "missile":
+            result = _simulate_missile(scenario)
+        elif weapon_type == "laser":
+            result = _simulate_laser(scenario)
+        else:
+            # //2.- Raise a helpful error to catch unsupported weapons early.
+            raise ValueError(f"Unsupported weapon type: {scenario.weapon.weapon_type}")
+
+        results[scenario.name] = result
+
+    # //3.- Return all computed results so the caller can compare against tuning curves.
+    return results
+

--- a/python-sim/tests/configs/combat_tuning.json
+++ b/python-sim/tests/configs/combat_tuning.json
@@ -1,0 +1,16 @@
+{
+  "global_tolerance": 0.05,
+  "scenarios": {
+    "missile_alpha_strike": {
+      "expected_damage": 34.40151,
+      "tolerance": 0.04
+    },
+    "laser_lance_barrage": {
+      "expected_damage": 50.844394
+    },
+    "missile_close_intercept": {
+      "expected_damage": 59.871787,
+      "tolerance": 0.03
+    }
+  }
+}

--- a/python-sim/tests/test_combat_scenarios.py
+++ b/python-sim/tests/test_combat_scenarios.py
@@ -1,0 +1,142 @@
+"""Regression tests for scripted combat scenario tuning curves."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# //1.- Allow tests to import the physics package from the repository root.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from physics.combat_scenarios import (
+    CombatScenario,
+    DefenseProfile,
+    ReplaySnippet,
+    SimulationResult,
+    WeaponSpec,
+    simulate_combat_scenarios,
+)
+
+
+CONFIG_PATH = Path(__file__).with_name("configs").joinpath("combat_tuning.json")
+
+
+def _relative_delta(observed: float, expected: float) -> float:
+    """Return the relative deviation between *observed* and *expected*."""
+
+    # //1.- Guard against division by zero when expected curves are null damage.
+    if expected == 0:
+        return 0.0 if observed == 0 else float("inf")
+    # //2.- Compute the absolute relative error for threshold comparisons.
+    return abs(observed - expected) / expected
+
+
+def _format_snippet(snippet: ReplaySnippet) -> str:
+    """Create a deterministic string that can be attached to assertion messages."""
+
+    # //1.- Join the ordered key/value pairs for quick human inspection.
+    sorted_items = sorted(snippet.details.items())
+    payload = ", ".join(f"{key}={value:.3f}" for key, value in sorted_items)
+    # //2.- Return a compact replay string to aid debugging.
+    return f"{snippet.headline}: {payload}"
+
+
+def _load_tuning_config() -> Dict[str, Dict[str, float]]:
+    """Load expected tuning values for each scripted scenario."""
+
+    # //1.- Read the JSON payload from disk and expose nested structures directly.
+    with CONFIG_PATH.open("r", encoding="utf-8") as handle:
+        config = json.load(handle)
+    return config
+
+
+def test_combat_scenarios_match_tuning(caplog: pytest.LogCaptureFixture) -> None:
+    """Validate missile and laser combat calculations against tuning curves."""
+
+    # //1.- Arrange combat scenarios that the physics layer must support.
+    config = _load_tuning_config()
+    scenarios = [
+        CombatScenario(
+            name="missile_alpha_strike",
+            weapon=WeaponSpec(
+                weapon_type="missile",
+                base_damage=220.0,
+                accuracy=0.75,
+                armor_penetration=0.35,
+                tracking=0.4,
+            ),
+            defense=DefenseProfile(
+                shield_strength=180.0,
+                armor_rating=0.5,
+                evasion=0.22,
+            ),
+            distance=250.0,
+        ),
+        CombatScenario(
+            name="laser_lance_barrage",
+            weapon=WeaponSpec(
+                weapon_type="laser",
+                base_damage=150.0,
+                accuracy=0.88,
+                armor_penetration=0.25,
+                beam_coherence=0.6,
+            ),
+            defense=DefenseProfile(
+                shield_strength=140.0,
+                armor_rating=0.45,
+                evasion=0.18,
+            ),
+            distance=320.0,
+        ),
+        CombatScenario(
+            name="missile_close_intercept",
+            weapon=WeaponSpec(
+                weapon_type="missile",
+                base_damage=160.0,
+                accuracy=0.82,
+                armor_penetration=0.25,
+                tracking=0.55,
+            ),
+            defense=DefenseProfile(
+                shield_strength=90.0,
+                armor_rating=0.3,
+                evasion=0.12,
+            ),
+            distance=90.0,
+        ),
+    ]
+
+    # //2.- Act by running the scripted combat simulations with verbose logging.
+    caplog.set_level("INFO")
+    results = simulate_combat_scenarios(scenarios)
+
+    # //3.- Assert the curves match expected tuning within the required tolerances.
+    global_tolerance = config.get("global_tolerance", 0.05)
+    for scenario in scenarios:
+        result: SimulationResult = results[scenario.name]
+        tuning_info = config["scenarios"][scenario.name]
+        expected_damage = tuning_info["expected_damage"]
+        tolerance = tuning_info.get("tolerance", global_tolerance)
+        relative_delta = _relative_delta(result.expected_damage, expected_damage)
+
+        if relative_delta > tolerance:
+            formatted_snippet = _format_snippet(result.replay_snippet)
+            pytest.fail(
+                (
+                    f"Scenario {scenario.name} damage deviation {relative_delta:.3f} "
+                    f"exceeded tolerance {tolerance:.3f}. {formatted_snippet}"
+                )
+            )
+
+        assert relative_delta <= tolerance
+
+    # //4.- Confirm that outcome logging occurred for downstream replay tools.
+    for scenario in scenarios:
+        matching_logs = [
+            record for record in caplog.records if record.message.startswith(scenario.name)
+        ]
+        assert matching_logs, f"Expected logs for scenario {scenario.name}"


### PR DESCRIPTION
## Summary
- add a physics combat scenario simulator that produces logs and replay snippets
- store expected tuning values for missile and laser encounters in a JSON config
- add a regression test that compares simulated damage to the tuning curves and fails with replay data on deviation

## Testing
- pytest tests/test_combat_scenarios.py
- pytest *(fails: missing google protobuf dependency in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68df5c8391dc8329bc6cd6c0e9b6f3a1