### PR TITLE
Add vehicle control UI with persistent settings

### DIFF
--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.test.tsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { VehicleControlSettings } from './VehicleControlSettings'
+import { getSelectableVehicles } from '../../../../typescript-client/src/webLoadoutBridge'
+
+describe('VehicleControlSettings', () => {
+  beforeEach(() => {
+    //1.- Reset storage to ensure persistence tests operate deterministically.
+    window.localStorage.clear()
+  })
+
+  it('lists the default keybindings for reference', () => {
+    render(<VehicleControlSettings />)
+
+    expect(screen.getByRole('heading', { name: 'Keybindings' })).toBeInTheDocument()
+    expect(screen.getByText(/Accelerate/)).toBeInTheDocument()
+    expect(screen.getByText(/KeyW/)).toBeInTheDocument()
+  })
+
+  it('persists geometry adjustments to local storage', async () => {
+    render(<VehicleControlSettings />)
+
+    fireEvent.change(screen.getByLabelText(/Wheelbase/), { target: { value: '3.2' } })
+
+    await waitFor(() => {
+      const stored = JSON.parse(window.localStorage.getItem('vehicle-geometry-settings') ?? '{}')
+      expect(stored.wheelbase).toBeCloseTo(3.2)
+    })
+  })
+
+  it('derives default loadout selections from the roster', async () => {
+    const selectable = getSelectableVehicles()
+    const expectedVehicle = selectable[0]?.id ?? ''
+    const expectedLoadout = selectable[0]?.defaultLoadoutId ?? selectable[0]?.loadouts[0]?.id ?? ''
+
+    render(<VehicleControlSettings />)
+
+    await waitFor(() => {
+      const stored = JSON.parse(window.localStorage.getItem('vehicle-loadout-selection') ?? '{}')
+      expect(stored.vehicleId).toBe(expectedVehicle)
+      expect(stored.loadoutId).toBe(expectedLoadout)
+    })
+  })
+})

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import React, { useEffect, useMemo } from 'react'
+
+import VehicleGeometryControls, {
+  type VehicleGeometrySettings,
+} from './VehicleGeometryControls'
+import VehicleLoadoutSelector from './VehicleLoadoutSelector'
+import { usePersistentSetting } from '../../../src/ui/settings/usePersistentSetting'
+import { KeybindingConfiguration } from '../../../src/input/keybindings'
+import { getSelectableVehicles } from '../../../../typescript-client/src/webLoadoutBridge'
+
+interface VehicleLoadoutSelection {
+  //1.- Track the selected vehicle identifier so spawns remain deterministic across reloads.
+  vehicleId: string
+  //2.- Persist the selected loadout identifier for convenience when revisiting the panel.
+  loadoutId: string
+}
+
+const DEFAULT_GEOMETRY: VehicleGeometrySettings = {
+  //1.- Choose chassis defaults that map to the stock skiff configuration.
+  wheelbase: 2.6,
+  //2.- Default the track width to a balanced stance.
+  trackWidth: 1.8,
+  //3.- Set the center of mass height to the tuned mid-point for stability.
+  centerOfMassHeight: 0.85,
+  //4.- Disable inverted steering by default so controls match the keybinding descriptions.
+  steeringInverted: false,
+}
+
+const DEFAULT_LOADOUT_SELECTION: VehicleLoadoutSelection = {
+  //1.- Use the first selectable vehicle until the roster expands.
+  vehicleId: '',
+  //2.- Defer the loadout to be resolved once the vehicle is known.
+  loadoutId: '',
+}
+
+export function VehicleControlSettings() {
+  //1.- Persist geometry selections so tuning survives page reloads.
+  const [geometry, setGeometry] = usePersistentSetting<VehicleGeometrySettings>(
+    'vehicle-geometry-settings',
+    DEFAULT_GEOMETRY,
+  )
+  //2.- Persist loadout selections to avoid forcing players to reselect their preferred kit.
+  const [selection, setSelection] = usePersistentSetting<VehicleLoadoutSelection>(
+    'vehicle-loadout-selection',
+    DEFAULT_LOADOUT_SELECTION,
+  )
+  //3.- Cache the selectable roster entries to derive default selections and preview metadata.
+  const selectableVehicles = useMemo(() => getSelectableVehicles(), [])
+
+  const resolvedVehicleId = selection.vehicleId || selectableVehicles[0]?.id || ''
+  const resolvedLoadoutId = useMemo(() => {
+    const entry = selectableVehicles.find((candidate) => candidate.id === resolvedVehicleId)
+    const preferredLoadout = selection.loadoutId || entry?.defaultLoadoutId || entry?.loadouts[0]?.id || ''
+    return preferredLoadout
+  }, [resolvedVehicleId, selectableVehicles, selection.loadoutId])
+
+  useEffect(() => {
+    //1.- Normalize persisted state so freshly initialized stores adopt the derived defaults.
+    if (selection.vehicleId !== resolvedVehicleId || selection.loadoutId !== resolvedLoadoutId) {
+      setSelection({ vehicleId: resolvedVehicleId, loadoutId: resolvedLoadoutId })
+    }
+  }, [resolvedLoadoutId, resolvedVehicleId, selection.loadoutId, selection.vehicleId, setSelection])
+
+  //4.- Precompute the described keybindings so the list renders deterministically.
+  const bindings = useMemo(
+    () => KeybindingConfiguration.withDefaults().describe(),
+    [],
+  )
+
+  return (
+    <section aria-label="Vehicle control settings">
+      <VehicleGeometryControls value={geometry} onChange={setGeometry} />
+      <VehicleLoadoutSelector
+        vehicleId={resolvedVehicleId}
+        loadoutId={resolvedLoadoutId}
+        onVehicleChange={(vehicleId) =>
+          setSelection((current) => ({ ...current, vehicleId, loadoutId: '' }))
+        }
+        onLoadoutChange={(loadoutId) => setSelection((current) => ({ ...current, loadoutId }))}
+      />
+      <section aria-label="Keybinding summary">
+        <h3>Keybindings</h3>
+        <ul>
+          {bindings.map((binding) => (
+            <li key={binding.action}>
+              <strong>{binding.action}</strong>: {binding.key}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </section>
+  )
+}
+
+export default VehicleControlSettings

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleGeometryControls.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleGeometryControls.test.tsx
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { VehicleGeometryControls, type VehicleGeometrySettings } from './VehicleGeometryControls'
+
+const DEFAULT_SETTINGS: VehicleGeometrySettings = {
+  //1.- Provide deterministic defaults mirroring the component's base state.
+  wheelbase: 2.6,
+  trackWidth: 1.8,
+  centerOfMassHeight: 0.85,
+  steeringInverted: false,
+}
+
+describe('VehicleGeometryControls', () => {
+  it('renders geometry sliders with formatted values', () => {
+    render(<VehicleGeometryControls value={DEFAULT_SETTINGS} onChange={() => {}} />)
+
+    expect(screen.getByLabelText(/Wheelbase/)).toHaveValue(DEFAULT_SETTINGS.wheelbase.toString())
+    expect(screen.getByLabelText(/Track Width/)).toHaveValue(DEFAULT_SETTINGS.trackWidth.toString())
+    expect(screen.getByLabelText(/Center of Mass Height/)).toHaveValue(
+      DEFAULT_SETTINGS.centerOfMassHeight.toString(),
+    )
+    expect(screen.getByLabelText(/Invert Steering/)).not.toBeChecked()
+  })
+
+  it('invokes the onChange callback when sliders are adjusted', () => {
+    const handleChange = vi.fn()
+    render(<VehicleGeometryControls value={DEFAULT_SETTINGS} onChange={handleChange} />)
+
+    fireEvent.change(screen.getByLabelText(/Wheelbase/), { target: { value: '3.1' } })
+    expect(handleChange).toHaveBeenCalledWith({ ...DEFAULT_SETTINGS, wheelbase: 3.1 })
+
+    fireEvent.click(screen.getByLabelText(/Invert Steering/))
+    expect(handleChange).toHaveBeenCalledWith({ ...DEFAULT_SETTINGS, steeringInverted: true })
+  })
+})

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleGeometryControls.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleGeometryControls.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import React from 'react'
+
+export interface VehicleGeometrySettings {
+  //1.- Capture the wheelbase in meters so sliders can expose chassis length adjustments.
+  wheelbase: number
+  //2.- Track the track width in meters to mirror lateral stance adjustments.
+  trackWidth: number
+  //3.- Persist the center of mass height in meters to influence handling.
+  centerOfMassHeight: number
+  //4.- Store whether steering inputs should be inverted for accessibility.
+  steeringInverted: boolean
+}
+
+interface VehicleGeometryControlsProps {
+  //1.- Receive the current geometry settings so the sliders reflect persisted values.
+  value: VehicleGeometrySettings
+  //2.- Notify listeners whenever a slider or toggle updates a geometry parameter.
+  onChange: (next: VehicleGeometrySettings) => void
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  //1.- Constrain slider derived values inside their configured range.
+  return Math.min(Math.max(value, min), max)
+}
+
+const NUMERIC_BOUNDS: Record<Exclude<keyof VehicleGeometrySettings, 'steeringInverted'>, {
+  min: number
+  max: number
+}> = {
+  //1.- Wheelbase slider spans from a compact 1.5m chassis to a stretched 4.5m platform.
+  wheelbase: { min: 1.5, max: 4.5 },
+  //2.- Track width slider covers nimble skiffs through wider tanks.
+  trackWidth: { min: 1.2, max: 3.5 },
+  //3.- Center of mass slider ranges from 0.2m (low slung) to 2.5m (towering rigs).
+  centerOfMassHeight: { min: 0.2, max: 2.5 },
+}
+
+export function VehicleGeometryControls({ value, onChange }: VehicleGeometryControlsProps) {
+  //1.- Build change helpers so each slider updates a single field without recreating objects manually.
+  const updateField = (key: keyof VehicleGeometrySettings, raw: number | boolean) => {
+    if (typeof raw === 'number') {
+      const bounds = NUMERIC_BOUNDS[key as keyof typeof NUMERIC_BOUNDS]
+      const nextNumber = bounds ? clamp(raw, bounds.min, bounds.max) : raw
+      onChange({ ...value, [key]: nextNumber })
+      return
+    }
+    onChange({ ...value, [key]: raw })
+  }
+
+  return (
+    <fieldset>
+      <legend>Vehicle Geometry</legend>
+      <label>
+        Wheelbase ({value.wheelbase.toFixed(2)} m)
+        <input
+          type="range"
+          min={1.5}
+          max={4.5}
+          step={0.1}
+          value={value.wheelbase}
+          onChange={(event) => updateField('wheelbase', Number.parseFloat(event.target.value))}
+        />
+      </label>
+      <label>
+        Track Width ({value.trackWidth.toFixed(2)} m)
+        <input
+          type="range"
+          min={1.2}
+          max={3.5}
+          step={0.1}
+          value={value.trackWidth}
+          onChange={(event) => updateField('trackWidth', Number.parseFloat(event.target.value))}
+        />
+      </label>
+      <label>
+        Center of Mass Height ({value.centerOfMassHeight.toFixed(2)} m)
+        <input
+          type="range"
+          min={0.2}
+          max={2.5}
+          step={0.05}
+          value={value.centerOfMassHeight}
+          onChange={(event) => updateField('centerOfMassHeight', Number.parseFloat(event.target.value))}
+        />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={value.steeringInverted}
+          onChange={(event) => updateField('steeringInverted', event.target.checked)}
+        />
+        Invert Steering
+      </label>
+    </fieldset>
+  )
+}
+
+export default VehicleGeometryControls

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.test.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { VehicleLoadoutSelector } from './VehicleLoadoutSelector'
+import { getSelectableVehicles } from '../../../../typescript-client/src/webLoadoutBridge'
+
+describe('VehicleLoadoutSelector', () => {
+  it('renders vehicle and loadout options from the roster', () => {
+    const selectable = getSelectableVehicles()
+    const firstVehicle = selectable[0]
+
+    render(
+      <VehicleLoadoutSelector
+        vehicleId=""
+        loadoutId=""
+        onVehicleChange={() => {}}
+        onLoadoutChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByLabelText('Vehicle')).toHaveDisplayValue(firstVehicle.displayName)
+    if (firstVehicle.loadouts.length > 0) {
+      expect(screen.getByLabelText('Loadout')).toHaveDisplayValue(firstVehicle.loadouts[0]?.displayName ?? '')
+    }
+  })
+
+  it('emits callbacks when the user changes selections', () => {
+    const selectable = getSelectableVehicles()
+    const firstVehicle = selectable[0]
+    const loadout = firstVehicle.loadouts[0]
+
+    const handleVehicleChange = vi.fn()
+    const handleLoadoutChange = vi.fn()
+
+    render(
+      <VehicleLoadoutSelector
+        vehicleId={firstVehicle.id}
+        loadoutId={loadout?.id ?? ''}
+        onVehicleChange={handleVehicleChange}
+        onLoadoutChange={handleLoadoutChange}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Vehicle'), { target: { value: firstVehicle.id } })
+    expect(handleVehicleChange).toHaveBeenCalledWith(firstVehicle.id)
+
+    if (loadout) {
+      fireEvent.change(screen.getByLabelText('Loadout'), { target: { value: loadout.id } })
+      expect(handleLoadoutChange).toHaveBeenCalledWith(loadout.id)
+    }
+  })
+})

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React, { useMemo } from 'react'
+
+import {
+  getSelectableVehicles,
+  type LoadoutOption,
+} from '../../../../typescript-client/src/webLoadoutBridge'
+
+interface VehicleLoadoutSelectorProps {
+  //1.- Provide the currently selected vehicle identifier so the UI stays controlled.
+  vehicleId: string
+  //2.- Track the current loadout identifier for the nested selector.
+  loadoutId: string
+  //3.- Emit vehicle selection changes to higher level components for persistence.
+  onVehicleChange: (vehicleId: string) => void
+  //4.- Emit loadout selection changes to higher level components for persistence.
+  onLoadoutChange: (loadoutId: string) => void
+}
+
+const findDefaultLoadout = (option: LoadoutOption | undefined): string => {
+  //1.- Prefer the configured default identifier when present, otherwise fall back to the first loadout.
+  if (!option) {
+    return ''
+  }
+  if (option.defaultLoadoutId) {
+    return option.defaultLoadoutId
+  }
+  return option.loadouts[0]?.id ?? ''
+}
+
+export function VehicleLoadoutSelector({
+  vehicleId,
+  loadoutId,
+  onVehicleChange,
+  onLoadoutChange,
+}: VehicleLoadoutSelectorProps) {
+  //1.- Resolve the selectable vehicles once per render lifecycle to avoid recomputing arrays on every interaction.
+  const selectableVehicles = useMemo(() => getSelectableVehicles(), [])
+  //1.- Resolve the currently active vehicle by falling back to the first selectable entry.
+  const resolvedVehicleId = vehicleId || selectableVehicles[0]?.id || ''
+  const activeVehicle = selectableVehicles.find((entry) => entry.id === resolvedVehicleId)
+  //2.- Mirror the default loadout when no persisted selection exists yet.
+  const effectiveLoadoutId = loadoutId || findDefaultLoadout(activeVehicle)
+  const loadoutOptions = activeVehicle?.loadouts ?? []
+
+  return (
+    <fieldset>
+      <legend>Vehicle Loadout</legend>
+      <label>
+        Vehicle
+        <select
+          value={resolvedVehicleId}
+          onChange={(event) => {
+            const nextVehicle = event.target.value
+            const nextActive = selectableVehicles.find((entry) => entry.id === nextVehicle)
+            onVehicleChange(nextVehicle)
+            const defaultLoadout = findDefaultLoadout(nextActive)
+            onLoadoutChange(defaultLoadout)
+          }}
+        >
+          {selectableVehicles.map((vehicle) => (
+            <option key={vehicle.id} value={vehicle.id}>
+              {vehicle.displayName}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Loadout
+        <select
+          value={effectiveLoadoutId}
+          onChange={(event) => onLoadoutChange(event.target.value)}
+          disabled={loadoutOptions.length === 0}
+        >
+          {loadoutOptions.map((loadout) => (
+            <option key={loadout.id} value={loadout.id}>
+              {loadout.displayName}
+            </option>
+          ))}
+        </select>
+      </label>
+    </fieldset>
+  )
+}
+
+export default VehicleLoadoutSelector

--- a/tunnelcave_sandbox_web/src/ui/settings/usePersistentSetting.test.tsx
+++ b/tunnelcave_sandbox_web/src/ui/settings/usePersistentSetting.test.tsx
@@ -1,0 +1,39 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { usePersistentSetting } from './usePersistentSetting'
+
+describe('usePersistentSetting', () => {
+  beforeEach(() => {
+    //1.- Reset storage between runs so assertions remain deterministic.
+    window.localStorage.clear()
+  })
+
+  it('returns the default value when storage is empty', () => {
+    const { result } = renderHook(() => usePersistentSetting('test-key', 42))
+    expect(result.current[0]).toBe(42)
+  })
+
+  it('stores updates in localStorage and updates state', () => {
+    const { result } = renderHook(() => usePersistentSetting('test-key', 0))
+
+    act(() => {
+      result.current[1](7)
+    })
+
+    expect(result.current[0]).toBe(7)
+    expect(window.localStorage.getItem('test-key')).toBe('7')
+  })
+
+  it('responds to storage events', () => {
+    const { result } = renderHook(() => usePersistentSetting('test-key', 1))
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: 'test-key', newValue: JSON.stringify(9) }),
+      )
+    })
+
+    expect(result.current[0]).toBe(9)
+  })
+})

--- a/tunnelcave_sandbox_web/src/ui/settings/usePersistentSetting.ts
+++ b/tunnelcave_sandbox_web/src/ui/settings/usePersistentSetting.ts
@@ -1,0 +1,71 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+export type PersistentSetter<T> = (value: T | ((previous: T) => T)) => void
+
+export function usePersistentSetting<T>(key: string, defaultValue: T): [T, PersistentSetter<T>] {
+  //1.- Detect whether the hook executes in a browser environment before using localStorage APIs.
+  const isClient = typeof window !== 'undefined'
+  //2.- Memoize the storage reader to avoid re-parsing JSON on every render when the value is stable.
+  const readValue = useMemo(() => {
+    return (): T => {
+      if (!isClient) {
+        return defaultValue
+      }
+      try {
+        const raw = window.localStorage.getItem(key)
+        if (!raw) {
+          return defaultValue
+        }
+        return JSON.parse(raw) as T
+      } catch {
+        return defaultValue
+      }
+    }
+  }, [defaultValue, isClient, key])
+
+  const [value, setValue] = useState<T>(() => readValue())
+
+  useEffect(() => {
+    //1.- When running client side, mirror state changes into localStorage for persistence.
+    if (!isClient) {
+      return
+    }
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value))
+    } catch {
+      //1.- Swallow storage exceptions (e.g., quota errors) so UI remains usable.
+    }
+  }, [isClient, key, value])
+
+  useEffect(() => {
+    //1.- Subscribe to storage events so updates from other tabs stay in sync.
+    if (!isClient) {
+      return
+    }
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== key) {
+        return
+      }
+      if (event.storageArea && event.storageArea !== window.localStorage) {
+        return
+      }
+      setValue(event.newValue ? (JSON.parse(event.newValue) as T) : defaultValue)
+    }
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [defaultValue, isClient, key])
+
+  const update: PersistentSetter<T> = useCallback(
+    (next) => {
+      //1.- Support both direct values and updater functions for ergonomic callers.
+      setValue((current) => (typeof next === 'function' ? (next as (previous: T) => T)(current) : next))
+    },
+    [],
+  )
+
+  return [value, update]
+}

