### PR TITLE
Document Python-only piloting workflow

### DIFF
--- a/docs/python_only_client/README.md
+++ b/docs/python_only_client/README.md
@@ -1,0 +1,62 @@
+# Python-Only Piloting Guide
+
+This guide explains how to fly Drift Pursuit vehicles using the existing Python SDK instead of the unfinished Next.js web shell.
+
+## When to Choose Python Over Next.js
+
+- **You only need direct control:** The Go broker already exposes the gRPC `/PublishIntents` stream that the Python `IntentClient` wraps, so you can send throttle, yaw, pitch, roll, boost, and reset commands without a browser session.【F:python-sim/bot_sdk/intent_client.py†L36-L118】
+- **You want broker diffs programmatically:** `StateStreamReceiver` consumes the broker's state diff stream, buffers it in tick order, and raises callbacks for your game logic—no DOM or rendering required.【F:python-sim/bot_sdk/state_stream.py†L1-L102】
+- **You prefer a CLI wrapper:** `python -m bots.fsm_cli` already wires both helpers together and lets you drive archetype bots against the live broker or record intents offline.【F:python-sim/bots/fsm_cli.py†L1-L118】
+- **You only need heads-up telemetry:** The Next.js client ships as a minimal shell with empty render anchors, so it provides no visual advantages yet beyond what you script yourself.【F:README.md†L1-L82】
+
+Choose the web client once you have Three.js rendering, cockpit HUD, or matchmaking UX needs. Until then, the Python path is faster for raw piloting and telemetry capture.
+
+## Prerequisites
+
+1. **Broker runtime** — Go 1.20+, `go run .` inside `go-broker/`.
+2. **Python tooling** — Python 3.11 with Poetry to install `python-sim/` dependencies.
+3. **Shared secret** — If gRPC auth is enabled, export `BROKER_GRPC_SHARED_SECRET` so Python and the broker agree.【F:README.md†L24-L78】
+
+## Launching a Python-Only Session
+
+1. **Start the broker**
+   ```bash
+   cd go-broker
+   export BROKER_WS_AUTH_MODE=disabled
+   export BROKER_GRPC_AUTH_MODE=shared_secret
+   export BROKER_GRPC_SHARED_SECRET=dev-secret
+   go run .
+   ```
+2. **Install the Python SDK**
+   ```bash
+   cd ../python-sim
+   poetry install
+   ```
+3. **Stream world diffs and send intents**
+   ```bash
+   poetry run python -m bots.fsm_cli patrol \
+     --client-id cli-pilot \
+     --waypoints "0,0;50,0;50,50;0,50" \
+     --allow-boost \
+     --diff-log -
+   ```
+   - `IntentClient` connects to `localhost:43127` by default; override with `--address` if you run the broker elsewhere.【F:python-sim/bots/fsm_cli.py†L47-L118】
+   - Supply `--dry-run` to record generated intents without hitting the broker, or drop `--diff-log -` to stream live diffs.
+
+## Building Your Own Controller
+
+1. **Subscribe to diffs** — Instantiate `StateStreamReceiver` and feed it `StateDiffFrame` messages from the broker gRPC stream; the receiver keeps ticks ordered and exposes latency samples for debugging.【F:python-sim/bot_sdk/state_stream.py†L1-L102】
+2. **Publish intents** — Create an `IntentClient`, call `start()`, push dictionaries with desired control values via `send_intent`, and finally call `stop()` to flush acknowledgements.【F:python-sim/bot_sdk/intent_client.py†L24-L118】
+3. **Compose a loop** — Combine both helpers in a coroutine or thread to react to diffs and emit intents at the cadence you configure (10–20 Hz supported).【F:python-sim/bot_sdk/intent_client.py†L36-L82】
+
+You can strip down the FSM CLI, reuse its parser, or write your own loop—no web client is required for any of these flows.
+
+## When to Reintroduce Next.js
+
+Return to the Next.js shell once you need:
+
+- GPU-rendered cave geometry and cockpit instrumentation once Three.js assets are ready.
+- Mouse/keyboard bindings for human pilots instead of scripted bots.
+- Session selection and match lifecycle UI.
+
+Until those features are implemented, the Python SDK remains the quickest path to playable sessions.

--- a/docs/vehicle_capabilities/README.md
+++ b/docs/vehicle_capabilities/README.md
@@ -1,0 +1,12 @@
+# Vehicle and Client Capabilities Overview
+
+## Procedural Vehicle Content
+- The roster is defined through static gameplay configuration rather than procedurally generated meshes. Entries in `vehicleRoster.ts` enumerate the available craft (with only the Skiff selectable and ground vehicles marked as placeholders) and tie each one to hand-authored stats and loadouts, without any procedural mesh data.
+- Vehicle stats and loadouts derive from `gameplayConfig.ts`, again providing authored numbers instead of parametric geometry. As such, the project currently lacks a system that would synthesize vehicle 3D models on the fly.
+
+## Python-Only Playability
+- The Python SDK ships gRPC helpers such as `IntentClient` for publishing throttle/steer commands at a fixed cadence and `StateStreamReceiver` companions that deliver world diffs, letting a Python program pilot vehicles without the browser UI.
+- Sample bots like `GRPCBot` and the FSM CLI showcase full control loops entirely in Python: they subscribe to the broker diff stream, emit intents, and expose CLI options to tune behaviour. You can adapt these implementations for interactive control or automation without needing to extend the core functionality first.
+
+## Required Extensions
+- Because the broker and SDK already expose control surfaces and diff streams, you can play from Python today. Further expansion is only necessary if you want richer vehicle assets (e.g., importing authored meshes) or custom client features beyond what the sample bots provide.

