### PR TITLE
feat: add interactive vehicle scene

### DIFF
--- a/docs/integration_bridge/README.md
+++ b/docs/integration_bridge/README.md
@@ -1,0 +1,37 @@
+# Web Bridge Integration Plan
+
+## Audit Summary
+- `python-sim` exposes vehicle state via physics modules and now provides an HTTP bridge at `web_bridge.server` for handshake, state polling, and command dispatch.
+- `tunnelcave_sandbox` hosts legacy simulation scenes compatible with the Python runtime.
+- `tunnelcave_sandbox_web` renders the browser client using Next.js, with new components that connect to the HTTP bridge.
+
+## Communication Layer Decisions
+- Initial integration keeps the authoritative simulation in Python and synchronises through an HTTP bridge to reduce browser-side porting.
+- REST-style endpoints (`/handshake`, `/state`, `/command`) provide a minimal surface area that can be upgraded to WebSockets once telemetry streaming is required.
+
+## Asset Pipeline Considerations
+- Vehicle meshes reside under `tunnelcave_sandbox/assets` (export tooling to be added in subsequent iterations).
+- Convert assets to `glTF` using Blender export presets to minimise file size before publishing to the web client.
+
+## Front-End Rendering & Controls
+- Next.js client now includes `SimulationControlPanel`, enabling handshake verification and dispatch of throttle/brake commands.
+- Integration with the 3D renderer will map telemetry returned by `/state` into scene graph updates.
+
+## Back-End API
+- `SimulationControlServer` hosts the HTTP bridge with pluggable state providers and command handlers so existing simulation loops can push telemetry into the bridge without refactors.
+- Default state provider supplies placeholder telemetry for development and testing.
+
+## Synchronisation Strategy
+- Clients poll `/state` for now. Upgrade paths include server-sent events or WebSockets for smoother telemetry updates when the simulation loop is wired in.
+
+## Alternative Control Surfaces
+- Python CLI or desktop clients can reuse the HTTP bridge endpoints to issue commands without depending on the browser stack.
+
+## Deployment Notes
+- Start the server via `python -m web_bridge.server` with `PYTHONPATH=python-sim` during development.
+- Run `npm run dev` inside `tunnelcave_sandbox_web` and set `NEXT_PUBLIC_SIM_BRIDGE_URL` to the bridge origin (e.g. `http://localhost:8000`).
+
+## Next Steps
+- Wire real simulation telemetry into the `state_provider` callback.
+- Streamline asset conversion scripts and document Blender export presets.
+- Expand the control surface with keyboard/gamepad bindings and interpolation against streamed telemetry.

