### PR TITLE
Proxy simulation bridge traffic through Next.js API

### DIFF
--- a/docs/env_configuration/README.md
+++ b/docs/env_configuration/README.md
@@ -7,10 +7,11 @@ The Drift Pursuit sandbox relies on a small `.env.local` file inside `tunnelcave
 | Key | Purpose | Local sample |
 | --- | --- | --- |
 | `NEXT_PUBLIC_BROKER_URL` | Websocket endpoint for exchanging HUD telemetry with the broker service. | `ws://localhost:43127/ws` |
+| `SIM_BRIDGE_URL` | Server-side override for the simulation bridge origin used by the API proxy. | `http://localhost:8000` |
 | `NEXT_PUBLIC_SIM_BRIDGE_URL` | HTTP origin that exposes the simulation bridge handshake and command endpoints. | `http://localhost:8000` |
 
 > [!TIP]
-> Run `scripts/setup-env.sh` from the repository root to scaffold a `.env.local` file pre-populated with the values above, including inline comments that explain how to adjust them for non-local setups.
+> Run `scripts/setup-env.sh` from the repository root to scaffold a `.env.local` file pre-populated with the values above, including inline comments that explain how to adjust them for non-local setups. When deploying the Next.js frontend separately from the bridge, set `SIM_BRIDGE_URL` on the server to avoid CORS preflight failures.
 
 ## Manual Setup Checklist
 

