### PR TITLE
Add arrow key throttle support to gameplay vehicle controls

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/BattlefieldCanvas.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/BattlefieldCanvas.tsx
@@ -146,7 +146,7 @@ export default function BattlefieldCanvas({ config, playerName, vehicleId, sessi
       <div className="hud-overlay" data-testid="battlefield-hud">
         <p className="hud-session">Session: {sessionId}</p>
         <p className="hud-welcome">{welcomeMessage}</p>
-        <p className="hud-tip">Use W/A/S/D to steer your vehicle.</p>
+        <p className="hud-tip">Use W/A/S/D or the arrow keys to steer and manage throttle.</p>
       </div>
     </div>
   )

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
@@ -15,6 +15,10 @@ describe('createVehicleController', () => {
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 's' }))
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'a' }))
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'd' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowDown' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight' }))
   })
 
   it('accelerates forward when W is pressed', () => {
@@ -37,6 +41,25 @@ describe('createVehicleController', () => {
     controller.step(0.5, craft)
     const speedAfterDamping = Math.abs(controller.getSpeed())
     expect(speedAfterDamping).toBeLessThan(speedAfterAcceleration)
+    controller.dispose()
+  })
+
+  it('supports arrow keys for accelerating and braking control', () => {
+    const controller = createVehicleController({ acceleration: 40, maxSpeed: 120, damping: 1 })
+    const craft = new THREE.Object3D()
+    //1.- Engage the throttle using the arrow key to confirm speed builds up as expected.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
+    controller.step(0.25, craft)
+    const speedAfterAccelerating = controller.getSpeed()
+    expect(speedAfterAccelerating).toBeGreaterThan(0)
+
+    //2.- Apply the opposite arrow key so the vehicle can bleed speed without forcing reverse motion immediately.
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+    controller.step(0.25, craft)
+    const speedAfterBraking = controller.getSpeed()
+    expect(speedAfterBraking).toBeLessThan(speedAfterAccelerating)
+
     controller.dispose()
   })
 })

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
@@ -45,10 +45,17 @@ export function createVehicleController(options: VehicleControllerOptions = {}):
     window.addEventListener('keyup', handleKeyUp)
   }
 
+  const forwardKeys = ['w', 'arrowup']
+  const backwardKeys = ['s', 'arrowdown']
+  const leftKeys = ['a', 'arrowleft']
+  const rightKeys = ['d', 'arrowright']
+
   const step = (delta: number, object: THREE.Object3D) => {
-    //1.- Resolve input intent by comparing opposite key states for forward and rotational controls.
-    const forwardIntent = (activeKeys.has('w') ? 1 : 0) - (activeKeys.has('s') ? 1 : 0)
-    const turnIntent = (activeKeys.has('a') ? 1 : 0) - (activeKeys.has('d') ? 1 : 0)
+    //1.- Resolve the forward and turning intents, mirroring both WASD and arrow-key input for accessibility.
+    const forwardIntent = (forwardKeys.some((key) => activeKeys.has(key)) ? 1 : 0) -
+      (backwardKeys.some((key) => activeKeys.has(key)) ? 1 : 0)
+    const turnIntent = (leftKeys.some((key) => activeKeys.has(key)) ? 1 : 0) -
+      (rightKeys.some((key) => activeKeys.has(key)) ? 1 : 0)
 
     //2.- Adjust the craft speed, clamp the magnitude, and apply exponential damping for smoother motion.
     speed += forwardIntent * acceleration * delta


### PR DESCRIPTION
## Summary
- allow the gameplay vehicle controller to respond to arrow key input for throttle and steering
- refresh the battlefield HUD instructions to include the new controls
- cover the new behaviour with unit tests for arrow key acceleration and braking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2c2439e5c8329b6e23dfea6678eeb