--- a/planning/tasks/TASKS.md
+++ b/planning/tasks/TASKS.md
@@ -1,0 +1,56 @@
+# Integration Tasks for Web-Based Vehicle Control
+
+## Objective
+Enable interactive control of existing 3D vehicle simulations from a Next.js web application by leveraging assets and logic already available in the `python-sim` and `tunnelcave_sandbox` projects. Assess alternative interaction options (such as a pure Python control surface) as contingency paths.
+
+## Task Breakdown
+
+### 1. Audit Existing Simulation Assets and Interfaces
+- [ ] Inventory 3D models and simulation logic currently available in `python-sim`, `tunnelcave_sandbox`, and `tunnelcave_sandbox_web`.
+- [ ] Document asset formats, physics/update loops, and any existing APIs or sockets exposed by the simulation.
+- [ ] Verify licensing and size constraints for transferring assets to the web client.
+
+### 2. Define Communication Layer Between Simulation and Web Client
+- [ ] Evaluate whether the simulation should run server-side (Python) with a real-time data stream or be ported to run entirely in the browser.
+- [ ] Select a transport protocol (e.g., WebSockets, WebRTC, REST) to synchronize state between Python back end and Next.js front end.
+- [ ] Prototype a minimal handshake between Python simulation process and a dummy Next.js endpoint to validate connectivity.
+
+### 3. Prepare 3D Assets for Web Consumption
+- [ ] Convert or export required models to browser-friendly formats (e.g., glTF/GLB) while keeping polycount manageable.
+- [ ] Establish a shared asset pipeline so updates in `python-sim` can be mirrored to the Next.js project automatically.
+- [ ] Create documentation that details asset conversion steps and storage locations in the repo.
+
+### 4. Implement Next.js Front-End Rendering and Controls
+- [ ] Integrate a 3D rendering library (such as Three.js or react-three-fiber) into the Next.js application.
+- [ ] Load converted models and ensure they render correctly with lighting and materials that match the simulation aesthetic.
+- [ ] Implement vehicle control UI and map control inputs (keyboard, gamepad, or on-screen) to simulation commands.
+- [ ] Add client-side tests covering rendering initialization and basic control input handling.
+
+### 5. Implement Back-End Simulation Control API
+- [ ] Expose simulation state and control endpoints in Python (e.g., FastAPI or Flask service) that relay commands to the vehicles.
+- [ ] Ensure synchronization of state updates (position, velocity, etc.) and broadcast to connected web clients.
+- [ ] Add automated tests validating command routing and state update payloads.
+
+### 6. Synchronize Simulation State to Browser
+- [ ] Establish streaming updates (WebSocket channels or polling) to push vehicle telemetry to the Next.js app.
+- [ ] Implement client-side state reconciliation to avoid jitter (e.g., interpolation/extrapolation).
+- [ ] Add tests to verify correct handling of incoming telemetry and update loops.
+
+### 7. Explore Alternative Interaction Surfaces
+- [ ] Prototype a Python-native control interface (CLI or desktop) that uses the same back-end API, ensuring flexibility beyond the browser.
+- [ ] Document pros/cons, performance characteristics, and maintenance implications of each interaction approach.
+
+### 8. Deployment and DevOps Considerations
+- [ ] Define local development workflow (Docker Compose or scripts) for running simulation back end alongside Next.js front end.
+- [ ] Plan deployment targets (e.g., containerized services) and ensure network/security configurations support real-time control.
+- [ ] Add CI steps for linting, tests, and integration checks across Python and Next.js components.
+
+### 9. Documentation and Knowledge Transfer
+- [ ] Produce setup guides for developers covering asset conversion, environment configuration, and running the integrated system.
+- [ ] Create user documentation describing how to control vehicles via the web interface and any alternative clients.
+- [ ] Schedule walkthrough sessions or recordings to onboard the team to the new interaction model.
+
+## Deliverables
+- Task completion checklist with owner assignments and timelines.
+- Working prototype demonstrating browser-based vehicle control with synchronized simulation state.
+- Supporting documentation, automated tests, and deployment artifacts.


### PR DESCRIPTION
## Summary
- add documentation describing how to pilot Drift Pursuit entirely from the Python SDK instead of the unfinished Next.js client
- outline prerequisites, setup steps, and guidance for composing custom controllers with IntentClient and StateStreamReceiver
- clarify when it makes sense to revisit the Next.js shell versus staying Python-only

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df7be3a68c832993f942cbf68699d0