### PR TITLE
Document visualizer operations and add pnpm Vitest CI job

### DIFF
--- a/.github/workflows/web-client-tests.yml
+++ b/.github/workflows/web-client-tests.yml
@@ -1,0 +1,31 @@
+name: Web client Vitest suites
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  vitest:
+    name: Run pnpm test (networking, geometry, UI)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Enable pnpm via Corepack
+        run: corepack enable pnpm
+
+      - name: Install dependencies
+        working-directory: tunnelcave_sandbox_web
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Vitest suites
+        working-directory: tunnelcave_sandbox_web
+        run: pnpm test -- --run

--- a/docs/visualizer_ops/README.md
+++ b/docs/visualizer_ops/README.md
@@ -1,0 +1,94 @@
+# Visualizer Operations Guide
+
+This runbook explains how to bring up the full Drift Pursuit visualizer stack on a local workstation: the Go broker streams
+telemetry, the Python HTTP bridge exposes simulation controls, and the Next.js client renders the sandbox UI. Follow each
+section in order to ensure the three services share credentials and network bindings.
+
+## Prerequisites
+- **Go 1.24.x** (matches the `toolchain go1.24.3` directive in `go-broker/go.mod`).
+- **Python 3.11+** with `pip` available for managing the bridge dependencies.
+- **Node.js 20.x** with `corepack` enabled so pnpm 10.18.x can be activated (see `docs/visualizer_setup/README.md`).
+- **pnpm 10.18.x** (`corepack use pnpm@10.18.0`) for the Next.js workspace.
+- **Environment ports** `43127` (WebSocket broker) and `8000` (HTTP bridge) must be free.
+
+## 1. Launch the Go broker
+1. Export the minimum secrets expected by the configuration loader:
+   ```bash
+   export BROKER_GRPC_SHARED_SECRET="local-dev-secret"
+   export BROKER_WS_AUTH_MODE="disabled"         # optional because this is already the default
+   ```
+2. Start the broker from the repository root (the listener defaults to `:43127` as defined in `internal/config/config.go`):
+   ```bash
+   cd go-broker
+   go run .
+   ```
+3. Verify the WebSocket listener is ready:
+   ```bash
+   curl -i http://localhost:43127/healthz || true
+   ```
+   The `/healthz` handler defined in `go-broker/main.go` returns a JSON payload with `status: "ok"` once the broker finishes
+   its startup sequence.
+
+## 2. Start the Python simulation bridge
+1. Create an isolated environment and install the lightweight tooling needed for tests:
+   ```bash
+   cd python-sim
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install pytest
+   ```
+   The repository modules are pure Python, so setting `PYTHONPATH` to the workspace is sufficient for imports; `pytest` is the
+   only external dependency required by the existing test suites.
+2. Run the bridge server with the default state provider on port `8000`:
+   ```bash
+   export PYTHONPATH="${PWD}"
+   python -m web_bridge.server
+   ```
+3. Confirm the handshake endpoint responds:
+   ```bash
+   curl http://localhost:8000/handshake
+   ```
+   Expect a JSON payload similar to `{ "status": "ok", "message": "Simulation bridge online" }` as defined in
+   `python-sim/web_bridge/server.py`.
+
+## 3. Configure and run the Next.js visualizer client
+1. Install dependencies with pnpm:
+   ```bash
+   cd tunnelcave_sandbox_web
+   corepack enable pnpm
+   pnpm install
+   ```
+2. Scaffold `.env.local` with broker endpoints:
+   ```bash
+   ../scripts/setup-env.sh --force
+   ```
+   The generated file defines `NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws` and
+   `NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000` so the browser can reach both services.
+3. Launch the development server:
+   ```bash
+   pnpm dev
+   ```
+4. Open `http://localhost:3000` in a browser. The client bootstrap (`app/components/ClientBootstrap.tsx`) will surface an
+   inline warning if either environment variable is missing.
+
+## 4. Optional smoke-test screenshot
+Once the UI is reachable, the Playwright script at `tunnelcave_sandbox_web/test/smoke/visual-smoke.spec.ts` can capture a
+baseline screenshot for visual regression tracking:
+```bash
+cd tunnelcave_sandbox_web
+npx playwright install --with-deps
+pnpm exec playwright test test/smoke/visual-smoke.spec.ts
+```
+Set `VISUALIZER_BASE_URL` and `VISUALIZER_SMOKE_OUTPUT` to override the navigation target or screenshot path if needed.
+
+## 5. Test expectations before merge
+All automated suites must be green prior to merging changes:
+- Run the Go unit suite: `cd go-broker && go test ./...`.
+- Execute the Python bridge tests: `cd python-sim && pytest`.
+- From `tunnelcave_sandbox_web`, ensure `pnpm test` passes so the networking mocks, procedural geometry, and UI interaction
+  Vitest suites stay healthy.
+- If the Playwright smoke test is updated, run `pnpm exec playwright test` as part of the review checklist.
+
+Document successful runs (timestamps and commit hash) in your pull request description when promoting changes to the main
+branch.

