### PR TITLE
Refactor control panel events to avoid three.js build dependency

### DIFF
--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
@@ -7,7 +7,7 @@ import SimulationControlPanel from './SimulationControlPanel'
 import {
   CONTROL_PANEL_EVENT,
   type ControlPanelIntentDetail,
-} from '../../../typescript-client/src/world/vehicleSceneManager'
+} from '../../../typescript-client/src/world/controlPanelEvents'
 
 const originalFetch = global.fetch
 

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   CONTROL_PANEL_EVENT,
   type ControlPanelIntentDetail,
-} from '../../../typescript-client/src/world/vehicleSceneManager'
+} from '../../../typescript-client/src/world/controlPanelEvents'
 
 type CommandName = 'throttle' | 'brake'
 

--- a/tunnelcave_sandbox_web/vitest.config.ts
+++ b/tunnelcave_sandbox_web/vitest.config.ts
@@ -12,8 +12,11 @@ export default defineConfig({
     //1.- Target the networking mocks, procedural geometry, and UI interaction suites together with the remaining client tests.
     include: [
       'app/**/*.test.ts',
+      'app/**/*.test.tsx',
       'src/**/*.test.ts',
+      'src/**/*.test.tsx',
       'test/**/*.test.ts',
+      'test/**/*.test.tsx',
     ],
     environment: 'jsdom',
     globals: true,

--- a/typescript-client/src/world/controlPanelEvents.test.ts
+++ b/typescript-client/src/world/controlPanelEvents.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTROL_PANEL_EVENT, type ControlPanelIntentDetail } from "./controlPanelEvents";
+
+describe("controlPanelEvents", () => {
+  it("exposes a shared DOM contract for control intents", () => {
+    const detail: ControlPanelIntentDetail = { control: "throttle", value: 2, issuedAtMs: 99 };
+    const event = new CustomEvent<ControlPanelIntentDetail>(CONTROL_PANEL_EVENT, { detail });
+    //1.- Assert the exported identifier is reused as the event type string.
+    expect(event.type).toBe(CONTROL_PANEL_EVENT);
+    //2.- Confirm type inference preserves payload fields for downstream listeners.
+    expect(event.detail).toEqual(detail);
+  });
+});

--- a/typescript-client/src/world/controlPanelEvents.ts
+++ b/typescript-client/src/world/controlPanelEvents.ts
@@ -1,0 +1,15 @@
+export const CONTROL_PANEL_EVENT = "simulation-control-intent";
+//1.- Shared DOM event name so HUD and UI components can coordinate control intents.
+
+export type ControlPanelIntent = "throttle" | "brake" | "steer";
+//1.- Enumerate the supported control names to keep event payloads strongly typed.
+
+export interface ControlPanelIntentDetail {
+  control: ControlPanelIntent;
+  value: number;
+  issuedAtMs?: number;
+}
+//1.- Describe the payload fields forwarded with each control intent event.
+
+export type ControlPanelEvent = CustomEvent<ControlPanelIntentDetail>;
+//1.- Alias the strongly typed CustomEvent so listeners can narrow event.detail easily.

--- a/typescript-client/src/world/vehicleSceneManager.test.ts
+++ b/typescript-client/src/world/vehicleSceneManager.test.ts
@@ -2,12 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { InterpolatedState } from "../networking/interpolator";
 import type { VehicleRosterEntry } from "../vehicleRoster";
 import { VehicleGeometryFactory } from "./procedural/vehicleFactory";
-import {
-  CONTROL_PANEL_EVENT,
-  type ControlPanelIntentDetail,
-  VehicleSceneManager,
-  type VehicleStateSource,
-} from "./vehicleSceneManager";
+import { CONTROL_PANEL_EVENT, type ControlPanelIntentDetail } from "./controlPanelEvents";
+import { VehicleSceneManager, type VehicleStateSource } from "./vehicleSceneManager";
 
 class MockStateSource extends EventTarget implements VehicleStateSource {
   private readonly states = new Map<string, InterpolatedState>();

--- a/typescript-client/src/world/vehicleSceneManager.ts
+++ b/typescript-client/src/world/vehicleSceneManager.ts
@@ -11,18 +11,12 @@ import {
   Vector3,
 } from "three";
 import { VehicleGeometryFactory, type VehicleGeometryResult } from "./procedural/vehicleFactory";
-
-export const CONTROL_PANEL_EVENT = "simulation-control-intent";
-
-export type ControlPanelIntent = "throttle" | "brake" | "steer";
-
-export interface ControlPanelIntentDetail {
-  control: ControlPanelIntent;
-  value: number;
-  issuedAtMs?: number;
-}
-
-export type ControlPanelEvent = CustomEvent<ControlPanelIntentDetail>;
+import {
+  CONTROL_PANEL_EVENT,
+  type ControlPanelEvent,
+  type ControlPanelIntent,
+  type ControlPanelIntentDetail,
+} from "./controlPanelEvents";
 
 export interface VehicleStateSource extends EventTarget {
   getEntityState(entityId: string, nowMs?: number): InterpolatedState | undefined;

--- a/typescript-client/vitest.config.ts
+++ b/typescript-client/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   test: {
     //1.- Use the node environment so three.js can run without DOM APIs.
     environment: "node",
-    //2.- Limit discovery to world geometry and scene manager tests to avoid executing legacy harness files.
-    include: ["src/world/procedural/**/*.test.ts", "src/world/vehicleSceneManager.test.ts"],
+    //2.- Discover all world scoped tests so shared event utilities run alongside scene manager coverage.
+    include: ["src/world/**/*.test.ts"],
     //3.- Enable globals for consistency with other TypeScript tests in the project.
     globals: false,
   },


### PR DESCRIPTION
## Summary
- extract the control panel event contract into a standalone module so it no longer forces three.js to load when only the DOM event name is needed
- update the sandbox control panel to consume the new module and extend Vitest discovery to cover TSX-based tests
- add dedicated tests for the event contract and include the new suite in the TypeScript client test runner

## Testing
- npm test (typescript-client)
- npm test -- SimulationControlPanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e03a7bc7948329ba847da026cdb205