--- a/tunnelcave_sandbox_web/test/mocks/three.ts
+++ b/tunnelcave_sandbox_web/test/mocks/three.ts
@@ -1,0 +1,166 @@
+export class Vector3 {
+  //1.- Track the vector components to support translation interpolation.
+  x: number
+  y: number
+  z: number
+
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x
+    this.y = y
+    this.z = z
+  }
+
+  set(x: number, y: number, z: number): this {
+    this.x = x
+    this.y = y
+    this.z = z
+    return this
+  }
+
+  copy(other: Vector3): this {
+    return this.set(other.x, other.y, other.z)
+  }
+
+  lerp(target: Vector3, alpha: number): this {
+    this.x += (target.x - this.x) * alpha
+    this.y += (target.y - this.y) * alpha
+    this.z += (target.z - this.z) * alpha
+    return this
+  }
+}
+
+export class Euler {
+  //1.- Represent pitch/yaw/roll with an order string for quaternion conversion.
+  x: number
+  y: number
+  z: number
+  order: string
+
+  constructor(x = 0, y = 0, z = 0, order = 'XYZ') {
+    this.x = x
+    this.y = y
+    this.z = z
+    this.order = order
+  }
+
+  set(x: number, y: number, z: number, order = this.order): this {
+    this.x = x
+    this.y = y
+    this.z = z
+    this.order = order
+    return this
+  }
+}
+
+export class Quaternion {
+  //1.- Store quaternion components to mirror three.js' public interface.
+  x = 0
+  y = 0
+  z = 0
+  w = 1
+
+  set(x: number, y: number, z: number, w: number): this {
+    this.x = x
+    this.y = y
+    this.z = z
+    this.w = w
+    return this
+  }
+
+  copy(other: Quaternion): this {
+    return this.set(other.x, other.y, other.z, other.w)
+  }
+
+  setFromEuler(euler: Euler): this {
+    const c1 = Math.cos(euler.x / 2)
+    const c2 = Math.cos(euler.y / 2)
+    const c3 = Math.cos(euler.z / 2)
+    const s1 = Math.sin(euler.x / 2)
+    const s2 = Math.sin(euler.y / 2)
+    const s3 = Math.sin(euler.z / 2)
+
+    this.x = s1 * c2 * c3 + c1 * s2 * s3
+    this.y = c1 * s2 * c3 - s1 * c2 * s3
+    this.z = c1 * c2 * s3 + s1 * s2 * c3
+    this.w = c1 * c2 * c3 - s1 * s2 * s3
+    return this
+  }
+
+  slerp(target: Quaternion, alpha: number): this {
+    //1.- Perform a simple normalized linear interpolation for determinism in tests.
+    this.x += (target.x - this.x) * alpha
+    this.y += (target.y - this.y) * alpha
+    this.z += (target.z - this.z) * alpha
+    this.w += (target.w - this.w) * alpha
+    const length = Math.hypot(this.x, this.y, this.z, this.w) || 1
+    return this.set(this.x / length, this.y / length, this.z / length, this.w / length)
+  }
+}
+
+export class Object3D {
+  //1.- Emulate the scene graph hierarchy with parent/child relationships.
+  children: Object3D[] = []
+  parent: Object3D | null = null
+  position = new Vector3()
+  quaternion = new Quaternion()
+  rotation = new Euler()
+  matrixAutoUpdate = true
+  userData: Record<string, unknown> = {}
+  visible = true
+  name = ''
+
+  add(...objects: Object3D[]): this {
+    for (const object of objects) {
+      object.parent = this
+      this.children.push(object)
+    }
+    return this
+  }
+
+  remove(...objects: Object3D[]): this {
+    this.children = this.children.filter((candidate) => !objects.includes(candidate))
+    for (const object of objects) {
+      if (object.parent === this) {
+        object.parent = null
+      }
+    }
+    return this
+  }
+
+  removeFromParent(): this {
+    if (this.parent) {
+      this.parent.remove(this)
+    }
+    return this
+  }
+
+  updateMatrix(): void {
+    //1.- No-op placeholder to keep the API compatible with three.js.
+  }
+}
+
+export class Group extends Object3D {}
+
+export class Mesh extends Object3D {
+  //1.- Persist geometry and material references for metadata access.
+  geometry: unknown
+  material: unknown
+
+  constructor(geometry?: unknown, material?: unknown) {
+    super()
+    this.geometry = geometry
+    this.material = material
+  }
+}
+
+export class MeshStandardMaterial {
+  //1.- Store the options so tests can inspect them if required.
+  constructor(public parameters: Record<string, unknown> = {}) {}
+}
+
+export const MathUtils = {
+  //1.- Offer a deterministic conversion for Euler helper functions.
+  degToRad(degrees: number): number {
+    return (degrees * Math.PI) / 180
+  },
+}

--- a/tunnelcave_sandbox_web/vitest.config.ts
+++ b/tunnelcave_sandbox_web/vitest.config.ts
@@ -1,6 +1,13 @@
+import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      //1.- Provide a lightweight stub for three.js so unit tests avoid heavy WebGL dependencies.
+      three: path.resolve(__dirname, 'test/mocks/three.ts'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- add vehicle geometry and loadout selector components that show default keybindings
- persist vehicle tuning selections with a reusable usePersistentSetting hook
- stub three.js for Vitest and cover new UI with Testing Library suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e01a38c58c8329a45ae0be8715e356