### PR TITLE
Fix web client Dockerfile for Next standalone builds

### DIFF
--- a/tunnelcave_sandbox_web/Dockerfile
+++ b/tunnelcave_sandbox_web/Dockerfile
@@ -34,6 +34,8 @@ COPY tunnelcave_sandbox_web/ .
 
 # bring in the sibling library *inside* /app so TS can resolve deps via /app/node_modules
 COPY typescript-client ./typescript-client
+# //1.- Ensure the public directory exists so later COPY commands succeed even when the project has no public assets yet.
+RUN mkdir -p public
 RUN npm run build
 
 # -------- run (standalone) --------
@@ -48,6 +50,27 @@ RUN apk add --no-cache libc6-compat
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
+
+# //1.- Normalise the standalone output so the container can boot regardless of whether Next.js nests the server entrypoint inside a project folder (common in monorepos).
+# //2.- Connect the standalone server back to the shared static and public assets so runtime lookups resolve correctly.
+RUN set -eux; \
+    if [ ! -f server.js ]; then \
+      entry_path="$(find . -maxdepth 3 -path '*/server.js' -print -quit)"; \
+      if [ -z "$entry_path" ]; then \
+        echo "Failed to locate the Next.js standalone server entrypoint" >&2; \
+        exit 1; \
+      fi; \
+      ln -sf "$entry_path" server.js; \
+      entry_dir="$(dirname "$entry_path")"; \
+      if [ -d .next/static ]; then \
+        mkdir -p "$entry_dir/.next"; \
+        rm -rf "$entry_dir/.next/static"; \
+        ln -s /app/.next/static "$entry_dir/.next/static"; \
+      fi; \
+      if [ -d public ] && [ ! -e "$entry_dir/public" ]; then \
+        ln -s /app/public "$entry_dir/public"; \
+      fi; \
+    fi
 
 USER node
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- ensure the web-client Docker build always has a public directory available
- normalize the Next.js standalone output so the runtime finds the server entry and static assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1cb6028688329a1a6ed3846c2f79a