### PR TITLE
Add lobby session launcher with vehicle presets

### DIFF
--- a/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SessionLaunchPanel from './SessionLaunchPanel'
+
+describe('SessionLaunchPanel', () => {
+  const originalClipboard = navigator.clipboard
+
+  beforeEach(() => {
+    //1.- Reset spies and stub the clipboard API so copy interactions can be asserted.
+    vi.restoreAllMocks()
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  afterEach(() => {
+    //1.- Ensure mounted trees are removed and globals restored after each scenario.
+    cleanup()
+    Object.assign(navigator, { clipboard: originalClipboard })
+  })
+
+  it('propagates pilot and vehicle changes then triggers the start callback', () => {
+    const onPlayerNameChange = vi.fn()
+    const onVehicleIdChange = vi.fn()
+    const onStart = vi.fn()
+
+    render(
+      <SessionLaunchPanel
+        playerName=""
+        vehicleId="arrowhead"
+        onPlayerNameChange={onPlayerNameChange}
+        onVehicleIdChange={onVehicleIdChange}
+        onStart={onStart}
+        shareUrl="http://localhost:3000/?vehicle=arrowhead"
+      />,
+    )
+
+    const nameInput = screen.getByTestId('pilot-name-input') as HTMLInputElement
+    const vehicleSelect = screen.getByTestId('vehicle-select') as HTMLSelectElement
+    const startButton = screen.getByTestId('start-session-button') as HTMLButtonElement
+
+    fireEvent.change(nameInput, { target: { value: 'Nova Seeker' } })
+    fireEvent.change(vehicleSelect, { target: { value: 'aurora' } })
+    fireEvent.click(startButton)
+
+    expect(onPlayerNameChange).toHaveBeenCalledWith('Nova Seeker')
+    expect(onVehicleIdChange).toHaveBeenCalledWith('aurora')
+    expect(onStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies the share URL to the clipboard and surfaces confirmation feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    render(
+      <SessionLaunchPanel
+        playerName="Nova"
+        vehicleId="aurora"
+        onPlayerNameChange={() => {}}
+        onVehicleIdChange={() => {}}
+        onStart={() => {}}
+        shareUrl="http://localhost:3000/?pilot=Nova&vehicle=aurora"
+      />,
+    )
+
+    const copyButton = screen.getByTestId('copy-share-url') as HTMLButtonElement
+
+    fireEvent.click(copyButton)
+
+    expect(writeText).toHaveBeenCalledWith('http://localhost:3000/?pilot=Nova&vehicle=aurora')
+    const feedback = await screen.findByTestId('copy-feedback')
+    expect(feedback.textContent ?? '').toContain('copied')
+  })
+
+  it('warns when attempting to copy without a configured share URL', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    render(
+      <SessionLaunchPanel
+        playerName=""
+        vehicleId="arrowhead"
+        onPlayerNameChange={() => {}}
+        onVehicleIdChange={() => {}}
+        onStart={() => {}}
+      />,
+    )
+
+    const copyButton = screen.getByTestId('copy-share-url') as HTMLButtonElement
+
+    fireEvent.click(copyButton)
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    const feedback = screen.getByTestId('copy-feedback')
+    expect(feedback.textContent ?? '').toContain('unavailable')
+  })
+})

--- a/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.tsx
+++ b/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+import type { VehiclePresetName } from '../../src/world/procedural/vehicles'
+
+interface SessionLaunchPanelProps {
+  //1.- Current pilot handle supplied by the hosting bootstrap component.
+  playerName: string
+  //2.- Currently selected vehicle preset identifier.
+  vehicleId: VehiclePresetName
+  //3.- Callback invoked when the pilot updates their chosen handle.
+  onPlayerNameChange: (name: string) => void
+  //4.- Callback invoked when the pilot selects a different vehicle preset.
+  onVehicleIdChange: (vehicle: VehiclePresetName) => void
+  //5.- Callback fired when the pilot confirms they are ready to enter the session.
+  onStart: () => void
+  //6.- Shareable session URL generated from the current lobby configuration.
+  shareUrl?: string
+}
+
+const VEHICLE_LABELS: Record<VehiclePresetName, string> = {
+  //1.- Provide approachable names for each preset so the lobby feels inviting.
+  arrowhead: 'Arrowhead Interceptor',
+  aurora: 'Aurora Glider',
+  duskfall: 'Duskfall Raider',
+  steelwing: 'Steelwing Vanguard',
+}
+
+export default function SessionLaunchPanel({
+  playerName,
+  vehicleId,
+  onPlayerNameChange,
+  onVehicleIdChange,
+  onStart,
+  shareUrl,
+}: SessionLaunchPanelProps) {
+  //1.- Track whether the share link has been copied so feedback can be surfaced inline.
+  const [copyFeedback, setCopyFeedback] = useState('')
+
+  useEffect(() => {
+    //1.- Reset the copy feedback whenever the share URL changes to avoid stale hints.
+    setCopyFeedback('')
+  }, [shareUrl])
+
+  const handleCopyShareUrl = useCallback(async () => {
+    //1.- Abort if the share link is unavailable or empty.
+    if (!shareUrl) {
+      setCopyFeedback('Share link unavailable. Configure the lobby first.')
+      return
+    }
+    try {
+      if (navigator.clipboard?.writeText) {
+        //2.- Prefer the asynchronous clipboard API when supported by the browser.
+        await navigator.clipboard.writeText(shareUrl)
+      } else {
+        //3.- Fallback to a temporary textarea strategy for legacy environments.
+        const textarea = document.createElement('textarea')
+        textarea.value = shareUrl
+        textarea.setAttribute('readonly', 'true')
+        textarea.style.position = 'absolute'
+        textarea.style.left = '-9999px'
+        document.body.appendChild(textarea)
+        textarea.select()
+        document.execCommand('copy')
+        textarea.remove()
+      }
+      setCopyFeedback('Share link copied to clipboard!')
+    } catch (error) {
+      console.warn('Failed to copy share link', error)
+      setCopyFeedback('Copy failed. Select and copy the link manually.')
+    }
+  }, [shareUrl])
+
+  const shareLinkValue = useMemo(() => shareUrl ?? '', [shareUrl])
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      //1.- Prevent the browser from performing a full page reload.
+      event.preventDefault()
+      onStart()
+    },
+    [onStart],
+  )
+
+  return (
+    <section aria-label="Session lobby">
+      <h2>Join the Cave Run</h2>
+      <p>
+        Configure your pilot handle and preferred craft, then share the invite link so friends can dive into the
+        cavern with you.
+      </p>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="pilot-name">Pilot Handle</label>
+          <input
+            id="pilot-name"
+            name="pilot"
+            type="text"
+            value={playerName}
+            onChange={(event) => onPlayerNameChange(event.target.value)}
+            placeholder="e.g. Aurora Rider"
+            data-testid="pilot-name-input"
+          />
+        </div>
+        <div>
+          <label htmlFor="vehicle-select">Vehicle</label>
+          <select
+            id="vehicle-select"
+            name="vehicle"
+            value={vehicleId}
+            onChange={(event) => onVehicleIdChange(event.target.value as VehiclePresetName)}
+            data-testid="vehicle-select"
+          >
+            {Object.entries(VEHICLE_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="share-url">Session Share Link</label>
+          <input
+            id="share-url"
+            name="share-url"
+            type="url"
+            value={shareLinkValue}
+            readOnly
+            data-testid="share-url"
+          />
+          <button type="button" onClick={handleCopyShareUrl} data-testid="copy-share-url">
+            Copy Link
+          </button>
+          {copyFeedback ? <p data-testid="copy-feedback">{copyFeedback}</p> : null}
+        </div>
+        <div>
+          <button type="submit" data-testid="start-session-button">
+            Start Session
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/tunnelcave_sandbox_web/src/runtime/clientShell.ts
+++ b/tunnelcave_sandbox_web/src/runtime/clientShell.ts
@@ -2,6 +2,7 @@ import { HudController } from "../hud/controller"
 import type { EventStreamClient } from "@client/eventStream"
 import type { ConnectionStatus } from "../networking/WebSocketClient"
 import { createSandboxHudSession } from "./sandboxSession"
+import type { VehiclePresetName } from "../world/procedural/vehicles"
 
 export interface HudSession {
   //1.- Connected world session exposing telemetry getters for HUD metrics.
@@ -22,6 +23,8 @@ export interface ClientShellOptions {
   brokerUrl?: string
   //3.- Asynchronous world session factory invoked once DOM anchors are ready.
   createWorldSession?: () => Promise<HudSession>
+  //4.- Lobby provided pilot and vehicle selections used when establishing sandbox sessions.
+  playerProfile?: { pilotName?: string; vehicleId?: VehiclePresetName }
 }
 
 class PassiveHudClient extends EventTarget {
@@ -113,6 +116,8 @@ async function instantiateControllers(doc: Document, options: ClientShellOptions
       createSandboxHudSession({
         canvas: renderer.getCanvas(),
         brokerUrl: options.brokerUrl,
+        pilotName: options.playerProfile?.pilotName,
+        vehicleId: options.playerProfile?.vehicleId,
       }))
 
   if (sessionFactory) {

--- a/tunnelcave_sandbox_web/src/runtime/sandboxSession.test.ts
+++ b/tunnelcave_sandbox_web/src/runtime/sandboxSession.test.ts
@@ -7,6 +7,7 @@ const buildVehicle = vi.fn(() => ({
 
 vi.mock('../world/procedural/vehicles', () => ({
   buildVehicle,
+  VEHICLE_PRESETS: { arrowhead: {}, aurora: {}, duskfall: {}, steelwing: {} },
 }))
 
 const rendererState: { renderers: any[] } = { renderers: [] }
@@ -146,14 +147,22 @@ describe('sandboxSession', () => {
     }))
 
     const session = await createSandboxHudSession(
-      { canvas, brokerUrl: 'ws://localhost:43127/ws', requestAnimationFrame, cancelAnimationFrame },
+      {
+        //1.- Provide the sandbox options with a broker URL, lobby-selected pilot handle, and vehicle preset.
+        canvas,
+        brokerUrl: 'ws://localhost:43127/ws',
+        requestAnimationFrame,
+        cancelAnimationFrame,
+        pilotName: 'Ace Pilot',
+        vehicleId: 'aurora',
+      },
       { createWorldSession },
     )
 
     expect(createWorldSession).toHaveBeenCalledTimes(1)
     const dial = createWorldSession.mock.calls[0]?.[0]?.dial
     expect(dial.url).toBe('ws://localhost:43127/ws')
-    expect(dial.auth.subject).toBe('sandbox-player')
+    expect(dial.auth.subject).toBe('ace-pilot')
     expect(connect).toHaveBeenCalledTimes(1)
     expect(session.client).toBe(client)
 
@@ -163,14 +172,31 @@ describe('sandboxSession', () => {
     expect(dispose).toHaveBeenCalledTimes(1)
   })
 
+  it('falls back to the default vehicle preset when an unknown selection is provided', async () => {
+    const { createSandboxHudSession } = await import('./sandboxSession')
+    const canvas = document.createElement('canvas')
+    const requestAnimationFrame = vi.fn(() => 1)
+    const cancelAnimationFrame = vi.fn()
+
+    await createSandboxHudSession({
+      //2.- Pass an invalid preset identifier to exercise the fallback path.
+      canvas,
+      requestAnimationFrame,
+      cancelAnimationFrame,
+      vehicleId: 'unknown' as any,
+    })
+
+    expect(buildVehicle).toHaveBeenCalledWith('arrowhead')
+  })
+
   it('builds dial options with environment overrides', async () => {
     const { buildDialOptions } = await import('./sandboxSession')
     process.env.NEXT_PUBLIC_BROKER_SUBJECT = ' pilot '
     process.env.NEXT_PUBLIC_BROKER_TOKEN = ' token '
     process.env.NEXT_PUBLIC_BROKER_PROTOCOLS = 'proto1, proto2'
 
-    const dial = buildDialOptions('ws://example.test/ws')
-    expect(dial.auth.subject).toBe('pilot')
+    const dial = buildDialOptions('ws://example.test/ws', { subject: ' Skye Runner ' })
+    expect(dial.auth.subject).toBe('skye-runner')
     expect(dial.auth.token).toBe('token')
     expect(dial.protocols).toEqual(['proto1', 'proto2'])
 

--- a/tunnelcave_sandbox_web/src/runtime/sandboxSession.ts
+++ b/tunnelcave_sandbox_web/src/runtime/sandboxSession.ts
@@ -2,7 +2,7 @@ import type { HudSession } from './clientShell'
 import type { ConnectionStatus } from '../networking/WebSocketClient'
 import type { SocketDialOptions } from '../networking/authenticatedSocket'
 import { createWorldSession, type WorldSessionHandle } from '@client/networking/worldSession'
-import { buildVehicle } from '../world/procedural/vehicles'
+import { buildVehicle, VEHICLE_PRESETS, type VehiclePresetName } from '../world/procedural/vehicles'
 import {
   AmbientLight,
   Clock,
@@ -50,6 +50,10 @@ export interface SandboxSessionOptions {
   //4.- Optional frame scheduler overrides so tests can inject fake timers.
   requestAnimationFrame?: (callback: FrameRequestCallback) => number
   cancelAnimationFrame?: (handle: number) => void
+  //5.- Optional pilot handle collected from the lobby for personalised broker subjects.
+  pilotName?: string
+  //6.- Optional vehicle preset identifier chosen from the interactive lobby.
+  vehicleId?: VehiclePresetName
 }
 
 export interface SandboxDependencies {
@@ -69,6 +73,33 @@ interface SandboxWorldHandles {
 
 const DEFAULT_BACKGROUND = 0x050714
 const DEFAULT_SUBJECT = 'sandbox-player'
+const FALLBACK_VEHICLE: VehiclePresetName = 'arrowhead'
+
+function normaliseSubject(candidate: string | undefined): string {
+  //1.- Lowercase and dash-separate the pilot name so broker subjects remain URL safe.
+  const trimmed = candidate?.trim() ?? ''
+  if (!trimmed) {
+    return DEFAULT_SUBJECT
+  }
+  const slug = trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return slug || DEFAULT_SUBJECT
+}
+
+function resolveVehicleSelection(vehicleId: string | undefined): VehiclePresetName {
+  //1.- Fall back to the default preset when the selection is missing or unknown.
+  if (!vehicleId) {
+    return FALLBACK_VEHICLE
+  }
+  const normalised = vehicleId.trim().toLowerCase() as VehiclePresetName
+  if (Object.prototype.hasOwnProperty.call(VEHICLE_PRESETS, normalised)) {
+    return normalised
+  }
+  return FALLBACK_VEHICLE
+}
 
 function resolveWindow(options: SandboxSessionOptions): Window | typeof globalThis {
   //1.- Prefer an explicit override, fall back to the owner document window, then globalThis.
@@ -82,9 +113,10 @@ function resolveWindow(options: SandboxSessionOptions): Window | typeof globalTh
   return globalThis
 }
 
-function resolveAuth(): SocketDialOptions['auth'] {
+function resolveAuth(subjectOverride?: string): SocketDialOptions['auth'] {
   //1.- Normalise optional string environment variables and apply sensible defaults for local play.
-  const subject = (process.env.NEXT_PUBLIC_BROKER_SUBJECT ?? DEFAULT_SUBJECT).trim() || DEFAULT_SUBJECT
+  const subjectCandidate = subjectOverride ?? process.env.NEXT_PUBLIC_BROKER_SUBJECT ?? DEFAULT_SUBJECT
+  const subject = normaliseSubject(subjectCandidate)
   const token = process.env.NEXT_PUBLIC_BROKER_TOKEN?.trim()
   const secret = process.env.NEXT_PUBLIC_BROKER_SECRET?.trim()
   const audience = process.env.NEXT_PUBLIC_BROKER_AUDIENCE?.trim()
@@ -130,6 +162,7 @@ function configureRenderer(
   options: SandboxSessionOptions,
   scheduler: Required<Pick<SandboxSessionOptions, 'requestAnimationFrame' | 'cancelAnimationFrame'>>,
   win: Window | typeof globalThis,
+  vehiclePreset: VehiclePresetName,
 ): SandboxWorldHandles {
   //1.- Create the renderer with anti-aliasing so the craft looks smooth even on large displays.
   const renderer = new WebGLRenderer({ canvas: options.canvas, antialias: true })
@@ -150,7 +183,7 @@ function configureRenderer(
   scene.add(ambient)
   scene.add(directional)
 
-  const vehicle = buildVehicle('arrowhead')
+  const vehicle = buildVehicle(vehiclePreset)
   vehicle.position.set(0, 0, 0)
   scene.add(vehicle)
 
@@ -216,12 +249,12 @@ function disposeWorld(
   handles.renderer.dispose()
 }
 
-export function buildDialOptions(url: string): SocketDialOptions {
+export function buildDialOptions(url: string, overrides?: { subject?: string }): SocketDialOptions {
   //1.- Combine the broker URL with auth and protocol overrides to produce the dial options.
   return {
     url,
     protocols: resolveProtocols(),
-    auth: resolveAuth(),
+    auth: resolveAuth(overrides?.subject),
   }
 }
 
@@ -274,7 +307,8 @@ export async function createSandboxHudSession(
     cancelAnimationFrame: cancelFrame,
   }
 
-  const world = configureRenderer(options, scheduler, win)
+  const vehiclePreset = resolveVehicleSelection(options.vehicleId)
+  const world = configureRenderer(options, scheduler, win, vehiclePreset)
   const passiveClient = new SandboxHudClient()
 
   let session: WorldSessionHandle | null = null
@@ -284,7 +318,9 @@ export async function createSandboxHudSession(
     const factory = dependencies.createWorldSession ?? createWorldSession
     try {
       //2.- Instantiate the world session and establish a live connection when a broker URL is configured.
-      session = factory({ dial: buildDialOptions(options.brokerUrl) })
+      session = factory({
+        dial: buildDialOptions(options.brokerUrl, { subject: options.pilotName }),
+      })
       passiveClient.setStatus('connecting')
       await session.connect()
       connectedClient = session.client

--- a/tunnelcave_sandbox_web/src/world/procedural/vehicles.ts
+++ b/tunnelcave_sandbox_web/src/world/procedural/vehicles.ts
@@ -327,9 +327,63 @@ export function buildArrowhead(): VehicleOptions {
   };
 }
 
+//4.- Expand the preset catalogue with themed variants so the lobby can offer meaningful choices.
 export const VEHICLE_PRESETS = {
   arrowhead: buildArrowhead(),
+  aurora: mergeOptions(buildArrowhead(), {
+    name: "aurora",
+    materials: {
+      hull: new MeshStandardMaterial({ color: 0x65b7ff, metalness: 0.55, roughness: 0.32 }),
+      wing: new MeshStandardMaterial({ color: 0xd4f1ff, metalness: 0.38, roughness: 0.18 }),
+      tail: new MeshStandardMaterial({ color: 0xa2d7ff, metalness: 0.4, roughness: 0.24 }),
+      fx: new MeshStandardMaterial({
+        color: 0x9fffff,
+        metalness: 0.08,
+        roughness: 0.12,
+        transparent: true,
+        opacity: 0.85,
+        emissive: 0x8fffff,
+        emissiveIntensity: 0.7,
+      }),
+    },
+  }),
+  duskfall: mergeOptions(buildArrowhead(), {
+    name: "duskfall",
+    materials: {
+      hull: new MeshStandardMaterial({ color: 0x522b81, metalness: 0.62, roughness: 0.28 }),
+      wing: new MeshStandardMaterial({ color: 0xc7b4ff, metalness: 0.36, roughness: 0.22 }),
+      tail: new MeshStandardMaterial({ color: 0x8e6bff, metalness: 0.5, roughness: 0.26 }),
+      fx: new MeshStandardMaterial({
+        color: 0xffa07a,
+        metalness: 0.12,
+        roughness: 0.14,
+        transparent: true,
+        opacity: 0.82,
+        emissive: 0xff7f50,
+        emissiveIntensity: 0.75,
+      }),
+    },
+  }),
+  steelwing: mergeOptions(buildArrowhead(), {
+    name: "steelwing",
+    materials: {
+      hull: new MeshStandardMaterial({ color: 0x5c646c, metalness: 0.72, roughness: 0.3 }),
+      wing: new MeshStandardMaterial({ color: 0xe5ecf2, metalness: 0.34, roughness: 0.2 }),
+      tail: new MeshStandardMaterial({ color: 0x9ca6af, metalness: 0.58, roughness: 0.22 }),
+      fx: new MeshStandardMaterial({
+        color: 0x9fffff,
+        metalness: 0.16,
+        roughness: 0.1,
+        transparent: true,
+        opacity: 0.78,
+        emissive: 0x9fffff,
+        emissiveIntensity: 0.6,
+      }),
+    },
+  }),
 };
+
+export type VehiclePresetName = keyof typeof VEHICLE_PRESETS;
 
 //4.- Assemble the procedural vehicle, populating userData with spin and chain metadata for animation systems.
 export type VehicleBuildTarget = keyof typeof VEHICLE_PRESETS | VehicleOptions | VehicleBuildPreset;


### PR DESCRIPTION
## Summary
- add a session launch panel to the sandbox home page so pilots can enter a handle, pick a craft, and grab a shareable URL
- thread lobby selections into the client shell and sandbox session to slug broker subjects and spawn the chosen vehicle
- expand the procedural vehicle catalog with themed presets and add coverage for the new lobby flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29a1385748329b11905ef56e0b77e