### PR TITLE
Configure bridge URL for web client container

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ Runtime behaviour is configuration‑driven. Environment variable defaults and o
    docker compose build
    docker compose up
    ```
-   - Web: **http://localhost:3000**
-   - Broker: **localhost:43127**
-   - Simulation bridge: **http://localhost:8000/handshake**
-   - Stop with `docker compose down`.
+- Web: **http://localhost:3000**
+- Broker: **localhost:43127**
+- Simulation bridge: **http://localhost:8000/handshake**
+- The web client container exports `SIM_BRIDGE_URL=http://bot-runner:8000`, so the proxy can reach the bundled Python bridge without additional configuration.
+- Stop with `docker compose down`.
 
 7. **(Optional) Build container images individually**
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       NODE_ENV: production
       # IMPORTANT: this is read by the browser, not the container
       NEXT_PUBLIC_BROKER_URL: ws://host.docker.internal:43127/ws
+      # Web client proxy reaches the bundled Python bridge via the Compose network.
+      SIM_BRIDGE_URL: http://bot-runner:8000
     ports:
       - "3000:3000"
     networks:

--- a/docs/env_configuration/README.md
+++ b/docs/env_configuration/README.md
@@ -17,7 +17,7 @@ The Drift Pursuit sandbox relies on a small `.env.local` file inside `tunnelcave
 > The simulation control panel automatically falls back to `/api/sim-bridge/*` when no direct base URL override is supplied. With that proxy in place, configuring `SIM_BRIDGE_URL` on the server is enough to reach the bridge; only add `NEXT_PUBLIC_SIM_BRIDGE_URL` when the browser must talk to the bridge origin directly.
 
 > [!NOTE]
-> When the Next.js frontend runs inside Docker, `localhost` resolves to the container itself. Point `SIM_BRIDGE_URL` (and `NEXT_PUBLIC_SIM_BRIDGE_URL` when needed) at `http://host.docker.internal:8000` so the proxy can reach a bridge running on your host machine.
+> When the Next.js frontend runs inside Docker, `localhost` resolves to the container itself. Point `SIM_BRIDGE_URL` (and `NEXT_PUBLIC_SIM_BRIDGE_URL` when needed) at `http://host.docker.internal:8000` so the proxy can reach a bridge running on your host machine. The provided `docker-compose.yml` sets `SIM_BRIDGE_URL=http://bot-runner:8000` so the web client reaches the bundled Python bridge by default.
 
 ## Manual Setup Checklist
 

--- a/docs/visualizer_ops/README.md
+++ b/docs/visualizer_ops/README.md
@@ -63,8 +63,9 @@ section in order to ensure the three services share credentials and network bind
    ```bash
    ../scripts/setup-env.sh --force
    ```
-   The generated file defines `NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws` and
-   `NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000` so the browser can reach both services.
+   The generated file defines `NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws`,
+   `SIM_BRIDGE_URL=http://localhost:8000`, and
+   `NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000` so both the proxy and the browser can reach the bridge.
 3. Launch the development server:
    ```bash
    pnpm dev

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -39,6 +39,9 @@ cat > "${TARGET_FILE}" <<'ENV_TEMPLATE'
 # Websocket endpoint served by the broker (default docker-compose port 43127).
 NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws
 
+# Server-side origin for the simulation bridge API proxy (default local bridge port 8000).
+SIM_BRIDGE_URL=http://localhost:8000
+
 # HTTP origin for the simulation bridge API (default local bridge port 8000).
 NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000
 ENV_TEMPLATE

--- a/tunnelcave_sandbox_web/app/setup-env.test.ts
+++ b/tunnelcave_sandbox_web/app/setup-env.test.ts
@@ -54,6 +54,7 @@ describe('setup-env.sh', () => {
     //1.- Verify the onboarding comments and sample values are written to disk.
     expect(scaffolded).toContain('Drift Pursuit sandbox environment configuration.')
     expect(scaffolded).toContain('NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws')
+    expect(scaffolded).toContain('SIM_BRIDGE_URL=http://localhost:8000')
     expect(scaffolded).toContain('NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000')
   })
 })


### PR DESCRIPTION
## Summary
- add the simulation bridge URL to the web-client service so the proxy can reach bot-runner inside Docker Compose
- scaffold SIM_BRIDGE_URL alongside the other defaults and document the container behaviour for local onboarding

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e1e591953c8329968899d3aebe1bdb