### PR TITLE
Add simulation monitoring metrics and FPS validation

### DIFF
--- a/go-broker/internal/simulation/tick_monitor.go
+++ b/go-broker/internal/simulation/tick_monitor.go
@@ -1,0 +1,87 @@
+package simulation
+
+import (
+	"sync"
+	"time"
+)
+
+// TickMetricsSnapshot summarises observed server tick durations.
+type TickMetricsSnapshot struct {
+	Samples int
+	Average time.Duration
+	Max     time.Duration
+	Last    time.Duration
+}
+
+// AverageFPS derives the frames-per-second equivalent of the sampled tick duration.
+func (s TickMetricsSnapshot) AverageFPS() float64 {
+	if s.Average <= 0 {
+		return 0
+	}
+	return float64(time.Second) / float64(s.Average)
+}
+
+// TickMonitor accumulates timing statistics for the simulation loop.
+type TickMonitor struct {
+	mu      sync.Mutex
+	samples int
+	total   time.Duration
+	max     time.Duration
+	last    time.Duration
+}
+
+// NewTickMonitor constructs an empty monitor ready to collect samples.
+func NewTickMonitor() *TickMonitor {
+	return &TickMonitor{}
+}
+
+// Observe records the duration of a completed simulation tick.
+func (m *TickMonitor) Observe(duration time.Duration) {
+	if m == nil || duration <= 0 {
+		return
+	}
+	m.mu.Lock()
+	// //1.- Accumulate the sample count and aggregate duration for average calculations.
+	m.samples++
+	m.total += duration
+	// //2.- Track the worst-case tick so operators can spot spikes quickly.
+	if duration > m.max {
+		m.max = duration
+	}
+	// //3.- Remember the latest tick for real-time dashboards.
+	m.last = duration
+	m.mu.Unlock()
+}
+
+// Snapshot returns a copy of the aggregated tick statistics.
+func (m *TickMonitor) Snapshot() TickMetricsSnapshot {
+	if m == nil {
+		return TickMetricsSnapshot{}
+	}
+	m.mu.Lock()
+	samples := m.samples
+	total := m.total
+	max := m.max
+	last := m.last
+	m.mu.Unlock()
+
+	average := time.Duration(0)
+	if samples > 0 {
+		average = total / time.Duration(samples)
+	}
+	return TickMetricsSnapshot{Samples: samples, Average: average, Max: max, Last: last}
+}
+
+// Reset clears the accumulated statistics so a fresh match can begin cleanly.
+func (m *TickMonitor) Reset() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	// //1.- Zero out all internal counters so subsequent snapshots start from scratch.
+	m.samples = 0
+	m.total = 0
+	m.max = 0
+	m.last = 0
+	m.mu.Unlock()
+}

