### PR TITLE
Update vehicle control imports to use client alias

### DIFF
--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { VehicleControlSettings } from './VehicleControlSettings'
-import { getSelectableVehicles } from '../@client/webLoadoutBridge'
+import { getSelectableVehicles } from '@client/webLoadoutBridge'
 
 describe('VehicleControlSettings', () => {
   beforeEach(() => {

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleControlSettings.tsx
@@ -8,7 +8,7 @@ import VehicleGeometryControls, {
 import VehicleLoadoutSelector from './VehicleLoadoutSelector'
 import { usePersistentSetting } from '../../../src/ui/settings/usePersistentSetting'
 import { KeybindingConfiguration } from '../../../src/input/keybindings'
-import { getSelectableVehicles } from '../@client/webLoadoutBridge'
+import { getSelectableVehicles } from '@client/webLoadoutBridge'
 
 interface VehicleLoadoutSelection {
   //1.- Track the selected vehicle identifier so spawns remain deterministic across reloads.

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import { VehicleLoadoutSelector } from './VehicleLoadoutSelector'
-import { getSelectableVehicles } from '../@client/webLoadoutBridge'
+import { getSelectableVehicles } from '@client/webLoadoutBridge'
 
 describe('VehicleLoadoutSelector', () => {
   it('renders vehicle and loadout options from the roster', () => {

--- a/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.tsx
+++ b/tunnelcave_sandbox_web/app/components/vehicleControls/VehicleLoadoutSelector.tsx
@@ -5,7 +5,7 @@ import React, { useMemo } from 'react'
 import {
   getSelectableVehicles,
   type LoadoutOption,
-} from '../@client/webLoadoutBridge'
+} from '@client/webLoadoutBridge'
 
 interface VehicleLoadoutSelectorProps {
   //1.- Provide the currently selected vehicle identifier so the UI stays controlled.


### PR DESCRIPTION
## Summary
- update the vehicle control components and tests to import the web loadout bridge via the shared client alias

## Testing
- npm run build --prefix tunnelcave_sandbox_web *(fails: Module not found: Can't resolve '@client/world/controlPanelEvents')*


------
https://chatgpt.com/codex/tasks/task_e_68e18fe9cec48329abba8212b2ee9892