--- a/tunnelcave_sandbox_web/package.json
+++ b/tunnelcave_sandbox_web/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@types/node": "^24.6.2",

--- a/tunnelcave_sandbox_web/pnpm-lock.yaml
+++ b/tunnelcave_sandbox_web/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^0.168.0
         version: 0.168.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.55.1
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.9.1
@@ -47,7 +50,7 @@ importers:
         version: 24.1.3
       next:
         specifier: ^15.5.4
-        version: 15.5.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 15.5.4(@playwright/test@1.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       pnpm:
         specifier: ^10.18.0
         version: 10.18.0
@@ -454,6 +457,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.52.4':
     resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
     cpu: [arm]
@@ -811,6 +819,11 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1030,6 +1043,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pnpm@10.18.0:
     resolution: {integrity: sha512-6AT4ifHOzEDVctsITuw+SIFzn43sacD/ENLRvv+aTjCTg7ontbdQBZ1/TBSVNbbNDSyx7Trrc5I5pChKaPQM+g==}
@@ -1577,6 +1600,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.4':
     optional: true
 
+  '@playwright/test@1.55.1':
+    dependencies:
+      playwright: 1.55.1
+
   '@rollup/rollup-android-arm-eabi@4.52.4':
     optional: true
 
@@ -1921,6 +1948,9 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2081,7 +2111,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@15.5.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@15.5.4(@playwright/test@1.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 15.5.4
       '@swc/helpers': 0.5.15
@@ -2099,6 +2129,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.4
       '@next/swc-win32-arm64-msvc': 15.5.4
       '@next/swc-win32-x64-msvc': 15.5.4
+      '@playwright/test': 1.55.1
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -2139,6 +2170,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pnpm@10.18.0: {}
 

--- a/tunnelcave_sandbox_web/test/smoke/visual-smoke.spec.ts
+++ b/tunnelcave_sandbox_web/test/smoke/visual-smoke.spec.ts
@@ -1,0 +1,27 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { expect, test } from '@playwright/test'
+
+async function ensureArtifactPath(filePath: string): Promise<void> {
+  //1.- Guarantee the screenshot directory exists before Playwright writes the artifact.
+  await mkdir(dirname(filePath), { recursive: true })
+}
+
+test('captures a default visual snapshot of the client shell', async ({ page }) => {
+  const baseUrl = process.env.VISUALIZER_BASE_URL ?? 'http://localhost:3000'
+  const screenshotPath = process.env.VISUALIZER_SMOKE_OUTPUT ?? 'artifacts/visualizer-smoke.png'
+
+  //1.- Prepare the filesystem target so the screenshot call cannot fail because of a missing folder.
+  await ensureArtifactPath(screenshotPath)
+
+  //2.- Navigate to the running Next.js client and wait for the application shell to become visible.
+  await page.goto(baseUrl, { waitUntil: 'networkidle' })
+  await expect(page.locator('#__next')).toBeVisible()
+
+  //3.- Stabilize the UI by ensuring either the HUD root test id or the primary canvas is visible.
+  const hudOrCanvas = page.locator('[data-testid="hud-root"], canvas').first()
+  await expect(hudOrCanvas).toBeVisible({ timeout: 5000 })
+
+  //4.- Capture a full-page screenshot for downstream visual regression diffing.
+  await page.screenshot({ path: screenshotPath, fullPage: true })
+})

--- a/tunnelcave_sandbox_web/vitest.config.ts
+++ b/tunnelcave_sandbox_web/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     },
   },
   test: {
+    //1.- Target the networking mocks, procedural geometry, and UI interaction suites together with the remaining client tests.
+    include: [
+      'app/**/*.test.ts',
+      'src/**/*.test.ts',
+      'test/**/*.test.ts',
+    ],
     environment: 'jsdom',
     globals: true,
     setupFiles: [],


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs pnpm and runs the web client's Vitest suites covering networking mocks, procedural geometry, and UI interactions
- align the Next.js Vitest configuration and dependencies with the new coverage scope and provide a Playwright smoke-test script for visual screenshots
- author a visualizer operations guide describing how to run the Go broker, Python bridge, and Next.js client together plus pre-merge testing expectations

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e01fceeb688329b3f7f238600128ae