--- a/tunnelcave_sandbox_web/app/api/sim-bridge/command/route.test.ts
+++ b/tunnelcave_sandbox_web/app/api/sim-bridge/command/route.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { POST } from './route'
+
+const originalEnv = { ...process.env }
+const originalFetch = global.fetch
+
+describe('sim-bridge command route', () => {
+  beforeEach(() => {
+    //1.- Reset the bridge URL configuration and install a fetch mock per scenario.
+    delete process.env.SIM_BRIDGE_URL
+    delete process.env.NEXT_PUBLIC_SIM_BRIDGE_URL
+    global.fetch = vi.fn() as unknown as typeof global.fetch
+  })
+
+  afterEach(() => {
+    //1.- Restore the global environment after each test to prevent cross-test pollution.
+    process.env = { ...originalEnv }
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('rejects commands when no bridge URL has been configured', async () => {
+    const request = new Request('http://localhost/api/sim-bridge/command', {
+      method: 'POST',
+      body: JSON.stringify({ command: 'throttle' }),
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(body.message).toContain('SIM_BRIDGE_URL')
+  })
+
+  it('forwards commands to the configured bridge', async () => {
+    process.env.SIM_BRIDGE_URL = 'http://backend:9000'
+    const upstreamResponse = { status: 'ok', command: { command: 'throttle' } }
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      json: async () => upstreamResponse,
+    })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const request = new Request('http://localhost/api/sim-bridge/command', {
+      method: 'POST',
+      body: JSON.stringify({ command: 'throttle', issuedAtMs: 123 }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(fetchMock).toHaveBeenCalledWith('http://backend:9000/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'throttle', issuedAtMs: 123 }),
+    })
+    expect(response.status).toBe(200)
+    expect(body).toEqual(upstreamResponse)
+  })
+
+  it('reports gateway errors when the upstream request fails', async () => {
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = 'http://localhost:8000'
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error('timeout'))
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const request = new Request('http://localhost/api/sim-bridge/command', {
+      method: 'POST',
+      body: JSON.stringify({ command: 'brake' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(body.message).toContain('Failed to forward command to simulation bridge at http://localhost:8000')
+  })
+})

--- a/tunnelcave_sandbox_web/app/api/sim-bridge/command/route.ts
+++ b/tunnelcave_sandbox_web/app/api/sim-bridge/command/route.ts
@@ -1,0 +1,39 @@
+import { missingBridgeConfigMessage, resolveBridgeBaseUrl } from '../config'
+
+export async function POST(request: Request): Promise<Response> {
+  //1.- Resolve the upstream simulation bridge URL before forwarding the command payload.
+  const baseUrl = resolveBridgeBaseUrl()
+  if (!baseUrl) {
+    const payload = { status: 'error', message: missingBridgeConfigMessage() }
+    //2.- Reject the request when configuration is missing so the caller can update the environment.
+    return new Response(JSON.stringify(payload), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  try {
+    //3.- Forward the command to the bridge while preserving the caller-provided body.
+    const clonedRequest = request.clone()
+    const upstream = await fetch(`${baseUrl}/command`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: await clonedRequest.text(),
+    })
+    const body = await upstream.json()
+    return new Response(JSON.stringify(body), {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    //4.- Surface a gateway error that includes the upstream address for easier troubleshooting.
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    const payload = {
+      status: 'error',
+      message: `Failed to forward command to simulation bridge at ${baseUrl}: ${message}`,
+    }
+    return new Response(JSON.stringify(payload), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/tunnelcave_sandbox_web/app/api/sim-bridge/config.test.ts
+++ b/tunnelcave_sandbox_web/app/api/sim-bridge/config.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { missingBridgeConfigMessage, resolveBridgeBaseUrl } from './config'
+
+describe('resolveBridgeBaseUrl', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    //1.- Clear the bridge configuration variables so each test controls the environment explicitly.
+    delete process.env.SIM_BRIDGE_URL
+    delete process.env.NEXT_PUBLIC_SIM_BRIDGE_URL
+  })
+
+  afterEach(() => {
+    //1.- Restore the environment after each test to avoid polluting unrelated suites.
+    process.env = { ...originalEnv }
+  })
+
+  it('prefers the private SIM_BRIDGE_URL when present', () => {
+    process.env.SIM_BRIDGE_URL = ' http://broker:9000 '
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = 'http://public.example'
+
+    const result = resolveBridgeBaseUrl()
+
+    expect(result).toBe('http://broker:9000')
+  })
+
+  it('falls back to the public Next.js configuration key', () => {
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = ' http://localhost:8000 '
+
+    const result = resolveBridgeBaseUrl()
+
+    expect(result).toBe('http://localhost:8000')
+  })
+
+  it('returns an empty string when neither key is configured', () => {
+    const result = resolveBridgeBaseUrl()
+
+    expect(result).toBe('')
+  })
+})
+
+describe('missingBridgeConfigMessage', () => {
+  it('provides actionable setup guidance', () => {
+    const message = missingBridgeConfigMessage()
+
+    expect(message).toContain('SIM_BRIDGE_URL')
+    expect(message).toContain('NEXT_PUBLIC_SIM_BRIDGE_URL')
+    expect(message).toContain('http://localhost:8000')
+  })
+})

--- a/tunnelcave_sandbox_web/app/api/sim-bridge/config.ts
+++ b/tunnelcave_sandbox_web/app/api/sim-bridge/config.ts
@@ -1,0 +1,25 @@
+const BRIDGE_ENV_KEYS = ['SIM_BRIDGE_URL', 'NEXT_PUBLIC_SIM_BRIDGE_URL'] as const
+
+type BridgeEnvKey = (typeof BRIDGE_ENV_KEYS)[number]
+
+export function resolveBridgeBaseUrl(): string {
+  //1.- Collect candidate values in priority order so private server-side configuration wins over client hints.
+  const values: Array<string | undefined> = BRIDGE_ENV_KEYS.map((key: BridgeEnvKey) => process.env[key])
+  //2.- Return the first non-empty, trimmed URL to preserve compatibility with both Next.js and backend services.
+  for (const candidate of values) {
+    const trimmed = candidate?.trim()
+    if (trimmed) {
+      return trimmed
+    }
+  }
+  //3.- Fall back to an empty string when no environment variable has been configured.
+  return ''
+}
+
+export function missingBridgeConfigMessage(): string {
+  //1.- Provide actionable guidance so operators know which environment variables to set.
+  const template =
+    'Simulation bridge URL not configured. Set SIM_BRIDGE_URL or NEXT_PUBLIC_SIM_BRIDGE_URL (e.g. http://localhost:8000).'
+  //2.- Return the advisory without trailing whitespace to keep logs clean.
+  return template.trim()
+}

--- a/tunnelcave_sandbox_web/app/api/sim-bridge/handshake/route.test.ts
+++ b/tunnelcave_sandbox_web/app/api/sim-bridge/handshake/route.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GET } from './route'
+
+const originalEnv = { ...process.env }
+const originalFetch = global.fetch
+
+describe('sim-bridge handshake route', () => {
+  beforeEach(() => {
+    //1.- Reset environment variables and install a deterministic fetch mock before each test.
+    delete process.env.SIM_BRIDGE_URL
+    delete process.env.NEXT_PUBLIC_SIM_BRIDGE_URL
+    global.fetch = vi.fn() as unknown as typeof global.fetch
+  })
+
+  afterEach(() => {
+    //1.- Restore environment variables and fetch implementation after each test case.
+    process.env = { ...originalEnv }
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('returns a helpful error when the bridge URL is not configured', async () => {
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(body.message).toContain('SIM_BRIDGE_URL')
+  })
+
+  it('proxies the handshake request to the configured bridge', async () => {
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = 'http://localhost:8000'
+    const handshake = { status: 'ok', message: 'Simulation bridge online' }
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      json: async () => handshake,
+    })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/handshake', { cache: 'no-store' })
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ ...handshake, bridgeUrl: 'http://localhost:8000' })
+  })
+
+  it('maps network failures to a gateway error', async () => {
+    process.env.SIM_BRIDGE_URL = 'http://backend:9000'
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(body.message).toContain('Failed to reach simulation bridge at http://backend:9000')
+  })
+})

--- a/tunnelcave_sandbox_web/app/api/sim-bridge/handshake/route.ts
+++ b/tunnelcave_sandbox_web/app/api/sim-bridge/handshake/route.ts
@@ -1,0 +1,38 @@
+import { missingBridgeConfigMessage, resolveBridgeBaseUrl } from '../config'
+
+export async function GET(): Promise<Response> {
+  //1.- Resolve the upstream simulation bridge URL before issuing the proxy request.
+  const baseUrl = resolveBridgeBaseUrl()
+  if (!baseUrl) {
+    const payload = { status: 'error', message: missingBridgeConfigMessage() }
+    //2.- Surface a service unavailable response so clients can present actionable guidance.
+    return new Response(JSON.stringify(payload), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  try {
+    //3.- Forward the handshake to the bridge without caching to reflect the live availability state.
+    const upstream = await fetch(`${baseUrl}/handshake`, { cache: 'no-store' })
+    const body = await upstream.json()
+    const responsePayload = {
+      ...body,
+      bridgeUrl: baseUrl,
+    }
+    return new Response(JSON.stringify(responsePayload), {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    //4.- Map network failures to a gateway error so the UI can inform the operator.
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    const payload = {
+      status: 'error',
+      message: `Failed to reach simulation bridge at ${baseUrl}: ${message}`,
+    }
+    return new Response(JSON.stringify(payload), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.test.tsx
@@ -7,7 +7,7 @@ import SimulationControlPanel from './SimulationControlPanel'
 import {
   CONTROL_PANEL_EVENT,
   type ControlPanelIntentDetail,
-} from '../../../typescript-client/src/world/vehicleSceneManager'
+} from '../../../typescript-client/src/world/controlPanelEvents'
 
 const originalFetch = global.fetch
 
@@ -63,6 +63,7 @@ describe('SimulationControlPanel', () => {
     const statusText = status?.textContent ?? ''
     const errorText = error?.textContent ?? ''
     expect(statusText).toContain('offline')
+    expect(errorText).toContain('SIM_BRIDGE_URL')
     expect(errorText).toContain('NEXT_PUBLIC_SIM_BRIDGE_URL')
     expect(errorText).toContain('http://localhost:8000')
   })
@@ -78,6 +79,36 @@ describe('SimulationControlPanel', () => {
     const status = container.querySelector('[data-testid="bridge-status"]')
     expect(status?.textContent ?? '').toContain('Simulation bridge online')
     expect(fetchMock).toHaveBeenCalledWith('http://localhost:8080/handshake', expect.any(Object))
+  })
+
+  it('surfaces detailed handshake errors from the API proxy', async () => {
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = 'http://localhost:8000'
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ message: 'Simulation bridge URL not configured.' }),
+      })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    await renderPanel(<SimulationControlPanel />)
+    await flushMicrotasks()
+
+    const error = container.querySelector('[data-testid="bridge-error"]')
+    expect(error?.textContent ?? '').toContain('Simulation bridge URL not configured.')
+  })
+
+  it('routes handshake requests through the API proxy when only the environment variable is set', async () => {
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = 'http://localhost:8000'
+    const handshake = { message: 'Simulation bridge online' }
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => handshake })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    await renderPanel(<SimulationControlPanel />)
+    await flushMicrotasks()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/sim-bridge/handshake', expect.objectContaining({ cache: 'no-store' }))
   })
 
   it('sends commands to the bridge', async () => {
@@ -105,6 +136,32 @@ describe('SimulationControlPanel', () => {
       headers: { 'Content-Type': 'application/json' },
       body: expect.stringContaining('throttle'),
     })
+  })
+
+  it('displays detailed command errors from the API proxy', async () => {
+    process.env.NEXT_PUBLIC_SIM_BRIDGE_URL = 'http://localhost:8000'
+    const handshake = { message: 'Simulation bridge online' }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => handshake })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => ({ message: 'Failed to forward command to simulation bridge.' }),
+      })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    await renderPanel(<SimulationControlPanel />)
+    await flushMicrotasks()
+
+    const throttleButton = container.querySelector('button') as HTMLButtonElement
+    await act(async () => {
+      throttleButton.click()
+    })
+    await flushMicrotasks()
+
+    const error = container.querySelector('[data-testid="bridge-error"]')
+    expect(error?.textContent ?? '').toContain('Failed to forward command to simulation bridge.')
   })
 
   it('emits control intents when buttons are pressed', async () => {

--- a/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
+++ b/tunnelcave_sandbox_web/app/components/SimulationControlPanel.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   CONTROL_PANEL_EVENT,
   type ControlPanelIntentDetail,
-} from '../../../typescript-client/src/world/vehicleSceneManager'
+} from '../../../typescript-client/src/world/controlPanelEvents'
 
 type CommandName = 'throttle' | 'brake'
 
@@ -13,14 +13,43 @@ type PanelProps = {
 }
 
 const DEFAULT_STATUS = 'Simulation bridge offline.'
-const CONFIG_HINT = 'Set NEXT_PUBLIC_SIM_BRIDGE_URL (e.g. http://localhost:8000) to enable interactive control.'
+const CONFIG_HINT =
+  'Set SIM_BRIDGE_URL or NEXT_PUBLIC_SIM_BRIDGE_URL (e.g. http://localhost:8000) to enable interactive control.'
 
 export default function SimulationControlPanel({ baseUrl }: PanelProps) {
-  //1.- Resolve the bridge base URL lazily so runtime overrides and props are respected.
-  const resolvedBaseUrl = useMemo(() => {
-    const candidate = baseUrl ?? process.env.NEXT_PUBLIC_SIM_BRIDGE_URL ?? ''
+  //1.- Resolve a direct override so tests and same-origin deployments can bypass the API proxy.
+  const overrideBaseUrl = useMemo(() => {
+    const candidate = baseUrl ?? ''
     return candidate.trim()
   }, [baseUrl])
+  //2.- Capture the environment-provided bridge URL when no explicit override has been supplied.
+  const envBaseUrl = useMemo(() => {
+    if (overrideBaseUrl) {
+      return ''
+    }
+    const candidate = process.env.NEXT_PUBLIC_SIM_BRIDGE_URL ?? ''
+    return candidate.trim()
+  }, [overrideBaseUrl])
+  //3.- Compute the handshake endpoint, favouring the API proxy when only the environment variable is available.
+  const handshakeUrl = useMemo(() => {
+    if (overrideBaseUrl) {
+      return `${overrideBaseUrl}/handshake`
+    }
+    if (envBaseUrl) {
+      return '/api/sim-bridge/handshake'
+    }
+    return ''
+  }, [envBaseUrl, overrideBaseUrl])
+  //4.- Compute the command endpoint, mirroring the handshake URL selection logic.
+  const commandUrl = useMemo(() => {
+    if (overrideBaseUrl) {
+      return `${overrideBaseUrl}/command`
+    }
+    if (envBaseUrl) {
+      return '/api/sim-bridge/command'
+    }
+    return ''
+  }, [envBaseUrl, overrideBaseUrl])
   //2.- Track status and error messages so the UI communicates connection progress.
   const [status, setStatus] = useState(DEFAULT_STATUS)
   const [error, setError] = useState('')
@@ -28,7 +57,7 @@ export default function SimulationControlPanel({ baseUrl }: PanelProps) {
 
   useEffect(() => {
     //1.- Abort early when the bridge URL is not configured to avoid failing network calls.
-    if (!resolvedBaseUrl) {
+    if (!handshakeUrl) {
       setStatus(DEFAULT_STATUS)
       setError(CONFIG_HINT)
       return
@@ -39,12 +68,14 @@ export default function SimulationControlPanel({ baseUrl }: PanelProps) {
     setStatus('Negotiating with simulation bridge…')
     setError('')
     //3.- Attempt to fetch the handshake payload from the bridge server.
-    fetch(`${resolvedBaseUrl}/handshake`, { cache: 'no-store', signal: controller.signal })
+    fetch(handshakeUrl, { cache: 'no-store', signal: controller.signal })
       .then(async (response) => {
+        const payload = await response.json()
         if (!response.ok) {
-          throw new Error(`Handshake failed with status ${response.status}`)
+          const message = typeof payload?.message === 'string' ? payload.message : `Handshake failed with status ${response.status}`
+          throw new Error(message)
         }
-        return response.json()
+        return payload
       })
       .then((payload: { message?: string }) => {
         if (cancelled) {
@@ -65,33 +96,34 @@ export default function SimulationControlPanel({ baseUrl }: PanelProps) {
       cancelled = true
       controller.abort()
     }
-  }, [resolvedBaseUrl])
+  }, [handshakeUrl])
 
   const sendCommand = useCallback(
     async (command: CommandName) => {
       //1.- Prevent command dispatches when the bridge URL has not been configured yet.
-      if (!resolvedBaseUrl) {
+      if (!commandUrl) {
         setError(CONFIG_HINT)
         return
       }
       try {
         setError('')
-        const response = await fetch(`${resolvedBaseUrl}/command`, {
+        const response = await fetch(commandUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ command, issuedAtMs: Date.now() }),
         })
+        const payload = await response.json().catch(() => ({}))
         if (!response.ok) {
-          throw new Error(`Command failed with status ${response.status}`)
+          const message = typeof payload?.message === 'string' ? payload.message : `Command failed with status ${response.status}`
+          throw new Error(message)
         }
-        const payload = await response.json()
         setLastCommand(payload.command?.command ?? command)
       } catch (cause) {
         const message = cause instanceof Error ? cause.message : 'Unknown error'
         setError(`Command error: ${message}`)
       }
     },
-    [resolvedBaseUrl],
+    [commandUrl],
   )
 
   const emitControlIntent = useCallback((command: CommandName) => {

--- a/tunnelcave_sandbox_web/vitest.config.ts
+++ b/tunnelcave_sandbox_web/vitest.config.ts
@@ -12,8 +12,11 @@ export default defineConfig({
     //1.- Target the networking mocks, procedural geometry, and UI interaction suites together with the remaining client tests.
     include: [
       'app/**/*.test.ts',
+      'app/**/*.test.tsx',
       'src/**/*.test.ts',
+      'src/**/*.test.tsx',
       'test/**/*.test.ts',
+      'test/**/*.test.tsx',
     ],
     environment: 'jsdom',
     globals: true,

--- a/typescript-client/src/world/controlPanelEvents.test.ts
+++ b/typescript-client/src/world/controlPanelEvents.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTROL_PANEL_EVENT, type ControlPanelIntentDetail } from "./controlPanelEvents";
+
+describe("controlPanelEvents", () => {
+  it("exposes a shared DOM contract for control intents", () => {
+    const detail: ControlPanelIntentDetail = { control: "throttle", value: 2, issuedAtMs: 99 };
+    const event = new CustomEvent<ControlPanelIntentDetail>(CONTROL_PANEL_EVENT, { detail });
+    //1.- Assert the exported identifier is reused as the event type string.
+    expect(event.type).toBe(CONTROL_PANEL_EVENT);
+    //2.- Confirm type inference preserves payload fields for downstream listeners.
+    expect(event.detail).toEqual(detail);
+  });
+});

--- a/typescript-client/src/world/controlPanelEvents.ts
+++ b/typescript-client/src/world/controlPanelEvents.ts
@@ -1,0 +1,15 @@
+export const CONTROL_PANEL_EVENT = "simulation-control-intent";
+//1.- Shared DOM event name so HUD and UI components can coordinate control intents.
+
+export type ControlPanelIntent = "throttle" | "brake" | "steer";
+//1.- Enumerate the supported control names to keep event payloads strongly typed.
+
+export interface ControlPanelIntentDetail {
+  control: ControlPanelIntent;
+  value: number;
+  issuedAtMs?: number;
+}
+//1.- Describe the payload fields forwarded with each control intent event.
+
+export type ControlPanelEvent = CustomEvent<ControlPanelIntentDetail>;
+//1.- Alias the strongly typed CustomEvent so listeners can narrow event.detail easily.

--- a/typescript-client/src/world/vehicleSceneManager.test.ts
+++ b/typescript-client/src/world/vehicleSceneManager.test.ts
@@ -2,12 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { InterpolatedState } from "../networking/interpolator";
 import type { VehicleRosterEntry } from "../vehicleRoster";
 import { VehicleGeometryFactory } from "./procedural/vehicleFactory";
-import {
-  CONTROL_PANEL_EVENT,
-  type ControlPanelIntentDetail,
-  VehicleSceneManager,
-  type VehicleStateSource,
-} from "./vehicleSceneManager";
+import { CONTROL_PANEL_EVENT, type ControlPanelIntentDetail } from "./controlPanelEvents";
+import { VehicleSceneManager, type VehicleStateSource } from "./vehicleSceneManager";
 
 class MockStateSource extends EventTarget implements VehicleStateSource {
   private readonly states = new Map<string, InterpolatedState>();

--- a/typescript-client/src/world/vehicleSceneManager.ts
+++ b/typescript-client/src/world/vehicleSceneManager.ts
@@ -11,18 +11,12 @@ import {
   Vector3,
 } from "three";
 import { VehicleGeometryFactory, type VehicleGeometryResult } from "./procedural/vehicleFactory";
-
-export const CONTROL_PANEL_EVENT = "simulation-control-intent";
-
-export type ControlPanelIntent = "throttle" | "brake" | "steer";
-
-export interface ControlPanelIntentDetail {
-  control: ControlPanelIntent;
-  value: number;
-  issuedAtMs?: number;
-}
-
-export type ControlPanelEvent = CustomEvent<ControlPanelIntentDetail>;
+import {
+  CONTROL_PANEL_EVENT,
+  type ControlPanelEvent,
+  type ControlPanelIntent,
+  type ControlPanelIntentDetail,
+} from "./controlPanelEvents";
 
 export interface VehicleStateSource extends EventTarget {
   getEntityState(entityId: string, nowMs?: number): InterpolatedState | undefined;

--- a/typescript-client/vitest.config.ts
+++ b/typescript-client/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   test: {
     //1.- Use the node environment so three.js can run without DOM APIs.
     environment: "node",
-    //2.- Limit discovery to world geometry and scene manager tests to avoid executing legacy harness files.
-    include: ["src/world/procedural/**/*.test.ts", "src/world/vehicleSceneManager.test.ts"],
+    //2.- Discover all world scoped tests so shared event utilities run alongside scene manager coverage.
+    include: ["src/world/**/*.test.ts"],
     //3.- Enable globals for consistency with other TypeScript tests in the project.
     globals: false,
   },


### PR DESCRIPTION
## Summary
- add Next.js API routes that proxy handshake and command traffic to the simulation bridge so the frontend no longer hits cross-origin errors
- update the simulation control panel to favor the proxy endpoints, surfacing detailed error feedback and preserving direct overrides for tests
- document the new `SIM_BRIDGE_URL` configuration option and cover the proxy, config helper, and UI changes with focused tests

## Testing
- npm test (tunnelcave_sandbox_web)


------
https://chatgpt.com/codex/tasks/task_e_68e03a7bc7948329ba847da026cdb205