### PR TITLE
Align web client alias with shared client package

### DIFF
--- a/tunnelcave_sandbox_web/next.config.mjs
+++ b/tunnelcave_sandbox_web/next.config.mjs
@@ -1,6 +1,21 @@
 // tunnelcave_sandbox_web/next.config.mjs
+import path from "path";
+import { fileURLToPath } from "url";
+
+const nextConfigDir = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  webpack: (config) => {
+    //1.- Synchronize the runtime alias with the monorepo client source directory.
+    config.resolve = config.resolve ?? {};
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      "@client": path.resolve(nextConfigDir, "../typescript-client/src"),
+    };
+    return config;
+  },
   experimental: { externalDir: true },
 };
+
 export default nextConfig;

--- a/tunnelcave_sandbox_web/src/hud/scoreboardAggregator.test.ts
+++ b/tunnelcave_sandbox_web/src/hud/scoreboardAggregator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { GameEvent } from '@client/generated/events'
-import { EventStreamClient, MemoryEventStore } from '@cliente/ventStream'
+import { EventStreamClient, MemoryEventStore } from '@client/eventStream'
 import { ScoreboardAggregator } from './scoreboardAggregator'
 
 function createScoreEvent(overrides: Partial<GameEvent> = {}): GameEvent {

--- a/tunnelcave_sandbox_web/test/config/nextConfigAlias.test.ts
+++ b/tunnelcave_sandbox_web/test/config/nextConfigAlias.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('next.config.mjs webpack alias', () => {
+  it('merges the @client alias with existing entries', async () => {
+    //1.- Load the Next.js config to access the webpack hook for alias inspection.
+    const { default: nextConfig } = await import('../../next.config.mjs')
+    const webpack = nextConfig.webpack
+
+    if (!webpack) {
+      throw new Error('Expected webpack configuration hook to be defined')
+    }
+
+    const result = webpack({
+      resolve: {
+        alias: {
+          existing: 'value',
+        },
+      },
+    })
+
+    expect(result.resolve?.alias?.existing).toBe('value')
+    expect(result.resolve?.alias?.['@client']).toBe(
+      path.resolve(process.cwd(), '../typescript-client/src'),
+    )
+  })
+})

--- a/tunnelcave_sandbox_web/tsconfig.json
+++ b/tunnelcave_sandbox_web/tsconfig.json
@@ -1,11 +1,16 @@
 {
   "compilerOptions": {
     "types": ["node", "three"],
-   "baseUrl": ".",
-   "paths": {
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types"
+    ],
+    "baseUrl": ".",
+    "paths": {
       "@web/*": ["src/*"],
-      "@client/*": ["typescript-client/src/*"]
-   },    
+      "@client/*": ["../typescript-client/src/*"],
+      "three": ["types/three/index.d.ts"]
+    },
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/tunnelcave_sandbox_web/types/three/index.d.ts
+++ b/tunnelcave_sandbox_web/types/three/index.d.ts
@@ -1,0 +1,3 @@
+//1.- Re-export the upstream three.js type definitions so external packages resolve cleanly.
+export * from '../../node_modules/@types/three/index';
+export { default } from '../../node_modules/@types/three/index';

--- a/tunnelcave_sandbox_web/vitest.config.ts
+++ b/tunnelcave_sandbox_web/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     alias: {
       //1.- Provide a lightweight stub for three.js so unit tests avoid heavy WebGL dependencies.
       three: path.resolve(__dirname, 'test/mocks/three.ts'),
+      //2.- Mirror the monorepo client alias so Vitest matches Next.js module resolution.
+      '@client': path.resolve(__dirname, '../typescript-client/src'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- point the @client TypeScript and webpack aliases at the shared ../typescript-client/src directory
- add a Vitest alias and regression test to keep the Next.js config alias in sync with the build tooling
- supply local type re-exports so three.js typings remain available when resolving modules from the sibling workspace

## Testing
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1922b27288329b88ecdf458899b95