--- a/python-sim/tests/test_web_bridge_server.py
+++ b/python-sim/tests/test_web_bridge_server.py
@@ -1,0 +1,119 @@
+"""Unit tests for the lightweight simulation control HTTP server."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# //1.- Ensure the python-sim package directory is importable when tests execute from the repository root.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from web_bridge.server import BridgeState, SimulationControlServer
+
+
+def _wait_for_server(host: str, port: int, timeout: float = 2.0) -> None:
+    """Poll the handshake endpoint until the server responds or the timeout elapses."""
+
+    # //1.- Loop until the handshake request returns successfully or the timeout fires.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"http://{host}:{port}/handshake"):
+                return
+        except urllib.error.URLError:
+            time.sleep(0.05)
+    raise TimeoutError("Server did not respond within the allotted time")
+
+
+@pytest.fixture()
+def running_server() -> SimulationControlServer:
+    """Spin up the control server for the duration of a test and tear it down afterwards."""
+
+    # //1.- Start the server on an ephemeral port so tests can run in parallel without clashing.
+    server = SimulationControlServer()
+    server.start()
+    host, port = server.address
+    _wait_for_server(host, port)
+    yield server
+    # //2.- Guarantee the socket is closed after each scenario completes.
+    server.stop()
+
+
+def test_handshake_returns_success(running_server: SimulationControlServer) -> None:
+    """Verify the handshake endpoint advertises the server as ready."""
+
+    # //1.- Issue a GET request and decode the JSON payload returned by the server.
+    host, port = running_server.address
+    with urllib.request.urlopen(f"http://{host}:{port}/handshake") as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    # //2.- Confirm the bridge signals a healthy state to the caller.
+    assert payload["status"] == "ok"
+    assert "Simulation bridge online" in payload["message"]
+
+
+def test_state_endpoint_uses_provider(running_server: SimulationControlServer) -> None:
+    """Ensure the state endpoint relays telemetry from the provided callback."""
+
+    # //1.- Replace the provider with a deterministic payload so assertions remain stable.
+    telemetry_called = threading.Event()
+
+    def custom_provider() -> BridgeState:
+        # //1.- Flag that the provider was invoked and return a predictable snapshot.
+        telemetry_called.set()
+        return BridgeState(tick_id=12, captured_at_ms=34.5, vehicles={"car": {"x": 1.0}})
+
+    running_server.stop()
+    server = SimulationControlServer(state_provider=custom_provider)
+    server.start()
+    host, port = server.address
+    _wait_for_server(host, port)
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/state") as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.stop()
+    # //2.- Validate the response mirrors the custom provider output.
+    assert telemetry_called.is_set()
+    assert payload == {
+        "status": "ok",
+        "tickId": 12,
+        "capturedAtMs": 34.5,
+        "vehicles": {"car": {"x": 1.0}},
+    }
+
+
+def test_post_command_invokes_handler() -> None:
+    """Confirm that POST /command forwards the payload to the registered handler."""
+
+    # //1.- Capture the command payload within the custom handler for verification.
+    received: Dict[str, object] = {}
+
+    def handler(payload: Dict[str, object]) -> None:
+        received.update(payload)
+
+    server = SimulationControlServer(command_handler=handler)
+    server.start()
+    host, port = server.address
+    _wait_for_server(host, port)
+    try:
+        request = urllib.request.Request(
+            f"http://{host}:{port}/command",
+            data=json.dumps({"command": "throttle", "value": 1.0}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.stop()
+    # //2.- Ensure the handler observed the command and the response echoes the payload.
+    assert received == {"command": "throttle", "value": 1.0}
+    assert payload["status"] == "ok"
+    assert payload["command"] == {"command": "throttle", "value": 1.0}

--- a/python-sim/web_bridge/__init__.py
+++ b/python-sim/web_bridge/__init__.py
@@ -1,0 +1,5 @@
+"""Web bridge helpers that expose simulation control over HTTP."""
+
+from .server import SimulationControlServer, default_state_provider
+
+__all__ = ["SimulationControlServer", "default_state_provider"]

--- a/python-sim/web_bridge/server.py
+++ b/python-sim/web_bridge/server.py
@@ -1,0 +1,232 @@
+"""HTTP bridge exposing simulation control primitives."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable, Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BridgeState:
+    """Container describing the simulation state returned by the bridge."""
+
+    # //1.- Track a monotonically increasing identifier representing the simulation tick.
+    tick_id: int = 0
+    # //2.- Expose the captured timestamp so clients can interpolate updates.
+    captured_at_ms: float = 0.0
+    # //3.- Store a mapping of vehicle identifiers to lightweight telemetry dictionaries.
+    vehicles: Dict[str, Dict[str, float]] = field(default_factory=dict)
+
+
+def default_state_provider() -> BridgeState:
+    """Return a placeholder state payload while the real simulation integration is wired up."""
+
+    # //1.- Capture the current time once to ensure consistent timestamps within the payload.
+    now_ms = time.time() * 1000.0
+    # //2.- Populate the placeholder telemetry with a single vehicle parked at the origin.
+    vehicles = {
+        "demo_vehicle": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0,
+            "speed": 0.0,
+        }
+    }
+    # //3.- Return the bridge state featuring the static telemetry and a dummy tick identifier.
+    return BridgeState(tick_id=0, captured_at_ms=now_ms, vehicles=vehicles)
+
+
+class SimulationControlServer:
+    """Threaded HTTP server exposing simulation handshake, state, and command endpoints."""
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        state_provider: Callable[[], BridgeState] = default_state_provider,
+        command_handler: Optional[Callable[[Dict[str, object]], None]] = None,
+    ) -> None:
+        # //1.- Persist constructor arguments so the HTTP handler can query state and dispatch commands.
+        self._host = host
+        self._port = port
+        self._state_provider = state_provider
+        self._command_handler = command_handler or self._record_last_command
+        # //2.- Internal bookkeeping ensures we can expose diagnostics to tests and other tooling.
+        self._httpd: Optional[ThreadingHTTPServer] = None
+        self._serve_thread: Optional[threading.Thread] = None
+        self._last_command_lock = threading.Lock()
+        self._last_command: Optional[Dict[str, object]] = None
+
+    @property
+    def address(self) -> Tuple[str, int]:
+        """Return the socket binding once the server is running."""
+
+        # //1.- Ensure the server has been started before exposing the bind address.
+        if not self._httpd:
+            raise RuntimeError("Server is not running")
+        # //2.- Return the canonical host and port tuple the HTTP daemon resolved to.
+        return self._httpd.server_address  # type: ignore[return-value]
+
+    def start(self) -> None:
+        """Launch the HTTP server on a background thread."""
+
+        # //1.- Guard against accidental double starts that would leak sockets and threads.
+        if self._httpd is not None:
+            raise RuntimeError("Server already running")
+
+        # //2.- Manufacture a request handler class bound to this server instance.
+        server_ref = self
+
+        class RequestHandler(BaseHTTPRequestHandler):
+            # //1.- Explicitly disable the default logging to keep test output quiet.
+            def log_message(self, format: str, *args: object) -> None:  # type: ignore[override]
+                LOGGER.debug("web_bridge: %s", format % args)
+
+            def _set_headers(self, status: HTTPStatus, content_type: str = "application/json") -> None:
+                # //1.- Emit the HTTP status line and base headers shared across responses.
+                self.send_response(status)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+            def _write_json(self, payload: Dict[str, object], status: HTTPStatus = HTTPStatus.OK) -> None:
+                # //1.- Serialise the payload and flush it to the client with the appropriate headers.
+                body = json.dumps(payload).encode("utf-8")
+                self._set_headers(status)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_OPTIONS(self) -> None:  # type: ignore[override]
+                # //1.- Respond to CORS preflight checks without invoking the provider or handler.
+                self._set_headers(HTTPStatus.NO_CONTENT)
+                self.end_headers()
+
+            def do_GET(self) -> None:  # type: ignore[override]
+                # //1.- Normalise the request path to strip query strings before routing.
+                path = urlparse(self.path).path
+                if path == "/handshake":
+                    # //2.- Confirm to the client that the bridge is reachable and ready.
+                    payload = {
+                        "status": "ok",
+                        "message": "Simulation bridge online",
+                    }
+                    self._write_json(payload)
+                    return
+                if path == "/state":
+                    try:
+                        # //3.- Request the latest telemetry snapshot from the provider.
+                        snapshot = server_ref._state_provider()
+                        payload = {
+                            "status": "ok",
+                            "tickId": snapshot.tick_id,
+                            "capturedAtMs": snapshot.captured_at_ms,
+                            "vehicles": snapshot.vehicles,
+                        }
+                        self._write_json(payload)
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.exception("Failed to gather simulation state")
+                        self._write_json(
+                            {"status": "error", "message": str(exc)}, status=HTTPStatus.INTERNAL_SERVER_ERROR
+                        )
+                    return
+                # //4.- Return a not found response for any unrecognised path.
+                self._write_json({"status": "error", "message": "Not found"}, status=HTTPStatus.NOT_FOUND)
+
+            def do_POST(self) -> None:  # type: ignore[override]
+                # //1.- Restrict POST handling to the command endpoint and reject others.
+                path = urlparse(self.path).path
+                if path != "/command":
+                    self._write_json({"status": "error", "message": "Not found"}, status=HTTPStatus.NOT_FOUND)
+                    return
+                try:
+                    # //2.- Read and decode the JSON payload carrying the command details.
+                    content_length = int(self.headers.get("Content-Length", "0"))
+                    raw_body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+                    command_payload = json.loads(raw_body.decode("utf-8") or "{}")
+                    # //3.- Forward the command to the registered handler so the simulation can react.
+                    server_ref._command_handler(command_payload)
+                    response = {"status": "ok", "command": command_payload}
+                    self._write_json(response)
+                except json.JSONDecodeError as exc:
+                    # //4.- Handle malformed JSON gracefully so the client receives actionable feedback.
+                    self._write_json(
+                        {"status": "error", "message": f"Invalid JSON payload: {exc}"},
+                        status=HTTPStatus.BAD_REQUEST,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.exception("Command handler failed")
+                    self._write_json(
+                        {"status": "error", "message": str(exc)}, status=HTTPStatus.INTERNAL_SERVER_ERROR
+                    )
+
+        # //3.- Instantiate the HTTP daemon bound to the requested interface and port.
+        self._httpd = ThreadingHTTPServer((self._host, self._port), RequestHandler)
+        # //4.- Capture the resolved port number in case the caller requested an ephemeral port.
+        self._port = self._httpd.server_address[1]
+        # //5.- Run the server loop on a dedicated daemon thread so tests can stop it quickly.
+        self._serve_thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._serve_thread.start()
+
+    def stop(self) -> None:
+        """Terminate the HTTP server and wait for the thread to exit."""
+
+        # //1.- Exit gracefully when stop is invoked before the server has been started.
+        if self._httpd is None:
+            return
+        # //2.- Ask the HTTP daemon to shut down and join the background thread for cleanliness.
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._serve_thread:
+            self._serve_thread.join(timeout=2.0)
+        # //3.- Reset the internal state so the instance can be started again if needed.
+        self._httpd = None
+        self._serve_thread = None
+
+    def last_command(self) -> Optional[Dict[str, object]]:
+        """Return the most recent command observed by the default handler."""
+
+        # //1.- Synchronise access to the shared state to keep multi-threaded reads safe.
+        with self._last_command_lock:
+            return dict(self._last_command) if self._last_command is not None else None
+
+    def _record_last_command(self, payload: Dict[str, object]) -> None:
+        """Default handler that records the incoming command for later inspection."""
+
+        # //1.- Persist the payload so tests can confirm that commands were routed correctly.
+        with self._last_command_lock:
+            self._last_command = dict(payload)
+
+
+def _run_default_server() -> None:
+    """Launch the bridge server with the default provider when executed as a script."""
+
+    # //1.- Instantiate the server and begin listening for HTTP traffic.
+    server = SimulationControlServer()
+    server.start()
+    host, port = server.address
+    LOGGER.info("Simulation control server listening on http://%s:%s", host, port)
+    try:
+        # //2.- Keep the main thread alive so the daemon can continue serving requests.
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        LOGGER.info("Stopping simulation control server")
+    finally:
+        # //3.- Ensure resources are reclaimed when the process exits.
+        server.stop()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    _run_default_server()

--- a/tunnelcave_sandbox_web/app/components/ClientBootstrap.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/ClientBootstrap.test.tsx
@@ -1,32 +1,67 @@
-import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen } from '@testing-library/react'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { createRoot, type Root } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('ClientBootstrap', () => {
+  let container: HTMLDivElement
+  let root: Root | null
+
   beforeEach(() => {
-    //1.- Reset module state so environment changes are honoured between assertions.
+    //1.- Reset module caches and recreate a clean DOM container for each scenario.
     vi.resetModules()
-    cleanup()
+    container = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(container)
+    root = null
   })
+
+  const loadComponent = async () => {
+    //1.- Replace the heavy three.js scene with a lightweight stub for deterministic tests.
+    vi.doMock('./VehicleScene', () => ({
+      __esModule: true,
+      default: () => <div data-testid="vehicle-scene" />,
+    }))
+    const module = await import('./ClientBootstrap')
+    return module.default
+  }
+
+  const renderComponent = async (element: React.ReactElement) => {
+    //1.- Render the component within React's act helper so hooks resolve deterministically.
+    await act(async () => {
+      root = createRoot(container)
+      root.render(element)
+    })
+  }
+
+  const teardown = async () => {
+    //1.- Unmount the rendered tree to avoid cross-test leakage of effects or timers.
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+      root = null
+    }
+    container.remove()
+  }
 
   it('informs the user when the broker URL is missing', async () => {
     //1.- Ensure the public environment variable is absent for this scenario.
     delete process.env.NEXT_PUBLIC_BROKER_URL
-    const { default: ClientBootstrap } = await import('./ClientBootstrap')
-    render(<ClientBootstrap />)
-    expect(
-      screen.getByText(
-        /Broker URL missing. Create a .env.local file with NEXT_PUBLIC_BROKER_URL=ws:\/\/localhost:43127\/ws to enable live telemetry./i,
-      ),
-    ).toBeInTheDocument()
+    const ClientBootstrap = await loadComponent()
+    await renderComponent(<ClientBootstrap />)
+    const message = container.querySelector('[data-testid="status-message"]')
+    expect(message?.textContent ?? '').toMatch(/Broker URL missing/i)
+    await teardown()
   })
 
   it('confirms readiness when the broker URL is configured', async () => {
     //1.- Provide the websocket endpoint so the component reports readiness.
     process.env.NEXT_PUBLIC_BROKER_URL = 'ws://localhost:43127/ws'
-    const { default: ClientBootstrap } = await import('./ClientBootstrap')
-    render(<ClientBootstrap />)
-    expect(screen.getByTestId('status-message').textContent).toContain('ws://localhost:43127/ws')
+    const ClientBootstrap = await loadComponent()
+    await renderComponent(<ClientBootstrap />)
+    const message = container.querySelector('[data-testid="status-message"]')
+    expect(message?.textContent ?? '').toContain('ws://localhost:43127/ws')
+    await teardown()
   })
 })

