### PR TITLE
Add gameplay lobby and procedural battle page

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/BattlefieldCanvas.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/BattlefieldCanvas.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+import * as THREE from 'three'
+
+import type { BattlefieldConfig } from './generateBattlefield'
+import { createVehicleController } from './vehicleController'
+
+interface BattlefieldCanvasProps {
+  config: BattlefieldConfig
+  playerName: string
+  vehicleId: string
+  sessionId: string
+}
+
+export default function BattlefieldCanvas({ config, playerName, vehicleId, sessionId }: BattlefieldCanvasProps) {
+  //1.- Allocate a container ref so the WebGL renderer can mount a canvas once the component hydrates.
+  const mountRef = useRef<HTMLDivElement | null>(null)
+  //2.- Cache the welcome banner so the overlay remains stable between renders.
+  const welcomeMessage = useMemo(() => `${playerName || 'Rookie'} piloting ${vehicleId}`, [playerName, vehicleId])
+
+  useEffect(() => {
+    const mount = mountRef.current
+    if (!mount) {
+      return
+    }
+
+    //3.- Create the renderer and attach its canvas to the mount element.
+    const canvas = document.createElement('canvas')
+    canvas.dataset.testid = 'battlefield-canvas-surface'
+    mount.appendChild(canvas)
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
+    renderer.setPixelRatio(window.devicePixelRatio || 1)
+    renderer.setSize(mount.clientWidth || window.innerWidth, mount.clientHeight || window.innerHeight)
+
+    //4.- Assemble the scene graph including sandwich planes, lighting, and a procedural sky gradient.
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(0x080d1a)
+
+    const ambientLight = new THREE.AmbientLight(0xb0c4de, 0.6)
+    const sunLight = new THREE.DirectionalLight(0xfff2cc, 0.9)
+    sunLight.position.set(120, 180, 80)
+    scene.add(ambientLight)
+    scene.add(sunLight)
+
+    const camera = new THREE.PerspectiveCamera(60, (mount.clientWidth || window.innerWidth) / (mount.clientHeight || window.innerHeight), 0.1, 1000)
+    camera.position.set(config.spawnPoint.x, config.spawnPoint.y + 18, config.spawnPoint.z + 32)
+    camera.lookAt(config.spawnPoint)
+
+    const groundGeometry = new THREE.PlaneGeometry(config.fieldSize, config.fieldSize, 64, 64)
+    groundGeometry.rotateX(-Math.PI / 2)
+    const groundVertices = groundGeometry.attributes.position as THREE.BufferAttribute
+    for (let index = 0; index < groundVertices.count; index += 1) {
+      //5.- Apply crater offsets from the procedural features so the battlefield gains readable silhouettes.
+      const vx = groundVertices.getX(index)
+      const vz = groundVertices.getZ(index)
+      let offset = 0
+      for (const feature of config.features) {
+        const distance = Math.hypot(vx - feature.position.x, vz - feature.position.z)
+        if (distance < feature.radius) {
+          offset -= ((feature.radius - distance) / feature.radius) * feature.depth
+        }
+      }
+      groundVertices.setY(index, config.groundY + offset)
+    }
+    groundVertices.needsUpdate = true
+    const groundMaterial = new THREE.MeshStandardMaterial({ color: 0x2e4f30, roughness: 0.8, metalness: 0.1 })
+    const groundMesh = new THREE.Mesh(groundGeometry, groundMaterial)
+    scene.add(groundMesh)
+
+    const ceilingGeometry = groundGeometry.clone()
+    const ceilingVertices = ceilingGeometry.attributes.position as THREE.BufferAttribute
+    for (let index = 0; index < ceilingVertices.count; index += 1) {
+      const originalY = ceilingVertices.getY(index)
+      ceilingVertices.setY(index, config.ceilingY - (originalY - config.groundY))
+    }
+    const ceilingMaterial = new THREE.MeshStandardMaterial({ color: 0x1b1b2f, side: THREE.BackSide, roughness: 0.3, metalness: 0 })
+    const ceilingMesh = new THREE.Mesh(ceilingGeometry, ceilingMaterial)
+    ceilingMesh.rotateY(Math.PI)
+    scene.add(ceilingMesh)
+
+    const vehicleBody = new THREE.Group()
+    const hull = new THREE.Mesh(new THREE.ConeGeometry(2, 6, 12), new THREE.MeshStandardMaterial({ color: 0xff7043, metalness: 0.6, roughness: 0.4 }))
+    hull.rotation.x = Math.PI / 2
+    vehicleBody.add(hull)
+    const thruster = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 1.5, 2, 8), new THREE.MeshStandardMaterial({ color: 0x263238 }))
+    thruster.position.set(0, 0, 2)
+    thruster.rotation.x = Math.PI / 2
+    vehicleBody.add(thruster)
+    vehicleBody.position.copy(config.spawnPoint)
+    scene.add(vehicleBody)
+
+    const controller = createVehicleController({ bounds: config.fieldSize / 2 - 4, groundY: config.groundY, ceilingY: config.ceilingY })
+
+    const cameraTarget = new THREE.Vector3().copy(vehicleBody.position)
+    //6.- Maintain a reusable vector for camera chasing behaviour to avoid per-frame allocations.
+    const desiredCamera = new THREE.Vector3(camera.position.x, camera.position.y, camera.position.z)
+
+    let animationFrame = 0
+    let previousTime = performance.now()
+
+    const animate = () => {
+      animationFrame = requestAnimationFrame(animate)
+      const now = performance.now()
+      const delta = Math.min(0.1, (now - previousTime) / 1000)
+      previousTime = now
+      controller.step(delta, vehicleBody)
+      cameraTarget.copy(vehicleBody.position)
+      desiredCamera.set(cameraTarget.x, cameraTarget.y + 14, cameraTarget.z + 26)
+      camera.position.lerp(desiredCamera, 0.08)
+      camera.lookAt(vehicleBody.position)
+      renderer.render(scene, camera)
+    }
+
+    animate()
+
+    const handleResize = () => {
+      const width = mount.clientWidth || window.innerWidth
+      const height = mount.clientHeight || window.innerHeight
+      renderer.setSize(width, height)
+      camera.aspect = width / height
+      camera.updateProjectionMatrix()
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      cancelAnimationFrame(animationFrame)
+      controller.dispose()
+      window.removeEventListener('resize', handleResize)
+      renderer.dispose()
+      groundGeometry.dispose()
+      groundMaterial.dispose()
+      ceilingGeometry.dispose()
+      ceilingMaterial.dispose()
+      ;(hull.geometry as THREE.BufferGeometry).dispose()
+      ;(hull.material as THREE.Material).dispose()
+      ;(thruster.geometry as THREE.BufferGeometry).dispose()
+      ;(thruster.material as THREE.Material).dispose()
+      mount.removeChild(canvas)
+    }
+  }, [config, playerName, sessionId, vehicleId])
+
+  return (
+    <div className="battlefield-wrapper" data-testid="battlefield-wrapper" ref={mountRef}>
+      <div className="hud-overlay" data-testid="battlefield-hud">
+        <p className="hud-session">Session: {sessionId}</p>
+        <p className="hud-welcome">{welcomeMessage}</p>
+        <p className="hud-tip">Use W/A/S/D to steer your vehicle.</p>
+      </div>
+    </div>
+  )
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/generateBattlefield.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/generateBattlefield.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateBattlefield } from './generateBattlefield'
+
+describe('generateBattlefield', () => {
+  it('produces deterministic layouts for identical seeds', () => {
+    const first = generateBattlefield(1337, 6)
+    const second = generateBattlefield(1337, 6)
+    expect(first.fieldSize).toBe(second.fieldSize)
+    expect(first.groundY).toBe(second.groundY)
+    expect(first.ceilingY).toBe(second.ceilingY)
+    expect(first.spawnPoint.x).toBeCloseTo(second.spawnPoint.x)
+    expect(first.spawnPoint.y).toBeCloseTo(second.spawnPoint.y)
+    expect(first.spawnPoint.z).toBeCloseTo(second.spawnPoint.z)
+    expect(first.features).toHaveLength(second.features.length)
+    first.features.forEach((feature, index) => {
+      const counterpart = second.features[index]
+      expect(feature.position.x).toBeCloseTo(counterpart.position.x)
+      expect(feature.position.y).toBeCloseTo(counterpart.position.y)
+      expect(feature.position.z).toBeCloseTo(counterpart.position.z)
+      expect(feature.radius).toBeCloseTo(counterpart.radius)
+      expect(feature.depth).toBeCloseTo(counterpart.depth)
+    })
+  })
+
+  it('places the spawn point within the battlefield bounds', () => {
+    const config = generateBattlefield(9090, 12)
+    expect(config.spawnPoint.y).toBeGreaterThan(config.groundY)
+    expect(config.spawnPoint.y).toBeLessThan(config.ceilingY)
+    expect(Math.abs(config.spawnPoint.x)).toBeLessThanOrEqual(config.fieldSize * 0.5)
+    expect(Math.abs(config.spawnPoint.z)).toBeLessThanOrEqual(config.fieldSize * 0.5)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/generateBattlefield.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/generateBattlefield.ts
@@ -1,0 +1,69 @@
+import * as THREE from 'three'
+
+export interface BattlefieldFeature {
+  position: THREE.Vector3
+  radius: number
+  depth: number
+}
+
+export interface BattlefieldConfig {
+  seed: number
+  fieldSize: number
+  groundY: number
+  ceilingY: number
+  features: BattlefieldFeature[]
+  spawnPoint: THREE.Vector3
+}
+
+function mulberry32(seed: number) {
+  //1.- Convert the incoming seed into an unsigned integer to align with the mulberry algorithm expectations.
+  let t = seed >>> 0
+  return () => {
+    //2.- Advance the state with a constant increment and scramble the bits to produce uniform pseudo-random floats.
+    t = (t + 0x6d2b79f5) >>> 0
+    let r = Math.imul(t ^ (t >>> 15), t | 1)
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61)
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export function generateBattlefield(seed = Date.now() & 0xffffffff, featureCount = 18): BattlefieldConfig {
+  //1.- Prepare the deterministic random generator so identical seeds reproduce the same battlefield layout.
+  const random = mulberry32(seed)
+  //2.- Establish the spatial constraints for the arena including sandwich-style ceiling and floor planes.
+  const fieldSize = 320
+  const groundY = -20
+  const ceilingY = 45
+  const features: BattlefieldFeature[] = []
+
+  for (let index = 0; index < featureCount; index += 1) {
+    //3.- Produce crater-like features that distort the ground plane for variety in each generated map.
+    const radius = 8 + random() * 20
+    const depth = 2 + random() * 6
+    const offsetX = (random() - 0.5) * (fieldSize - radius * 2)
+    const offsetZ = (random() - 0.5) * (fieldSize - radius * 2)
+    features.push({
+      position: new THREE.Vector3(offsetX, groundY, offsetZ),
+      radius,
+      depth,
+    })
+  }
+
+  const spawnPoint = new THREE.Vector3(
+    //4.- Pick a random spawn location inside the arena so each player starts from a unique vantage point.
+    (random() - 0.5) * (fieldSize * 0.5),
+    groundY + 4,
+    (random() - 0.5) * (fieldSize * 0.5),
+  )
+
+  return {
+    //5.- Expose the configuration so the renderer and tests can reason about the generated battlefield.
+    seed,
+    fieldSize,
+    groundY,
+    ceilingY,
+    features,
+    spawnPoint,
+  }
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/page.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./BattlefieldCanvas', () => ({
+  __esModule: true,
+  default: ({ playerName, vehicleId, sessionId }: { playerName: string; vehicleId: string; sessionId: string }) => (
+    <div data-testid="mock-canvas">
+      {playerName}-{vehicleId}-{sessionId}
+    </div>
+  ),
+}))
+
+describe('GameplayPage', () => {
+  beforeEach(() => {
+    //1.- Reset the DOM between scenarios to avoid leaking rendered components or validation states.
+    document.body.innerHTML = ''
+  })
+
+  it('renders the join call to action by default', async () => {
+    const { default: GameplayPage } = await import('./page')
+    render(<GameplayPage />)
+    expect(screen.getByTestId('join-button').textContent).toContain('Join Battle')
+    expect(screen.queryByTestId('lobby-card')).toBeNull()
+  })
+
+  it('reveals lobby controls after joining', async () => {
+    const { default: GameplayPage } = await import('./page')
+    render(<GameplayPage />)
+    fireEvent.click(screen.getByTestId('join-button'))
+    expect(screen.queryByTestId('lobby-card')).not.toBeNull()
+    expect(screen.getAllByRole('button', { name: /ARROWHEAD|AURORA|DUSKFALL|STEELWING/ })).toHaveLength(4)
+  })
+
+  it('validates that a pilot name is supplied before launching', async () => {
+    const { default: GameplayPage } = await import('./page')
+    render(<GameplayPage />)
+    fireEvent.click(screen.getByTestId('join-button'))
+    fireEvent.click(screen.getByTestId('launch-button'))
+    expect(screen.getByTestId('name-error').textContent).toMatch(/enter a pilot name/i)
+    expect(screen.queryByTestId('battle-stage')).toBeNull()
+  })
+
+  it('mounts the battlefield when launch conditions are satisfied', async () => {
+    const { default: GameplayPage } = await import('./page')
+    render(<GameplayPage />)
+    fireEvent.click(screen.getByTestId('join-button'))
+    const input = screen.getByTestId('pilot-name-field') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Nova' } })
+    fireEvent.click(screen.getByTestId('vehicle-aurora'))
+    fireEvent.click(screen.getByTestId('launch-button'))
+    expect(screen.queryByTestId('battle-stage')).not.toBeNull()
+    expect(screen.getByTestId('mock-canvas').textContent).toContain('Nova-aurora-pilot')
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import React from 'react'
+import { useMemo, useState } from 'react'
+
+import BattlefieldCanvas from './BattlefieldCanvas'
+import { generateBattlefield } from './generateBattlefield'
+import { createPlayerSessionId } from './playerSession'
+
+const VEHICLES = ['arrowhead', 'aurora', 'duskfall', 'steelwing'] as const
+
+export type VehicleOption = (typeof VEHICLES)[number]
+
+export default function GameplayPage() {
+  //1.- Track the progression through the join flow so the interface reveals the correct controls.
+  const [stage, setStage] = useState<'initial' | 'lobby' | 'battle'>('initial')
+  //2.- Capture the player's chosen callsign and vehicle to seed the session.
+  const [playerName, setPlayerName] = useState('')
+  const [vehicleId, setVehicleId] = useState<VehicleOption>('arrowhead')
+  const [nameError, setNameError] = useState('')
+  //3.- Generate the procedural battlefield once so re-renders preserve the map layout.
+  const battlefield = useMemo(() => generateBattlefield(), [])
+  //4.- Allocate a session identifier per tab load to satisfy the unique player requirement.
+  const sessionId = useMemo(() => createPlayerSessionId(), [])
+
+  const handleJoin = () => {
+    //1.- Transition to the lobby state and present selection controls.
+    setStage('lobby')
+    setNameError('')
+  }
+
+  const handleVehicleChoice = (choice: VehicleOption) => {
+    //1.- Commit the selected craft so the battle launch uses the expected preset.
+    setVehicleId(choice)
+  }
+
+  const handleBattle = () => {
+    //1.- Validate the pilot name so the HUD has a meaningful identifier.
+    if (!playerName.trim()) {
+      setNameError('Enter a pilot name before launching into the battle.')
+      return
+    }
+    //2.- Clear any lingering validation messages and push the flow into the active battle stage.
+    setNameError('')
+    setStage('battle')
+  }
+
+  return (
+    <main className="gameplay-layout" data-testid="gameplay-page">
+      {stage === 'initial' && (
+        <section className="gameplay-card" data-testid="join-card">
+          <h1>Gameplay Lobby</h1>
+          <p>Prep your pilot handle and vehicle to enter the procedurally generated battlefield.</p>
+          <button className="primary" data-testid="join-button" onClick={handleJoin} type="button">
+            Join Battle
+          </button>
+        </section>
+      )}
+      {stage === 'lobby' && (
+        <section className="gameplay-card" data-testid="lobby-card">
+          <h2>Configure Your Pilot</h2>
+          <label className="field">
+            <span>Pilot Name</span>
+            <input
+              aria-label="Pilot name"
+              data-testid="pilot-name-field"
+              onChange={(event) => setPlayerName(event.target.value)}
+              placeholder="Callsign"
+              type="text"
+              value={playerName}
+            />
+          </label>
+          {nameError && (
+            <p className="error" data-testid="name-error">
+              {nameError}
+            </p>
+          )}
+          <div className="vehicle-grid" data-testid="vehicle-grid">
+            {VEHICLES.map((vehicle) => (
+              <button
+                className={vehicle === vehicleId ? 'vehicle selected' : 'vehicle'}
+                data-testid={`vehicle-${vehicle}`}
+                key={vehicle}
+                onClick={() => handleVehicleChoice(vehicle)}
+                type="button"
+              >
+                {vehicle.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          <button className="primary" data-testid="launch-button" onClick={handleBattle} type="button">
+            To the battle
+          </button>
+        </section>
+      )}
+      {stage === 'battle' && (
+        <section className="battle-stage" data-testid="battle-stage">
+          <BattlefieldCanvas config={battlefield} playerName={playerName} sessionId={sessionId} vehicleId={vehicleId} />
+        </section>
+      )}
+    </main>
+  )
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/playerSession.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/playerSession.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { createPlayerSessionId } from './playerSession'
+
+describe('createPlayerSessionId', () => {
+  it('prefixes identifiers with pilot', () => {
+    const id = createPlayerSessionId(() => 0.123456, () => 123456)
+    expect(id.startsWith('pilot-')).toBe(true)
+  })
+
+  it('yields unique identifiers for sequential calls', () => {
+    let tick = 1000
+    const values = [0.1, 0.2, 0.3, 0.4]
+    let index = 0
+    const random = () => values[index++ % values.length]
+    const timestamp = () => tick++
+    const ids = new Set<string>()
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      ids.add(createPlayerSessionId(random, timestamp))
+    }
+    expect(ids.size).toBe(4)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/playerSession.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/playerSession.ts
@@ -1,0 +1,12 @@
+export function createPlayerSessionId(
+  random: () => number = Math.random,
+  timestamp: () => number = () => Date.now(),
+): string {
+  //1.- Capture the current time so sessions spawned close together still resolve unique handles.
+  const timeComponent = timestamp().toString(36)
+  //2.- Use two random slices to reduce the probability of collision when multiple tabs open simultaneously.
+  const randomComponent = `${Math.floor(random() * 1e8).toString(36)}${Math.floor(random() * 1e8).toString(36)}`
+  //3.- Compose the stable session identifier that tags the player in broker negotiations and telemetry.
+  return `pilot-${timeComponent}-${randomComponent}`
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
@@ -1,0 +1,43 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createVehicleController } from './vehicleController'
+
+describe('createVehicleController', () => {
+  beforeEach(() => {
+    //1.- Guarantee a neutral keyboard state before each scenario.
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    //1.- Release any listeners added by the controller to avoid side effects between tests.
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 's' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'a' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'd' }))
+  })
+
+  it('accelerates forward when W is pressed', () => {
+    const controller = createVehicleController({ acceleration: 20, maxSpeed: 60, damping: 1 })
+    const craft = new THREE.Object3D()
+    const startZ = craft.position.z
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    controller.step(1, craft)
+    expect(craft.position.z).toBeLessThan(startZ)
+    controller.dispose()
+  })
+
+  it('applies damping to reduce speed when no input is active', () => {
+    const controller = createVehicleController({ acceleration: 30, maxSpeed: 80, damping: 0.5 })
+    const craft = new THREE.Object3D()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    controller.step(0.5, craft)
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'w' }))
+    const speedAfterAcceleration = Math.abs(controller.getSpeed())
+    controller.step(0.5, craft)
+    const speedAfterDamping = Math.abs(controller.getSpeed())
+    expect(speedAfterDamping).toBeLessThan(speedAfterAcceleration)
+    controller.dispose()
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
@@ -1,0 +1,85 @@
+import * as THREE from 'three'
+
+export interface VehicleControllerOptions {
+  acceleration?: number
+  maxSpeed?: number
+  damping?: number
+  turnSpeed?: number
+  bounds?: number
+  groundY?: number
+  ceilingY?: number
+}
+
+export interface VehicleController {
+  step: (delta: number, object: THREE.Object3D) => void
+  dispose: () => void
+  getSpeed: () => number
+}
+
+function normaliseKey(value: string): string {
+  return value.toLowerCase()
+}
+
+export function createVehicleController(options: VehicleControllerOptions = {}): VehicleController {
+  const acceleration = options.acceleration ?? 24
+  const maxSpeed = options.maxSpeed ?? 160
+  const damping = options.damping ?? 0.88
+  const turnSpeed = options.turnSpeed ?? Math.PI
+  const bounds = options.bounds ?? 160
+  const groundY = options.groundY ?? -16
+  const ceilingY = options.ceilingY ?? 40
+
+  const activeKeys = new Set<string>()
+  let speed = 0
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    activeKeys.add(normaliseKey(event.key))
+  }
+
+  const handleKeyUp = (event: KeyboardEvent) => {
+    activeKeys.delete(normaliseKey(event.key))
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+  }
+
+  const step = (delta: number, object: THREE.Object3D) => {
+    //1.- Resolve input intent by comparing opposite key states for forward and rotational controls.
+    const forwardIntent = (activeKeys.has('w') ? 1 : 0) - (activeKeys.has('s') ? 1 : 0)
+    const turnIntent = (activeKeys.has('a') ? 1 : 0) - (activeKeys.has('d') ? 1 : 0)
+
+    //2.- Adjust the craft speed, clamp the magnitude, and apply exponential damping for smoother motion.
+    speed += forwardIntent * acceleration * delta
+    speed = Math.max(-maxSpeed, Math.min(maxSpeed, speed))
+    speed *= damping ** (delta * 60)
+
+    //3.- Rotate the craft and translate along the derived planar heading.
+    object.rotation.y += turnIntent * turnSpeed * delta
+    const headingX = -Math.sin(object.rotation.y)
+    const headingZ = -Math.cos(object.rotation.y)
+    object.position.x += headingX * speed * delta
+    object.position.z += headingZ * speed * delta
+
+    //4.- Limit the craft to the battlefield bounds so players remain inside the generated arena.
+    object.position.x = Math.max(-bounds, Math.min(bounds, object.position.x))
+    object.position.z = Math.max(-bounds, Math.min(bounds, object.position.z))
+    object.position.y = Math.max(groundY + 1, Math.min(ceilingY - 1, object.position.y))
+  }
+
+  const dispose = () => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+    }
+    activeKeys.clear()
+  }
+
+  return {
+    step,
+    dispose,
+    getSpeed: () => speed,
+  }
+}
+

--- a/tunnelcave_sandbox_web/app/globals.css
+++ b/tunnelcave_sandbox_web/app/globals.css
@@ -62,3 +62,150 @@ body {
   letter-spacing: 0.01em;
   pointer-events: none;
 }
+
+.gameplay-layout {
+  /* 1.- Center the gameplay lobby and battle surface with generous breathing room. */
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.gameplay-card {
+  /* 1.- Provide a frosted panel for lobby interactions. */
+  max-width: 420px;
+  width: 100%;
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  box-shadow: 0 25px 60px rgba(8, 15, 32, 0.55);
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.gameplay-card .field {
+  /* 1.- Stack field labels above the inputs for clarity. */
+  display: grid;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.gameplay-card input {
+  /* 1.- Style the pilot name input prominently in the center panel. */
+  font-size: 1.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+}
+
+.vehicle-grid {
+  /* 1.- Present the vehicle choices as an evenly spaced button cluster. */
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.vehicle {
+  /* 1.- Create tactile vehicle buttons that indicate hover and selection states. */
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.8);
+  color: #f1f5f9;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.vehicle:hover {
+  /* 1.- Provide a subtle hover lift for interactivity feedback. */
+  transform: translateY(-2px);
+  background: rgba(30, 41, 59, 0.95);
+}
+
+.vehicle.selected {
+  /* 1.- Highlight the active vehicle selection with a luminous border. */
+  border-color: rgba(99, 102, 241, 0.8);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.35);
+}
+
+.primary {
+  /* 1.- Apply a bold call-to-action style shared by join and launch buttons. */
+  padding: 1rem 1.5rem;
+  border-radius: 9999px;
+  border: none;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  background: linear-gradient(135deg, #6366f1, #22d3ee);
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  /* 1.- Emphasise interactivity with a gentle lift and glow. */
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px rgba(34, 211, 238, 0.35);
+}
+
+.error {
+  /* 1.- Surface validation feedback prominently beneath the pilot input. */
+  color: #f87171;
+  font-weight: 600;
+  margin: 0;
+}
+
+.battle-stage {
+  /* 1.- Allow the WebGL canvas to stretch across the available viewport. */
+  width: 100%;
+  height: 100vh;
+  position: relative;
+}
+
+.battlefield-wrapper {
+  /* 1.- Anchor the renderer and overlay HUD elements. */
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.hud-overlay {
+  /* 1.- Provide a concise HUD overlay for session metadata and controls help. */
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+  display: grid;
+  gap: 0.25rem;
+  max-width: 280px;
+}
+
+.hud-session {
+  /* 1.- Distinguish the session label from other HUD lines. */
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.hud-welcome,
+.hud-tip {
+  /* 1.- Maintain consistent spacing for the supportive HUD text. */
+  margin: 0;
+  font-size: 0.9rem;
+  color: #cbd5f5;
+}


### PR DESCRIPTION
## Summary
- add a `/gameplay` route with a join flow that stages pilot names, vehicle choices, and launches the battle view
- implement a procedural three.js battlefield with sandwich terrain, vehicle controls, and session HUD overlays
- add supporting utilities plus unit tests for battlefield generation, session IDs, controller motion, and the gameplay UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b883dd0083298268ae7281899fde