### PR TITLE
Default control panel to proxy fallback

### DIFF
--- a/docs/env_configuration/README.md
+++ b/docs/env_configuration/README.md
@@ -8,10 +8,13 @@ The Drift Pursuit sandbox relies on a small `.env.local` file inside `tunnelcave
 | --- | --- | --- |
 | `NEXT_PUBLIC_BROKER_URL` | Websocket endpoint for exchanging HUD telemetry with the broker service. | `ws://localhost:43127/ws` |
 | `SIM_BRIDGE_URL` | Server-side override for the simulation bridge origin used by the API proxy. | `http://localhost:8000` |
-| `NEXT_PUBLIC_SIM_BRIDGE_URL` | HTTP origin that exposes the simulation bridge handshake and command endpoints. | `http://localhost:8000` |
+| `NEXT_PUBLIC_SIM_BRIDGE_URL` | Optional browser-visible origin for bypassing the proxy during cross-origin development. | `http://localhost:8000` |
 
 > [!TIP]
 > Run `scripts/setup-env.sh` from the repository root to scaffold a `.env.local` file pre-populated with the values above, including inline comments that explain how to adjust them for non-local setups. When deploying the Next.js frontend separately from the bridge, set `SIM_BRIDGE_URL` on the server to avoid CORS preflight failures.
+
+> [!IMPORTANT]
+> The simulation control panel automatically falls back to `/api/sim-bridge/*` when no direct base URL override is supplied. With that proxy in place, configuring `SIM_BRIDGE_URL` on the server is enough to reach the bridge; only add `NEXT_PUBLIC_SIM_BRIDGE_URL` when the browser must talk to the bridge origin directly.
 
 > [!NOTE]
 > When the Next.js frontend runs inside Docker, `localhost` resolves to the container itself. Point `SIM_BRIDGE_URL` (and `NEXT_PUBLIC_SIM_BRIDGE_URL` when needed) at `http://host.docker.internal:8000` so the proxy can reach a bridge running on your host machine.


### PR DESCRIPTION
## Summary
- default the SimulationControlPanel handshake and command endpoints to the `/api/sim-bridge` proxy when no explicit base URL is supplied
- handle the proxy's missing-configuration response by restoring the friendly setup hint instead of surfacing a fetch error
- extend the component tests and environment docs to cover SIM_BRIDGE_URL-only configurations and the new fallback behaviour

## Testing
- npm run test -- SimulationControlPanel

------
https://chatgpt.com/codex/tasks/task_e_68e1dcbed45c8329891e79d004a8fb98