--- a/go-broker/main_simulation_test.go
+++ b/go-broker/main_simulation_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	configpkg "driftpursuit/broker/internal/config"
+	"driftpursuit/broker/internal/logging"
+	"driftpursuit/broker/internal/networking"
+	pb "driftpursuit/broker/internal/proto/pb"
+	"driftpursuit/broker/internal/replay"
+)
+
+func TestBrokerLargeScaleSimulationMonitorsBandwidthAndTicks(t *testing.T) {
+	logger := logging.NewTestLogger()
+	base := time.Date(2024, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	regulator := networking.NewBandwidthRegulator(1<<20, clock)
+
+	broker := NewBroker(configpkg.DefaultMaxPayloadBytes, configpkg.DefaultMaxClients, base, logger, WithBandwidthRegulator(regulator))
+
+	for i := 0; i < 48; i++ {
+		id := fmt.Sprintf("actor-%02d", i)
+		broker.world.Vehicles.Upsert(&pb.VehicleState{
+			SchemaVersion:       "2024-test",
+			VehicleId:           id,
+			Position:            &pb.Vector3{X: float64(i), Y: float64(i % 4), Z: 0},
+			Velocity:            &pb.Vector3{X: 1, Y: 0, Z: 0},
+			FlightAssistEnabled: true,
+			UpdatedAtMs:         base.UnixMilli(),
+		})
+	}
+
+	step := 16 * time.Millisecond
+	for frame := 0; frame < 120; frame++ {
+		broker.advanceSimulation(step)
+		for i := 0; i < 48; i++ {
+			clientID := fmt.Sprintf("client-%02d", i)
+			if !broker.bandwidth.Allow(clientID, 2048) {
+				t.Fatalf("unexpected throttle for %s", clientID)
+			}
+		}
+		now = now.Add(step)
+	}
+	now = now.Add(200 * time.Millisecond)
+
+	if broker.tickCounter == 0 {
+		t.Fatalf("expected simulation to advance ticks")
+	}
+
+	metrics := broker.TickMetrics()
+	if metrics.Samples < 120 {
+		t.Fatalf("expected at least 120 samples, got %d", metrics.Samples)
+	}
+	if metrics.Average <= 0 {
+		t.Fatalf("expected average tick duration > 0")
+	}
+	if metrics.AverageFPS() < 55 {
+		t.Fatalf("expected average FPS >= 55, got %.2f", metrics.AverageFPS())
+	}
+
+	usage := broker.bandwidth.SnapshotUsage()
+	if len(usage) != 48 {
+		t.Fatalf("expected bandwidth stats for 48 clients, got %d", len(usage))
+	}
+	for id, sample := range usage {
+		if sample.BytesPerSecond <= 0 {
+			t.Fatalf("expected throughput sample for %s", id)
+		}
+	}
+}
+
+func TestDumpReplayProducesLoadableReplay(t *testing.T) {
+	tmp := t.TempDir()
+	base := time.Date(2024, 7, 15, 16, 0, 0, 0, time.UTC)
+
+	recorder, err := replay.NewRecorder(tmp, nil)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	logger := logging.NewTestLogger()
+	broker := NewBroker(configpkg.DefaultMaxPayloadBytes, configpkg.DefaultMaxClients, base, logger,
+		WithReplayRecorder(recorder),
+		WithMatchMetadata("seed-load", replay.TerrainParameters{"roughness": 0.4}),
+	)
+
+	broker.replayRecorder.RecordTick(1, 0, []byte(`{"tick":1}`))
+	broker.replayRecorder.RecordWorldFrame(1, 16, []byte(`{"world":true}`))
+	broker.replayRecorder.RecordEvent(1, 32, []byte(`{"event":"goal"}`))
+
+	path, err := broker.DumpReplay(context.Background())
+	if err != nil {
+		t.Fatalf("DumpReplay: %v", err)
+	}
+
+	loader, err := replay.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	entries := loader.Entries()
+	if len(entries) < 3 {
+		t.Fatalf("expected at least 3 replay entries, got %d", len(entries))
+	}
+
+	kinds := map[string]bool{}
+	for _, entry := range entries {
+		kinds[entry.Type] = true
+	}
+	for _, expected := range []string{"diff", "world", "event"} {
+		if !kinds[expected] {
+			t.Fatalf("missing replay entry type %q", expected)
+		}
+	}
+
+	count := 0
+	if err := loader.Replay(func(replay.TimelineEntry) error {
+		// //1.- Count entries to verify deterministic iteration succeeds.
+		count++
+		return nil
+	}); err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if count != len(entries) {
+		t.Fatalf("expected to visit %d entries, visited %d", len(entries), count)
+	}
+}

--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts && ts-node src/hud/damageFeed.test.ts && ts-node src/hud/radarContacts.test.ts && ts-node src/hud/radarOcclusionSimulation.test.ts"
+    "test": "ts-node src/gameplayConfig.test.ts && ts-node src/vehicleRoster.test.ts && ts-node src/vehicleLoadoutBridge.test.ts && ts-node src/vehicle_state.test.ts && ts-node src/combat_event.test.ts && ts-node src/intentPublisher.test.ts && ts-node src/interpolator.test.ts && ts-node src/physics/integrator.test.ts && ts-node src/timeSync.test.ts && ts-node src/authToken.test.ts && ts-node src/eventStream.test.ts && ts-node src/world_chunk_loader.test.ts && ts-node src/hud/damageFeed.test.ts && ts-node src/hud/radarContacts.test.ts && ts-node src/hud/radarOcclusionSimulation.test.ts && ts-node src/performance/performanceMonitor.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/typescript-client/src/performance/performanceMonitor.test.ts
+++ b/typescript-client/src/performance/performanceMonitor.test.ts
@@ -1,0 +1,31 @@
+import assert from "assert";
+import { PerformanceMonitor } from "./performanceMonitor";
+
+function simulateFrames(monitor: PerformanceMonitor, frameIntervalMs: number, frames: number): void {
+  let timestamp = 0;
+  for (let index = 0; index < frames; index += 1) {
+    // //1.- Record monotonically increasing timestamps to emulate render frames.
+    monitor.record(timestamp);
+    timestamp += frameIntervalMs;
+  }
+}
+
+(function testHighLoadMaintainsTargetFps() {
+  const monitor = new PerformanceMonitor(256);
+  simulateFrames(monitor, 1000 / 60, 256);
+  const snapshot = monitor.snapshot();
+  const threshold = 55;
+  if (snapshot.averageFps < threshold) {
+    throw new Error(`FPS ${snapshot.averageFps.toFixed(2)} below ${threshold}`);
+  }
+  assert.ok(snapshot.minFps > 0);
+  assert.ok(snapshot.maxFps >= snapshot.minFps);
+})();
+
+(function testDetectsLowFpsRegression() {
+  const monitor = new PerformanceMonitor(180);
+  simulateFrames(monitor, 1000 / 20, 180);
+  const snapshot = monitor.snapshot();
+  // //2.- Ensure the calculated FPS falls below the required minimum under heavy load.
+  assert.ok(snapshot.averageFps < 30, `expected fps to drop under stress, got ${snapshot.averageFps}`);
+})();

--- a/typescript-client/src/performance/performanceMonitor.ts
+++ b/typescript-client/src/performance/performanceMonitor.ts
@@ -1,0 +1,68 @@
+export interface PerformanceSnapshot {
+  samples: number;
+  averageFps: number;
+  minFps: number;
+  maxFps: number;
+}
+
+export class PerformanceMonitor {
+  private readonly capacity: number;
+  private readonly timestamps: number[] = [];
+
+  constructor(capacity = 240) {
+    if (!Number.isFinite(capacity) || capacity <= 1) {
+      throw new Error("capacity must be greater than one");
+    }
+    // //1.- Store the sliding-window capacity so heavy loads only retain recent frames.
+    this.capacity = Math.floor(capacity);
+  }
+
+  record(timestampMs: number): void {
+    if (!Number.isFinite(timestampMs)) {
+      throw new Error("timestamp must be finite");
+    }
+    if (this.timestamps.length > 0 && timestampMs <= this.timestamps[this.timestamps.length - 1]) {
+      throw new Error("timestamps must be strictly increasing");
+    }
+    // //2.- Append the timestamp while trimming the buffer to the configured capacity.
+    this.timestamps.push(timestampMs);
+    if (this.timestamps.length > this.capacity) {
+      this.timestamps.shift();
+    }
+  }
+
+  snapshot(): PerformanceSnapshot {
+    if (this.timestamps.length < 2) {
+      // //3.- Avoid division by zero when we do not yet have frame deltas.
+      return { samples: 0, averageFps: 0, minFps: 0, maxFps: 0 };
+    }
+
+    const fpsSamples: number[] = [];
+    for (let index = 1; index < this.timestamps.length; index += 1) {
+      const frameDeltaMs = this.timestamps[index] - this.timestamps[index - 1];
+      const frameSeconds = frameDeltaMs / 1000;
+      if (frameSeconds <= 0) {
+        continue;
+      }
+      // //4.- Convert the frame duration into an instantaneous FPS sample.
+      fpsSamples.push(1 / frameSeconds);
+    }
+
+    if (fpsSamples.length === 0) {
+      return { samples: 0, averageFps: 0, minFps: 0, maxFps: 0 };
+    }
+
+    let sum = 0;
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+    for (const sample of fpsSamples) {
+      // //5.- Accumulate aggregates so the snapshot can expose average and extrema.
+      sum += sample;
+      min = Math.min(min, sample);
+      max = Math.max(max, sample);
+    }
+
+    const average = sum / fpsSamples.length;
+    return { samples: fpsSamples.length, averageFps: average, minFps: min, maxFps: max };
+  }
+}


### PR DESCRIPTION
## Summary
- add a simulation tick monitor to the broker and expose timing metrics
- cover large-scale load, replay dumping, and bandwidth monitoring with new tests
- introduce a client performance monitor module with FPS regression tests and include it in the TypeScript test suite

## Testing
- go test ./...
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df5f95b82883299012b082ef5d76b9