--- a/tunnelcave_sandbox_web/app/components/ClientBootstrap.tsx
+++ b/tunnelcave_sandbox_web/app/components/ClientBootstrap.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+import SimulationControlPanel, { type CommandName } from './SimulationControlPanel'
+import VehicleScene, { type ExternalCommand } from './VehicleScene'
 
 const DEFAULT_STATUS = 'Loading web client shell…'
 
@@ -9,6 +12,13 @@ export default function ClientBootstrap() {
   const brokerUrl = useMemo(() => process.env.NEXT_PUBLIC_BROKER_URL?.trim() ?? '', [])
   //2.- Track the status message that guides visitors through the setup flow.
   const [status, setStatus] = useState(DEFAULT_STATUS)
+  const [externalCommand, setExternalCommand] = useState<ExternalCommand | undefined>(undefined)
+
+  const handleCommandSent = useCallback((command: CommandName) => {
+    //1.- Convert the successful button press into a high-resolution timestamp for the vehicle scene.
+    const issuedAtMs = typeof performance !== 'undefined' ? performance.now() : Date.now()
+    setExternalCommand({ command, issuedAtMs })
+  }, [])
 
   useEffect(() => {
     //1.- Explain how to configure the broker when the environment variable is absent.
@@ -38,9 +48,10 @@ export default function ClientBootstrap() {
         </ol>
       </section>
       <section>
-        <div id="canvas-root" aria-label="3D world mount" />
+        <VehicleScene externalCommand={externalCommand} />
         <div id="hud-root" aria-label="HUD overlay mount" />
       </section>
+      <SimulationControlPanel onCommandSent={handleCommandSent} />
     </main>
   )
 }

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SimulationControlPanel from './SimulationControlPanel'
+
+const originalFetch = global.fetch
+
+describe('SimulationControlPanel', () => {
+  let container: HTMLDivElement
+  let root: Root | null
+
+  beforeEach(() => {
+    //1.- Reset fetch mocks and create a dedicated DOM container per scenario.
+    vi.restoreAllMocks()
+    delete process.env.NEXT_PUBLIC_SIM_BRIDGE_URL
+    container = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(container)
+    root = null
+  })
+
+  afterEach(async () => {
+    //1.- Unmount any mounted tree to avoid leaking listeners or timers between runs.
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+      root = null
+    }
+    container.remove()
+  })
+
+  afterAll(() => {
+    //1.- Restore the original fetch implementation once the test suite completes.
+    global.fetch = originalFetch
+  })
+
+  const renderPanel = async (element: React.ReactElement) => {
+    //1.- Render within React's act helper to ensure layout effects settle synchronously in tests.
+    await act(async () => {
+      root = createRoot(container)
+      root.render(element)
+    })
+  }
+
+  const flushMicrotasks = async () => {
+    //1.- Await the resolution of pending microtasks so chained promises settle before assertions.
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+
+  it('instructs the user to configure the bridge URL when missing', async () => {
+    await renderPanel(<SimulationControlPanel baseUrl="" />)
+    const status = container.querySelector('[data-testid="bridge-status"]')
+    const error = container.querySelector('[data-testid="bridge-error"]')
+    expect(status?.textContent ?? '').toContain('offline')
+    expect(error?.textContent ?? '').toContain('NEXT_PUBLIC_SIM_BRIDGE_URL')
+  })
+
+  it('reports a successful handshake', async () => {
+    const handshake = { message: 'Simulation bridge online' }
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => handshake })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    await renderPanel(<SimulationControlPanel baseUrl="http://localhost:8080" />)
+    await flushMicrotasks()
+
+    const status = container.querySelector('[data-testid="bridge-status"]')
+    expect(status?.textContent ?? '').toContain('Simulation bridge online')
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8080/handshake', expect.any(Object))
+  })
+
+  it('sends commands to the bridge', async () => {
+    const handshake = { message: 'Simulation bridge online' }
+    const commandResponse = { command: { command: 'throttle' } }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => handshake })
+      .mockResolvedValueOnce({ ok: true, json: async () => commandResponse })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    await renderPanel(<SimulationControlPanel baseUrl="http://localhost:8080" />)
+    await flushMicrotasks()
+
+    const throttleButton = container.querySelector('button') as HTMLButtonElement
+    await act(async () => {
+      throttleButton.click()
+    })
+    await flushMicrotasks()
+
+    const lastCommand = container.querySelector('[data-testid="last-command"]')
+    expect(lastCommand?.textContent ?? '').toContain('throttle')
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:8080/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: expect.stringContaining('throttle'),
+    })
+  })
+
+  it('notifies listeners after successful commands', async () => {
+    const handshake = { message: 'Simulation bridge online' }
+    const commandResponse = { command: { command: 'brake' } }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => handshake })
+      .mockResolvedValueOnce({ ok: true, json: async () => commandResponse })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const listener = vi.fn()
+    await renderPanel(<SimulationControlPanel baseUrl="http://localhost:8080" onCommandSent={listener} />)
+    await flushMicrotasks()
+
+    const brakeButton = container.querySelectorAll('button')[1] as HTMLButtonElement
+    await act(async () => {
+      brakeButton.click()
+    })
+    await flushMicrotasks()
+
+    expect(listener).toHaveBeenCalledWith('brake')
+  })
+})

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+export type CommandName = 'throttle' | 'brake'
+
+type PanelProps = {
+  baseUrl?: string
+  onCommandSent?: (command: CommandName) => void
+}
+
+const DEFAULT_STATUS = 'Simulation bridge offline.'
+const CONFIG_HINT = 'Set NEXT_PUBLIC_SIM_BRIDGE_URL to enable interactive control.'
+
+export default function SimulationControlPanel({ baseUrl, onCommandSent }: PanelProps) {
+  //1.- Resolve the bridge base URL lazily so runtime overrides and props are respected.
+  const resolvedBaseUrl = useMemo(() => {
+    const candidate = baseUrl ?? process.env.NEXT_PUBLIC_SIM_BRIDGE_URL ?? ''
+    return candidate.trim()
+  }, [baseUrl])
+  //2.- Track status and error messages so the UI communicates connection progress.
+  const [status, setStatus] = useState(DEFAULT_STATUS)
+  const [error, setError] = useState('')
+  const [lastCommand, setLastCommand] = useState('none')
+
+  useEffect(() => {
+    //1.- Abort early when the bridge URL is not configured to avoid failing network calls.
+    if (!resolvedBaseUrl) {
+      setStatus(DEFAULT_STATUS)
+      setError(CONFIG_HINT)
+      return
+    }
+    let cancelled = false
+    const controller = new AbortController()
+    //2.- Notify the user that the handshake negotiation has started.
+    setStatus('Negotiating with simulation bridge…')
+    setError('')
+    //3.- Attempt to fetch the handshake payload from the bridge server.
+    fetch(`${resolvedBaseUrl}/handshake`, { cache: 'no-store', signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Handshake failed with status ${response.status}`)
+        }
+        return response.json()
+      })
+      .then((payload: { message?: string }) => {
+        if (cancelled) {
+          return
+        }
+        setStatus(payload.message ?? 'Simulation bridge online')
+        setError('')
+      })
+      .catch((reason: Error) => {
+        if (cancelled) {
+          return
+        }
+        setStatus(DEFAULT_STATUS)
+        setError(`Handshake error: ${reason.message}`)
+      })
+    //4.- Clean up the pending request if the component unmounts during negotiation.
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [resolvedBaseUrl])
+
+  const sendCommand = useCallback(
+    async (command: CommandName) => {
+      //1.- Prevent command dispatches when the bridge URL has not been configured yet.
+      if (!resolvedBaseUrl) {
+        setError(CONFIG_HINT)
+        return
+      }
+      try {
+        setError('')
+        const response = await fetch(`${resolvedBaseUrl}/command`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command, issuedAtMs: Date.now() }),
+        })
+        if (!response.ok) {
+          throw new Error(`Command failed with status ${response.status}`)
+        }
+        const payload = await response.json()
+        const resolvedCommand = payload.command?.command ?? command
+        setLastCommand(resolvedCommand)
+        //2.- Inform any listeners about the successful dispatch so scenes can react immediately.
+        onCommandSent?.(resolvedCommand)
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : 'Unknown error'
+        setError(`Command error: ${message}`)
+      }
+    },
+    [resolvedBaseUrl, onCommandSent],
+  )
+
+  //3.- Render the control panel with buttons that dispatch commands to the simulation bridge.
+  return (
+    <section aria-label="Simulation control panel">
+      <h2>Simulation Bridge</h2>
+      <p data-testid="bridge-status">{status}</p>
+      {error ? (
+        <p role="alert" data-testid="bridge-error">
+          {error}
+        </p>
+      ) : null}
+      <div>
+        <button type="button" onClick={() => void sendCommand('throttle')}>
+          Throttle
+        </button>
+        <button type="button" onClick={() => void sendCommand('brake')}>
+          Brake
+        </button>
+      </div>
+      <p data-testid="last-command">Last command: {lastCommand}</p>
+    </section>
+  )
+}

--- a/tunnelcave_sandbox_web/app/components/VehicleScene.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/VehicleScene.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import VehicleScene from './VehicleScene'
+
+vi.mock('three', async () => {
+  const actual = await vi.importActual<typeof import('three')>('three')
+  class WebGLRendererMock {
+    domElement: HTMLCanvasElement
+    constructor(params: { canvas: HTMLCanvasElement }) {
+      this.domElement = params.canvas
+    }
+    setPixelRatio() {}
+    setSize() {}
+    render() {}
+    dispose() {}
+  }
+  return { ...actual, WebGLRenderer: WebGLRendererMock }
+})
+
+vi.mock('three/examples/jsm/controls/OrbitControls', () => {
+  const { Vector3 } = require('three') as typeof import('three')
+  return {
+    OrbitControls: class {
+      target = new Vector3()
+      enableDamping = false
+      dampingFactor = 0
+      constructor() {}
+      update() {}
+      dispose() {}
+    },
+  }
+})
+
+describe('VehicleScene', () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+  let container: HTMLDivElement
+  let root: Root | null
+
+  beforeEach(() => {
+    //1.- Prepare a DOM container and fake timers so animation frames can be advanced deterministically.
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(container)
+    root = null
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      return window.setTimeout(() => {
+        callback(performance.now())
+      }, 16) as unknown as number
+    })
+    globalThis.cancelAnimationFrame = ((handle: number) => {
+      clearTimeout(handle as unknown as number)
+    }) as unknown as typeof globalThis.cancelAnimationFrame
+  })
+
+  afterEach(async () => {
+    //1.- Dispose the rendered tree, restore timers, and clean the document body between scenarios.
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+      root = null
+    }
+    container.remove()
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+    vi.useRealTimers()
+  })
+
+  const renderScene = async (element: React.ReactElement) => {
+    //1.- Mount the scene through React DOM's act helper so effects run synchronously during tests.
+    await act(async () => {
+      root = createRoot(container)
+      root.render(element)
+    })
+  }
+
+  const rerenderScene = async (element: React.ReactElement) => {
+    //1.- Update the mounted tree to feed new props like bridge commands into the scene.
+    await act(async () => {
+      root?.render(element)
+    })
+  }
+
+  const advanceTime = async (ms: number) => {
+    //1.- Step through queued animation frames using Vitest's timer utilities.
+    await vi.advanceTimersByTimeAsync(ms)
+  }
+
+  const dispatchKey = (type: 'keydown' | 'keyup', key: string) => {
+    //1.- Simulate keyboard interaction so WASD and arrow keys toggle vehicle inputs.
+    const event = new KeyboardEvent(type, { key })
+    window.dispatchEvent(event)
+  }
+
+  it('reacts to throttle commands provided through props', async () => {
+    await renderScene(<VehicleScene />)
+    expect(container.querySelector('[data-testid="throttle-indicator"]')?.textContent ?? '').toContain('Off')
+
+    await rerenderScene(
+      <VehicleScene
+        externalCommand={{ command: 'throttle', issuedAtMs: typeof performance !== 'undefined' ? performance.now() : Date.now() }}
+      />,
+    )
+    await advanceTime(200)
+
+    expect(container.querySelector('[data-testid="throttle-indicator"]')?.textContent ?? '').toContain('On')
+  })
+
+  it('registers keyboard input for steering and braking', async () => {
+    await renderScene(<VehicleScene />)
+
+    dispatchKey('keydown', 'ArrowUp')
+    await advanceTime(100)
+    expect(container.querySelector('[data-testid="throttle-indicator"]')?.textContent ?? '').toContain('On')
+
+    dispatchKey('keydown', 'ArrowLeft')
+    await advanceTime(100)
+    expect(container.querySelector('[data-testid="steer-indicator"]')?.textContent ?? '').toContain('Left')
+
+    dispatchKey('keydown', 'ArrowDown')
+    await advanceTime(100)
+    expect(container.querySelector('[data-testid="brake-indicator"]')?.textContent ?? '').toContain('On')
+  })
+
+  it('increases speed when throttle is held', async () => {
+    await renderScene(<VehicleScene />)
+    const initialSpeed = container.querySelector('[data-testid="speed-readout"]')?.textContent ?? ''
+
+    dispatchKey('keydown', 'w')
+    await advanceTime(800)
+    const speedText = container.querySelector('[data-testid="speed-readout"]')?.textContent ?? ''
+
+    expect(speedText).not.toEqual(initialSpeed)
+  })
+})

--- a/tunnelcave_sandbox_web/app/components/VehicleScene.tsx
+++ b/tunnelcave_sandbox_web/app/components/VehicleScene.tsx
@@ -1,0 +1,372 @@
+'use client'
+
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+
+import type { CommandName } from './SimulationControlPanel'
+
+export type ExternalCommand = {
+  command: CommandName
+  issuedAtMs: number
+}
+
+type InputState = {
+  throttleKeyboard: boolean
+  brakeKeyboard: boolean
+  steerKeyboard: -1 | 0 | 1
+  throttleCommandUntil: number
+  brakeCommandUntil: number
+}
+
+type TelemetryState = {
+  speedKph: number
+  headingDeg: number
+  throttleEngaged: boolean
+  brakeEngaged: boolean
+  steeringLabel: 'Left' | 'Right' | 'Straight'
+  rendererReady: boolean
+  rendererError: string
+}
+
+type VehicleSceneProps = {
+  externalCommand?: ExternalCommand
+}
+
+const INITIAL_INPUT: InputState = {
+  throttleKeyboard: false,
+  brakeKeyboard: false,
+  steerKeyboard: 0,
+  throttleCommandUntil: 0,
+  brakeCommandUntil: 0,
+}
+
+const INITIAL_TELEMETRY: TelemetryState = {
+  speedKph: 0,
+  headingDeg: 0,
+  throttleEngaged: false,
+  brakeEngaged: false,
+  steeringLabel: 'Straight',
+  rendererReady: false,
+  rendererError: '',
+}
+
+export default function VehicleScene({ externalCommand }: VehicleSceneProps) {
+  //1.- Keep stable references to the canvas element, mutable input state, and vehicle physics.
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const inputRef = useRef<InputState>({ ...INITIAL_INPUT })
+  const physicsRef = useRef({
+    position: new THREE.Vector3(0, 0.3, 0),
+    velocity: 0,
+    heading: 0,
+  })
+  const vehicleRef = useRef<THREE.Group | null>(null)
+  //2.- Track the telemetry shown to the player so tests can assert interactive changes.
+  const [telemetry, setTelemetry] = useState<TelemetryState>({ ...INITIAL_TELEMETRY })
+
+  //3.- Derive memoized styles for the overlay so rerenders do not allocate new objects.
+  const overlayStyle = useMemo<React.CSSProperties>(
+    () => ({
+      position: 'absolute',
+      top: '1rem',
+      left: '1rem',
+      padding: '0.75rem 1rem',
+      background: 'rgba(0, 0, 0, 0.55)',
+      color: '#ffffff',
+      borderRadius: '0.5rem',
+      fontFamily: 'system-ui, sans-serif',
+      fontSize: '0.9rem',
+      lineHeight: 1.4,
+      pointerEvents: 'none',
+      maxWidth: '16rem',
+    }),
+    [],
+  )
+
+  //4.- Provide a helper that updates both the mutable input state and the telemetry overlays.
+  const updateInputs = (updater: (current: InputState) => InputState) => {
+    inputRef.current = updater(inputRef.current)
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now()
+    const throttleActive =
+      inputRef.current.throttleKeyboard || now < inputRef.current.throttleCommandUntil
+    const brakeActive = inputRef.current.brakeKeyboard || now < inputRef.current.brakeCommandUntil
+    const steeringLabel: TelemetryState['steeringLabel'] =
+      inputRef.current.steerKeyboard < 0
+        ? 'Left'
+        : inputRef.current.steerKeyboard > 0
+          ? 'Right'
+          : 'Straight'
+    setTelemetry((previous) => ({
+      ...previous,
+      throttleEngaged: throttleActive,
+      brakeEngaged: brakeActive,
+      steeringLabel,
+    }))
+  }
+
+  useEffect(() => {
+    //1.- Synchronize the keyboard handlers so WASD and arrow keys manipulate throttle, brake, and steering.
+    const handleKeyDown = (event: KeyboardEvent) => {
+      switch (event.key.toLowerCase()) {
+        case 'arrowup':
+        case 'w':
+          updateInputs((current) => ({ ...current, throttleKeyboard: true }))
+          break
+        case 'arrowdown':
+        case 's':
+          updateInputs((current) => ({ ...current, brakeKeyboard: true }))
+          break
+        case 'arrowleft':
+        case 'a':
+          updateInputs((current) => ({ ...current, steerKeyboard: -1 }))
+          break
+        case 'arrowright':
+        case 'd':
+          updateInputs((current) => ({ ...current, steerKeyboard: 1 }))
+          break
+        default:
+          break
+      }
+    }
+    const handleKeyUp = (event: KeyboardEvent) => {
+      switch (event.key.toLowerCase()) {
+        case 'arrowup':
+        case 'w':
+          updateInputs((current) => ({ ...current, throttleKeyboard: false }))
+          break
+        case 'arrowdown':
+        case 's':
+          updateInputs((current) => ({ ...current, brakeKeyboard: false }))
+          break
+        case 'arrowleft':
+        case 'a':
+          updateInputs((current) => ({
+            ...current,
+            steerKeyboard: current.steerKeyboard === -1 ? 0 : current.steerKeyboard,
+          }))
+          break
+        case 'arrowright':
+        case 'd':
+          updateInputs((current) => ({
+            ...current,
+            steerKeyboard: current.steerKeyboard === 1 ? 0 : current.steerKeyboard,
+          }))
+          break
+        default:
+          break
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+    }
+  }, [])
+
+  useEffect(() => {
+    //1.- Apply external throttle and brake commands so the scene reacts to bridge-driven controls.
+    if (!externalCommand) {
+      return
+    }
+    if (externalCommand.command === 'throttle') {
+      updateInputs((current) => ({ ...current, throttleCommandUntil: externalCommand.issuedAtMs + 750 }))
+    }
+    if (externalCommand.command === 'brake') {
+      updateInputs((current) => ({ ...current, brakeCommandUntil: externalCommand.issuedAtMs + 600 }))
+    }
+  }, [externalCommand])
+
+  useEffect(() => {
+    //1.- Bail out until the canvas has been mounted by React.
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+
+    //2.- Attempt to create the renderer, camera, controls, and scene graph.
+    let renderer: THREE.WebGLRenderer | null = null
+    let animationFrameId: number | null = null
+    let resizeHandler: (() => void) | null = null
+    let controls: OrbitControls | null = null
+    const scene = new THREE.Scene()
+    try {
+      renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
+      renderer.setPixelRatio(window.devicePixelRatio ?? 1)
+      const { clientWidth, clientHeight } = canvas
+      renderer.setSize(clientWidth, clientHeight)
+      scene.background = new THREE.Color(0x87ceeb)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown WebGL initialization error'
+      setTelemetry((previous) => ({ ...previous, rendererReady: false, rendererError: message }))
+      return
+    }
+
+    const camera = new THREE.PerspectiveCamera(60, canvas.clientWidth / canvas.clientHeight, 0.1, 500)
+    camera.position.set(6, 4, 8)
+    camera.lookAt(new THREE.Vector3(0, 0.5, 0))
+
+    controls = new OrbitControls(camera, canvas)
+    controls.target.set(0, 0.5, 0)
+    controls.enableDamping = true
+    controls.dampingFactor = 0.05
+    controls.update()
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.6)
+    scene.add(ambient)
+    const sun = new THREE.DirectionalLight(0xffffff, 0.9)
+    sun.position.set(8, 15, 12)
+    scene.add(sun)
+
+    const groundGeometry = new THREE.PlaneGeometry(200, 200)
+    const groundMaterial = new THREE.MeshLambertMaterial({ color: 0x2f8f2f })
+    const ground = new THREE.Mesh(groundGeometry, groundMaterial)
+    ground.rotation.x = -Math.PI / 2
+    ground.receiveShadow = true
+    scene.add(ground)
+
+    const roadGeometry = new THREE.PlaneGeometry(4, 120)
+    const roadMaterial = new THREE.MeshLambertMaterial({ color: 0x333333 })
+    const road = new THREE.Mesh(roadGeometry, roadMaterial)
+    road.rotation.x = -Math.PI / 2
+    road.position.set(0, 0.01, 0)
+    scene.add(road)
+
+    const vehicle = new THREE.Group()
+    vehicleRef.current = vehicle
+
+    const chassisGeometry = new THREE.BoxGeometry(1.8, 0.6, 3.8)
+    const chassisMaterial = new THREE.MeshStandardMaterial({ color: 0xff5533, metalness: 0.2, roughness: 0.6 })
+    const chassis = new THREE.Mesh(chassisGeometry, chassisMaterial)
+    chassis.position.set(0, 0.6, 0)
+    chassis.castShadow = true
+    vehicle.add(chassis)
+
+    const cabinGeometry = new THREE.BoxGeometry(1.4, 0.5, 1.8)
+    const cabinMaterial = new THREE.MeshStandardMaterial({ color: 0xffffff, metalness: 0.1, roughness: 0.2 })
+    const cabin = new THREE.Mesh(cabinGeometry, cabinMaterial)
+    cabin.position.set(0, 0.95, -0.2)
+    vehicle.add(cabin)
+
+    const wheelGeometry = new THREE.CylinderGeometry(0.36, 0.36, 0.4, 24)
+    const wheelMaterial = new THREE.MeshStandardMaterial({ color: 0x111111, metalness: 0.3, roughness: 0.7 })
+    const wheelOffsets: Array<[number, number, number]> = [
+      [0.8, 0.3, 1.25],
+      [-0.8, 0.3, 1.25],
+      [0.8, 0.3, -1.25],
+      [-0.8, 0.3, -1.25],
+    ]
+    wheelOffsets.forEach(([x, y, z]) => {
+      const wheel = new THREE.Mesh(wheelGeometry, wheelMaterial)
+      wheel.rotation.z = Math.PI / 2
+      wheel.position.set(x, y, z)
+      wheel.castShadow = true
+      vehicle.add(wheel)
+    })
+
+    scene.add(vehicle)
+
+    const skyGeometry = new THREE.SphereGeometry(300, 32, 32)
+    const skyMaterial = new THREE.MeshBasicMaterial({ color: 0x87ceeb, side: THREE.BackSide })
+    const sky = new THREE.Mesh(skyGeometry, skyMaterial)
+    scene.add(sky)
+
+    const resizeCanvas = () => {
+      const { clientWidth, clientHeight } = canvas
+      camera.aspect = clientWidth / Math.max(clientHeight, 1)
+      camera.updateProjectionMatrix()
+      renderer?.setSize(clientWidth, clientHeight)
+    }
+    resizeCanvas()
+    resizeHandler = resizeCanvas
+    window.addEventListener('resize', resizeCanvas)
+
+    setTelemetry((previous) => ({ ...previous, rendererReady: true, rendererError: '' }))
+
+    let lastTimestamp = typeof performance !== 'undefined' ? performance.now() : Date.now()
+    const animate = (timestamp: number) => {
+      animationFrameId = requestAnimationFrame(animate)
+      const dt = Math.min((timestamp - lastTimestamp) / 1000, 0.05)
+      lastTimestamp = timestamp
+
+      const inputState = inputRef.current
+      const throttleActive =
+        inputState.throttleKeyboard || timestamp < inputState.throttleCommandUntil
+      const brakeActive = inputState.brakeKeyboard || timestamp < inputState.brakeCommandUntil
+      const steer = inputState.steerKeyboard
+
+      const physics = physicsRef.current
+      const acceleration = throttleActive ? 6 : 0
+      const braking = brakeActive ? 8 : 0
+      physics.velocity += (acceleration - braking) * dt
+      const drag = physics.velocity * 0.85 * dt
+      physics.velocity = Math.max(0, physics.velocity - drag)
+      if (physics.velocity > 0.01) {
+        physics.heading += steer * dt * 0.9
+        const forwardX = Math.sin(physics.heading)
+        const forwardZ = Math.cos(physics.heading)
+        physics.position.x += forwardX * physics.velocity * dt
+        physics.position.z += forwardZ * physics.velocity * dt
+      }
+
+      if (vehicleRef.current) {
+        vehicleRef.current.position.copy(physics.position)
+        vehicleRef.current.position.y = 0.1
+        vehicleRef.current.rotation.y = physics.heading
+      }
+
+      controls?.update()
+      renderer?.render(scene, camera)
+
+      setTelemetry((previous) => {
+        const normalizedHeading = THREE.MathUtils.euclideanModulo(physics.heading, Math.PI * 2)
+        const headingDeg = THREE.MathUtils.radToDeg(normalizedHeading)
+        return {
+          ...previous,
+          speedKph: physics.velocity * 3.6,
+          headingDeg,
+          throttleEngaged: throttleActive,
+          brakeEngaged: brakeActive,
+          steeringLabel: steer < 0 ? 'Left' : steer > 0 ? 'Right' : 'Straight',
+        }
+      })
+    }
+    animationFrameId = requestAnimationFrame(animate)
+
+    //3.- Clean up GPU resources, handlers, and animation loops when the component unmounts.
+    return () => {
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId)
+      }
+      window.removeEventListener('resize', resizeCanvas)
+      controls?.dispose()
+      renderer?.dispose()
+      scene.clear()
+      vehicleRef.current = null
+      setTelemetry((previous) => ({ ...previous, rendererReady: false }))
+    }
+  }, [])
+
+  //5.- Present the canvas and HUD overlay with live telemetry readouts.
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '480px', marginTop: '1rem' }}>
+      <canvas ref={canvasRef} style={{ width: '100%', height: '100%', borderRadius: '0.75rem' }} />
+      <div style={overlayStyle}>
+        <p data-testid="speed-readout">Speed: {telemetry.speedKph.toFixed(1)} km/h</p>
+        <p data-testid="heading-readout">Heading: {telemetry.headingDeg.toFixed(0)}°</p>
+        <p data-testid="throttle-indicator">
+          Throttle: {telemetry.throttleEngaged ? 'On' : 'Off'}
+        </p>
+        <p data-testid="brake-indicator">Brake: {telemetry.brakeEngaged ? 'On' : 'Off'}</p>
+        <p data-testid="steer-indicator">Steering: {telemetry.steeringLabel}</p>
+        {telemetry.rendererReady ? (
+          <p>Controls: Arrow keys or WASD.</p>
+        ) : telemetry.rendererError ? (
+          <p role="alert">Renderer error: {telemetry.rendererError}</p>
+        ) : (
+          <p>Initializing renderer…</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/tunnelcave_sandbox_web/next-env.d.ts
+++ b/tunnelcave_sandbox_web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tunnelcave_sandbox_web/package-lock.json
+++ b/tunnelcave_sandbox_web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",
+        "@rollup/rollup-linux-x64-gnu": "^4.24.0",
         "three": "^0.168.0"
       },
       "devDependencies": {
@@ -1468,15 +1469,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
-      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ]
@@ -3303,6 +3302,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",

--- a/tunnelcave_sandbox_web/package.json
+++ b/tunnelcave_sandbox_web/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.9.0",
+    "@rollup/rollup-linux-x64-gnu": "^4.24.0",
     "three": "^0.168.0"
   }
 }

--- a/tunnelcave_sandbox_web/tsconfig.json
+++ b/tunnelcave_sandbox_web/tsconfig.json
@@ -3,14 +3,34 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2023",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowJs": true,
+    "incremental": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["src", "app", "env.d.ts"]
+  "include": [
+    "app",
+    "env.d.ts",
+    "src",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add a three.js powered `VehicleScene` with keyboard and bridge command handling so the sandbox renders a controllable car in the browser
- feed control panel events into the new scene via the bootstrap flow and expose callbacks when commands succeed
- extend the test suite with coverage for the bootstrap mock, command listener behavior, and the vehicle scene animation loop

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68df7d58f2e483299f1cc20fa14fbf67