### PR TITLE
chore: enable standalone Next.js output for web client

### DIFF
--- a/tunnelcave_sandbox_web/next.config.mjs
+++ b/tunnelcave_sandbox_web/next.config.mjs
@@ -31,6 +31,8 @@ const nextConfig = {
     };
     return config;
   },
+  //2.- Enable the standalone build output so Docker images can copy the prebuilt server bundle directly.
+  output: "standalone",
   experimental: { externalDir: true },
 };
 


### PR DESCRIPTION
## Summary
- enable Next.js standalone build output for the web client configuration so Docker images can copy the prebuilt bundle

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1c9723034832994ed0a1d95a16bbf