### PR TITLE
Add onboarding env scaffolding and document defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ tunnelcave_sandbox_web/.next
 
 tunnelcave_sandbox_web/node_modules/
 tunnelcave_sandbox_web/node_modules/*
+tunnelcave_sandbox_web/.env.local
+tunnelcave_sandbox_web/.env.local.bak
 tunnelcave_sandbox_web/node_modules
 
 node_modules/

--- a/docs/env_configuration/README.md
+++ b/docs/env_configuration/README.md
@@ -1,0 +1,19 @@
+# Environment Configuration
+
+The Drift Pursuit sandbox relies on a small `.env.local` file inside `tunnelcave_sandbox_web/` to surface runtime configuration to the Next.js frontend. The keys listed below are safe defaults for local development and align with the expectations baked into the onboarding UI.
+
+## Required Keys
+
+| Key | Purpose | Local sample |
+| --- | --- | --- |
+| `NEXT_PUBLIC_BROKER_URL` | Websocket endpoint for exchanging HUD telemetry with the broker service. | `ws://localhost:43127/ws` |
+| `NEXT_PUBLIC_SIM_BRIDGE_URL` | HTTP origin that exposes the simulation bridge handshake and command endpoints. | `http://localhost:8000` |
+
+> [!TIP]
+> Run `scripts/setup-env.sh` from the repository root to scaffold a `.env.local` file pre-populated with the values above, including inline comments that explain how to adjust them for non-local setups.
+
+## Manual Setup Checklist
+
+1. Create `tunnelcave_sandbox_web/.env.local` if it does not exist.
+2. Populate the keys above, adjusting the host/port to match your running services.
+3. Restart `npm run dev` so the Next.js client reloads with the new environment variables.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# //1.- Discover the repository root so the script works from any invocation directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_FILE="${REPO_ROOT}/tunnelcave_sandbox_web/.env.local"
+BACKUP_FILE="${TARGET_FILE}.bak"
+
+# //2.- Detect if the caller requested an overwrite via the --force flag.
+OVERWRITE=false
+if [[ "${1:-}" == "--force" ]]; then
+  OVERWRITE=true
+fi
+
+# //3.- Ensure the Next.js workspace exists before attempting to scaffold.
+if [[ ! -d "${REPO_ROOT}/tunnelcave_sandbox_web" ]]; then
+  echo "error: tunnelcave_sandbox_web workspace not found" >&2
+  exit 1
+fi
+
+# //4.- Guard against clobbering an existing configuration unless --force is provided.
+if [[ -f "${TARGET_FILE}" && "${OVERWRITE}" != true ]]; then
+  echo "Found existing .env.local at ${TARGET_FILE}. Pass --force to overwrite." >&2
+  exit 0
+fi
+
+# //5.- Preserve the previous file so manual changes are not lost when overwriting.
+if [[ -f "${TARGET_FILE}" ]]; then
+  cp "${TARGET_FILE}" "${BACKUP_FILE}"
+  echo "Backed up existing .env.local to ${BACKUP_FILE}."
+fi
+
+# //6.- Write the recommended defaults with inline documentation for future adjustments.
+cat > "${TARGET_FILE}" <<'ENV_TEMPLATE'
+# Drift Pursuit sandbox environment configuration.
+# Update these values to point at your own services when not running locally.
+
+# Websocket endpoint served by the broker (default docker-compose port 43127).
+NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws
+
+# HTTP origin for the simulation bridge API (default local bridge port 8000).
+NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000
+ENV_TEMPLATE
+
+chmod 600 "${TARGET_FILE}"
+echo "Scaffolded ${TARGET_FILE} with local development defaults."

--- a/tunnelcave_sandbox_web/app/components/ClientBootstrap.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/ClientBootstrap.test.tsx
@@ -41,7 +41,9 @@ describe('ClientBootstrap', () => {
     const { default: ClientBootstrap } = await import('./ClientBootstrap')
     await renderComponent(<ClientBootstrap />)
     const message = container.querySelector('[data-testid="status-message"]')
-    expect(message?.textContent ?? '').toMatch(/Broker URL missing/i)
+    const text = message?.textContent ?? ''
+    expect(text).toMatch(/Broker URL missing/i)
+    expect(text).toContain('NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws')
     await teardown()
   })
 

--- a/tunnelcave_sandbox_web/app/components/ClientBootstrap.tsx
+++ b/tunnelcave_sandbox_web/app/components/ClientBootstrap.tsx
@@ -35,7 +35,10 @@ export default function ClientBootstrap() {
             Start the broker server locally and expose the websocket endpoint (default
             <code> ws://localhost:43127/ws</code>).
           </li>
-          <li>Create <code>.env.local</code> and set NEXT_PUBLIC_BROKER_URL to the broker endpoint.</li>
+          <li>
+            Create <code>.env.local</code> (use <code>scripts/setup-env.sh</code> for a starter file) and set NEXT_PUBLIC_BROKER_URL
+            to the broker endpoint.
+          </li>
           <li>Restart this page so the HUD connects using the configured broker URL.</li>
         </ol>
       </section>

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
@@ -56,8 +56,11 @@ describe('SimulationControlPanel', () => {
     await renderPanel(<SimulationControlPanel baseUrl="" />)
     const status = container.querySelector('[data-testid="bridge-status"]')
     const error = container.querySelector('[data-testid="bridge-error"]')
-    expect(status?.textContent ?? '').toContain('offline')
-    expect(error?.textContent ?? '').toContain('NEXT_PUBLIC_SIM_BRIDGE_URL')
+    const statusText = status?.textContent ?? ''
+    const errorText = error?.textContent ?? ''
+    expect(statusText).toContain('offline')
+    expect(errorText).toContain('NEXT_PUBLIC_SIM_BRIDGE_URL')
+    expect(errorText).toContain('http://localhost:8000')
   })
 
   it('reports a successful handshake', async () => {

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
@@ -9,7 +9,7 @@ type PanelProps = {
 }
 
 const DEFAULT_STATUS = 'Simulation bridge offline.'
-const CONFIG_HINT = 'Set NEXT_PUBLIC_SIM_BRIDGE_URL to enable interactive control.'
+const CONFIG_HINT = 'Set NEXT_PUBLIC_SIM_BRIDGE_URL (e.g. http://localhost:8000) to enable interactive control.'
 
 export default function SimulationControlPanel({ baseUrl }: PanelProps) {
   //1.- Resolve the bridge base URL lazily so runtime overrides and props are respected.

--- a/tunnelcave_sandbox_web/app/setup-env.test.ts
+++ b/tunnelcave_sandbox_web/app/setup-env.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { execFile } from 'node:child_process'
+import { promises as fs } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const appDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(appDir, '..', '..')
+const envFile = join(repoRoot, 'tunnelcave_sandbox_web', '.env.local')
+const scriptPath = join(repoRoot, 'scripts', 'setup-env.sh')
+
+async function runScript() {
+  //1.- Execute the Bash helper so the test observes the freshly scaffolded file contents.
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    execFile('bash', [scriptPath], { cwd: repoRoot }, (error) => {
+      if (error) {
+        rejectPromise(error)
+        return
+      }
+      resolvePromise()
+    })
+  })
+}
+
+describe('setup-env.sh', () => {
+  let originalContent: string | null = null
+  let existedBefore = false
+
+  beforeEach(async () => {
+    //1.- Capture the existing .env.local (if any) so the test can restore it afterwards.
+    try {
+      originalContent = await fs.readFile(envFile, 'utf8')
+      existedBefore = true
+    } catch {
+      originalContent = null
+      existedBefore = false
+    }
+    //2.- Remove the file to simulate a first-time onboarding experience.
+    await fs.rm(envFile, { force: true })
+  })
+
+  afterEach(async () => {
+    //1.- Restore or clean up the .env.local file so other tests are unaffected.
+    if (existedBefore && originalContent !== null) {
+      await fs.writeFile(envFile, originalContent, 'utf8')
+    } else {
+      await fs.rm(envFile, { force: true })
+    }
+  })
+
+  it('creates a .env.local with documented defaults', async () => {
+    await runScript()
+    const scaffolded = await fs.readFile(envFile, 'utf8')
+    //1.- Verify the onboarding comments and sample values are written to disk.
+    expect(scaffolded).toContain('Drift Pursuit sandbox environment configuration.')
+    expect(scaffolded).toContain('NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws')
+    expect(scaffolded).toContain('NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000')
+  })
+})


### PR DESCRIPTION
## Summary
- document the required web client environment variables and their local defaults
- add a setup-env.sh helper that scaffolds tunnelcave_sandbox_web/.env.local with comments and safe defaults
- ensure the onboarding UI and unit tests surface the documented defaults when env vars are missing and cover the script behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0031e783883299c79718303731630