### PR TITLE
Fix Next client alias resolution for Docker builds

### DIFF
--- a/tunnelcave_sandbox_web/next.config.mjs
+++ b/tunnelcave_sandbox_web/next.config.mjs
@@ -1,8 +1,24 @@
 // tunnelcave_sandbox_web/next.config.mjs
+import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const nextConfigDir = path.dirname(fileURLToPath(import.meta.url));
+
+export const resolveClientSourcePath = (baseDir = nextConfigDir) => {
+  //1.- Locate the shared client source directory whether it lives beside the app or inside the app (Docker copy).
+  const clientSourceCandidates = [
+    { label: "sibling", absolutePath: path.resolve(baseDir, "../typescript-client/src") },
+    { label: "local", absolutePath: path.resolve(baseDir, "typescript-client/src") },
+  ];
+  //2.- Resolve the first existing candidate so Webpack aliases point at the correct filesystem entry in all environments.
+  return (
+    clientSourceCandidates.find(({ absolutePath }) => fs.existsSync(absolutePath))?.absolutePath ??
+    clientSourceCandidates[0].absolutePath
+  );
+};
+
+const resolvedClientSourcePath = resolveClientSourcePath();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -11,7 +27,7 @@ const nextConfig = {
     config.resolve = config.resolve ?? {};
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
-      "@client": path.resolve(nextConfigDir, "../typescript-client/src"),
+      "@client": resolvedClientSourcePath,
     };
     return config;
   },

--- a/tunnelcave_sandbox_web/test/config/nextConfigAlias.test.ts
+++ b/tunnelcave_sandbox_web/test/config/nextConfigAlias.test.ts
@@ -1,10 +1,18 @@
+import fs from 'node:fs'
 import path from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 describe('next.config.mjs webpack alias', () => {
+  afterEach(() => {
+    //1.- Restore spies so each test evaluates the resolver with fresh filesystem semantics.
+    vi.restoreAllMocks()
+    //2.- Reset the module cache so subsequent imports execute the resolver logic again.
+    vi.resetModules()
+  })
+
   it('merges the @client alias with existing entries', async () => {
     //1.- Load the Next.js config to access the webpack hook for alias inspection.
-    const { default: nextConfig } = await import('../../next.config.mjs')
+    const { default: nextConfig, resolveClientSourcePath } = await import('../../next.config.mjs')
     const webpack = nextConfig.webpack
 
     if (!webpack) {
@@ -20,8 +28,29 @@ describe('next.config.mjs webpack alias', () => {
     })
 
     expect(result.resolve?.alias?.existing).toBe('value')
-    expect(result.resolve?.alias?.['@client']).toBe(
-      path.resolve(process.cwd(), '../typescript-client/src'),
-    )
+    expect(result.resolve?.alias?.['@client']).toBe(resolveClientSourcePath())
+  })
+
+  it('falls back to the local copy when the sibling directory is absent', async () => {
+    //1.- Force the resolver to pretend the sibling directory is missing so the local copy can be selected.
+    vi.resetModules()
+
+    const siblingPath = path.resolve(process.cwd(), '../typescript-client/src')
+    const localPath = path.resolve(process.cwd(), 'typescript-client/src')
+    const realExistsSync = fs.existsSync
+    const spy = vi.spyOn(fs, 'existsSync').mockImplementation((candidate) => {
+      if (candidate === siblingPath) {
+        return false
+      }
+      if (candidate === localPath) {
+        return true
+      }
+      return realExistsSync(candidate as fs.PathLike)
+    })
+
+    const { resolveClientSourcePath } = await import('../../next.config.mjs')
+
+    expect(spy).toHaveBeenCalled()
+    expect(resolveClientSourcePath()).toBe(localPath)
   })
 })

--- a/tunnelcave_sandbox_web/tsconfig.json
+++ b/tunnelcave_sandbox_web/tsconfig.json
@@ -8,7 +8,10 @@
     "baseUrl": ".",
     "paths": {
       "@web/*": ["src/*"],
-      "@client/*": ["../typescript-client/src/*"],
+      "@client/*": [
+        "../typescript-client/src/*",
+        "./typescript-client/src/*"
+      ],
       "three": ["types/three/index.d.ts"]
     },
     "target": "ES2022",


### PR DESCRIPTION
## Summary
- add a filesystem-aware resolver for the shared @client alias and reuse it in the webpack config
- extend the TypeScript path mapping so both monorepo and Docker layouts resolve the client package
- expand the Next.js config tests to verify alias merging and fallback behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1c6c5c76483299c9b37d89a965de4