### PR TITLE
Log listener URL on startup

### DIFF
--- a/go-broker/main.go
+++ b/go-broker/main.go
@@ -1811,7 +1811,14 @@ func main() {
 
 	server := &http.Server{Addr: cfg.Address, Handler: handler}
 
-	logger.Info("broker listening", logging.String("address", cfg.Address), logging.Bool("tls", certProvided))
+	//1.- Surface the externally reachable URL so terminal output immediately shows where the broker can be reached.
+	advertisedURL := listenerURL(cfg.Address, certProvided)
+	logger.Info(
+		"broker listening",
+		logging.String("address", cfg.Address),
+		logging.Bool("tls", certProvided),
+		logging.String("url", advertisedURL),
+	)
 
 	if certProvided {
 		if err := server.ListenAndServeTLS(cfg.TLSCertPath, cfg.TLSKeyPath); err != nil {

--- a/go-broker/server_url.go
+++ b/go-broker/server_url.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// listenerURL returns a human-friendly URL for the broker listener address.
+// 1.- Decide whether the broker should advertise an HTTP or HTTPS scheme based on TLS configuration.
+// 2.- Normalise the configured address so the message always shows a reachable host:port pair.
+func listenerURL(address string, tlsEnabled bool) string {
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s", scheme, normaliseHostPort(address))
+}
+
+func normaliseHostPort(address string) string {
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		return "localhost"
+	}
+	host, port, err := net.SplitHostPort(trimmed)
+	if err != nil {
+		if strings.HasPrefix(trimmed, ":") {
+			return "localhost" + trimmed
+		}
+		return trimmed
+	}
+	host = strings.TrimSpace(host)
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/go-broker/server_url_test.go
+++ b/go-broker/server_url_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestListenerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		address string
+		tls     bool
+		want    string
+	}{
+		"default_port_only":    {address: ":43127", want: "http://localhost:43127"},
+		"explicit_localhost":   {address: "localhost:8000", want: "http://localhost:8000"},
+		"explicit_ipv4_any":    {address: "0.0.0.0:9000", want: "http://localhost:9000"},
+		"explicit_ipv4_local":  {address: "127.0.0.1:43127", want: "http://127.0.0.1:43127"},
+		"explicit_ipv6_any":    {address: "[::]:43127", want: "http://localhost:43127"},
+		"explicit_ipv6_custom": {address: "[2001:db8::1]:43127", want: "http://[2001:db8::1]:43127"},
+		"tls_enabled":          {address: ":43127", tls: true, want: "https://localhost:43127"},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := listenerURL(tc.address, tc.tls)
+			if got != tc.want {
+				t.Fatalf("listenerURL(%q, %t) = %q, want %q", tc.address, tc.tls, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormaliseHostPortNoPort(t *testing.T) {
+	t.Parallel()
+
+	got := normaliseHostPort("")
+	if got != "localhost" {
+		t.Fatalf("expected localhost for empty address, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a helper that normalises listener addresses into a human-friendly URL
- include the computed URL in the startup log so the terminal shows where the broker is reachable
- cover the URL helper with table-driven tests for common address combinations

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e047d2902c8329b33e08ed6c805ba5