### PR TITLE
Add procedural gameplay systems for arcade flight prototype

### DIFF
--- a/tunnelcave_sandbox/src/gameplay/__init__.py
+++ b/tunnelcave_sandbox/src/gameplay/__init__.py
@@ -1,0 +1,5 @@
+"""Gameplay systems for the Drift Pursuit prototype."""
+from .terrain import TerrainSampler, TerrainSample
+from .placeables import PlaceableField, PlaceableChunk, RockInstance, TreeInstance, LakeInstance
+from .flight import VehicleState, FlightInput, ControlMode, FlightParameters
+from .world import GameplayWorld, TelemetryClient

--- a/tunnelcave_sandbox/src/gameplay/collision.py
+++ b/tunnelcave_sandbox/src/gameplay/collision.py
@@ -1,0 +1,235 @@
+"""Collision detection helpers for the gameplay flight model."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from . import vector
+from .placeables import PlaceableChunk, PlaceableField
+from .terrain import TerrainSample, TerrainSampler
+from .vector import Vector3
+
+
+# //1.- Capture collision state for the vehicle capsule sweep.
+@dataclass(frozen=True)
+class CollisionResult:
+    hit: bool
+    contact_point: Vector3
+    contact_normal: Vector3
+    hazard: str
+    kill: bool
+    new_velocity: Vector3
+    penetration_depth: float
+    skid: bool
+    damage: float
+    yaw_kick: float
+
+
+# //2.- Represent the capsule used to approximate the fuselage.
+@dataclass(frozen=True)
+class Capsule:
+    nose: Vector3
+    tail: Vector3
+    radius: float
+
+    def lerp(self, other: "Capsule", t: float) -> "Capsule":
+        return Capsule(
+            nose=vector.lerp(self.nose, other.nose, t),
+            tail=vector.lerp(self.tail, other.tail, t),
+            radius=self.radius * (1 - t) + other.radius * t,
+        )
+
+    @property
+    def midpoint(self) -> Vector3:
+        return vector.scale(vector.add(self.nose, self.tail), 0.5)
+
+
+# //3.- Compute the closest point on a segment for distance checks.
+def _closest_point_on_segment(point: Vector3, a: Vector3, b: Vector3) -> Vector3:
+    ap = vector.subtract(point, a)
+    ab = vector.subtract(b, a)
+    denom = vector.dot(ab, ab)
+    if denom == 0:
+        return a
+    t = max(0.0, min(1.0, vector.dot(ap, ab) / denom))
+    return vector.add(a, vector.scale(ab, t))
+
+
+# //4.- Determine intersection depth between a capsule and a sphere proxy.
+def _capsule_sphere_penetration(capsule: Capsule, center: Vector3, radius: float) -> float:
+    closest = _closest_point_on_segment(center, capsule.nose, capsule.tail)
+    distance = vector.length(vector.subtract(center, closest))
+    return radius + capsule.radius - distance
+
+
+# //5.- Approximate vertical altitude of the capsule above ground.
+def _altitude(sample: TerrainSample, capsule: Capsule) -> float:
+    return capsule.midpoint[1] - sample.ground_height - capsule.radius
+
+
+# //6.- Project a velocity vector against the contact normal applying restitution and friction.
+def _resolve_ground_velocity(velocity: Vector3, normal: Vector3, restitution: float, friction: float) -> Vector3:
+    normal_component = vector.project(velocity, normal)
+    if vector.dot(normal_component, normal) > 0:
+        return velocity
+    tangential = vector.subtract(velocity, normal_component)
+    bounce = vector.scale(normal, -vector.dot(velocity, normal) * max(restitution, 0.0))
+    damp_tangent = vector.scale(tangential, max(0.0, 1.0 - friction))
+    return vector.add(damp_tangent, bounce)
+
+
+# //7.- Collision system coordinating terrain and prop queries.
+class CollisionSystem:
+    def __init__(
+        self,
+        sampler: TerrainSampler,
+        field: PlaceableField,
+        clearance: float = 1.5,
+        max_slope: float = math.radians(60),
+        hazard_speed: float = 60.0,
+    ) -> None:
+        self._sampler = sampler
+        self._field = field
+        self._clearance = float(clearance)
+        self._max_slope = float(max_slope)
+        self._hazard_speed = float(hazard_speed)
+
+    def _chunk_for_point(self, point: Vector3) -> PlaceableChunk:
+        size = self._field.chunk_size
+        chunk_x = int(math.floor(point[0] / size))
+        chunk_z = int(math.floor(point[2] / size))
+        return self._field.chunk(chunk_x, chunk_z)
+
+    def _terrain_contact(self, sample: TerrainSample, capsule: Capsule, velocity: Vector3) -> CollisionResult | None:
+        altitude = _altitude(sample, capsule)
+        if altitude > self._clearance:
+            return None
+        normal = sample.surface_normal
+        skid = sample.slope_radians > self._max_slope
+        new_velocity = _resolve_ground_velocity(velocity, normal, restitution=0.08, friction=0.35)
+        penetration = self._clearance - altitude
+        return CollisionResult(
+            hit=True,
+            contact_point=capsule.midpoint,
+            contact_normal=normal,
+            hazard="ground",
+            kill=False,
+            new_velocity=new_velocity,
+            penetration_depth=penetration,
+            skid=skid,
+            damage=0.1 if skid else 0.0,
+            yaw_kick=0.0,
+        )
+
+    def _ceiling_contact(self, sample: TerrainSample, capsule: Capsule, velocity: Vector3) -> CollisionResult | None:
+        top = max(capsule.nose[1], capsule.tail[1]) + capsule.radius
+        if top + self._clearance < sample.ceiling_height:
+            return None
+        normal = (0.0, -1.0, 0.0)
+        reflected = list(velocity)
+        reflected[1] = -reflected[1] * 0.2
+        return CollisionResult(
+            hit=True,
+            contact_point=(capsule.midpoint[0], sample.ceiling_height, capsule.midpoint[2]),
+            contact_normal=normal,
+            hazard="ceiling",
+            kill=False,
+            new_velocity=(reflected[0], reflected[1], reflected[2]),
+            penetration_depth=top - sample.ceiling_height,
+            skid=False,
+            damage=0.0,
+            yaw_kick=0.0,
+        )
+
+    def _lake_contact(self, sample: TerrainSample, capsule: Capsule, speed: float) -> CollisionResult | None:
+        if not sample.is_water:
+            return None
+        water_depth = capsule.midpoint[1] - sample.water_height
+        if water_depth >= self._clearance:
+            return None
+        kill = speed > 45.0
+        return CollisionResult(
+            hit=True,
+            contact_point=(capsule.midpoint[0], sample.water_height, capsule.midpoint[2]),
+            contact_normal=(0.0, 1.0, 0.0),
+            hazard="water",
+            kill=kill,
+            new_velocity=(0.0, 0.0, 0.0),
+            penetration_depth=self._clearance - water_depth,
+            skid=False,
+            damage=0.5 if not kill else 1.0,
+            yaw_kick=0.0,
+        )
+
+    def _rock_contact(self, capsule: Capsule, chunk: PlaceableChunk, velocity: Vector3, speed: float) -> CollisionResult | None:
+        for rock in chunk.rocks:
+            depth = _capsule_sphere_penetration(capsule, rock.center, rock.radius)
+            if depth <= 0:
+                continue
+            kill = speed >= self._hazard_speed
+            normal = vector.normalize(vector.subtract(capsule.midpoint, rock.center), (0.0, 1.0, 0.0))
+            new_velocity = _resolve_ground_velocity(velocity, normal, restitution=0.05, friction=0.5)
+            return CollisionResult(
+                hit=True,
+                contact_point=rock.center,
+                contact_normal=normal,
+                hazard="rock",
+                kill=kill,
+                new_velocity=new_velocity,
+                penetration_depth=depth,
+                skid=False,
+                damage=0.8 if not kill else 1.0,
+                yaw_kick=0.4,
+            )
+        return None
+
+    def _tree_contact(self, capsule: Capsule, chunk: PlaceableChunk, velocity: Vector3, speed: float) -> CollisionResult | None:
+        for tree in chunk.trees:
+            trunk_radius = max(1.0, tree.crown_radius * 0.2)
+            trunk_top = vector.add(tree.base_center, (0.0, tree.trunk_height, 0.0))
+            closest = _closest_point_on_segment(capsule.midpoint, tree.base_center, trunk_top)
+            distance = vector.length(vector.subtract(capsule.midpoint, closest))
+            if distance > trunk_radius + capsule.radius:
+                continue
+            depth = trunk_radius + capsule.radius - distance
+            kill = speed >= self._hazard_speed * 0.8
+            normal = vector.normalize(vector.subtract(capsule.midpoint, closest), (0.0, 1.0, 0.0))
+            new_velocity = _resolve_ground_velocity(velocity, normal, restitution=0.05, friction=0.4)
+            return CollisionResult(
+                hit=True,
+                contact_point=closest,
+                contact_normal=normal,
+                hazard="tree",
+                kill=kill,
+                new_velocity=new_velocity,
+                penetration_depth=depth,
+                skid=False,
+                damage=0.5 if not kill else 1.0,
+                yaw_kick=0.6,
+            )
+        return None
+
+    def sweep(
+        self,
+        previous: Capsule,
+        current: Capsule,
+        velocity: Vector3,
+        speed: float,
+    ) -> CollisionResult | None:
+        steps = 8
+        for step in range(1, steps + 1):
+            t = step / steps
+            capsule = previous.lerp(current, t)
+            sample = self._sampler.sample(capsule.midpoint[0], capsule.midpoint[2])
+            chunk = self._chunk_for_point(capsule.midpoint)
+            for resolver in (
+                lambda: self._lake_contact(sample, capsule, speed),
+                lambda: self._terrain_contact(sample, capsule, velocity),
+                lambda: self._ceiling_contact(sample, capsule, velocity),
+                lambda: self._rock_contact(capsule, chunk, velocity, speed),
+                lambda: self._tree_contact(capsule, chunk, velocity, speed),
+            ):
+                result = resolver()
+                if result:
+                    return result
+        return None

--- a/tunnelcave_sandbox/src/gameplay/flight.py
+++ b/tunnelcave_sandbox/src/gameplay/flight.py
@@ -1,0 +1,242 @@
+"""Arcade-leaning flight dynamics model for the gameplay prototype."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from . import vector
+from .terrain import TerrainSampler
+from .vector import Vector3
+
+
+# //1.- Describe the selectable control schemes.
+class ControlMode(Enum):
+    ARCADE = auto()
+    DIRECT = auto()
+
+
+# //2.- Bundle tunable parameters for the flight model.
+@dataclass(frozen=True)
+class FlightParameters:
+    mass: float = 3200.0
+    thrust_max: float = 180000.0
+    drag_forward: float = 0.3
+    drag_lateral: float = 0.7
+    drag_vertical: float = 0.8
+    lift_coefficient: float = 320.0
+    induced_drag: float = 0.08
+    control_authority: float = 2.5
+    angular_damping: float = 1.2
+    boost_thrust: float = 90000.0
+    boost_duration: float = 2.0
+    boost_cooldown: float = 5.0
+    nose_radius: float = 2.5
+    body_radius: float = 3.5
+
+
+# //3.- Collect pilot input in a consistent structure.
+@dataclass(frozen=True)
+class FlightInput:
+    mode: ControlMode
+    aim_direction: Vector3 = (0.0, 0.0, 1.0)
+    pitch: float = 0.0
+    roll: float = 0.0
+    yaw: float = 0.0
+    throttle_delta: float = 0.0
+    boost: bool = False
+    airbrake: bool = False
+
+
+# //4.- Maintain orientation using orthonormal basis vectors.
+@dataclass(frozen=True)
+class Orientation:
+    forward: Vector3
+    up: Vector3
+
+    def normalized(self) -> "Orientation":
+        forward = vector.normalize(self.forward, (0.0, 0.0, 1.0))
+        up = vector.normalize(self.up, (0.0, 1.0, 0.0))
+        right = vector.normalize(vector.cross(forward, up), (1.0, 0.0, 0.0))
+        corrected_up = vector.normalize(vector.cross(right, forward), (0.0, 1.0, 0.0))
+        return Orientation(forward=forward, up=corrected_up)
+
+    def right(self) -> Vector3:
+        ortho = self.normalized()
+        return vector.normalize(vector.cross(ortho.forward, ortho.up), (1.0, 0.0, 0.0))
+
+
+# //5.- Persist aircraft state between simulation ticks.
+@dataclass(frozen=True)
+class VehicleState:
+    position: Vector3
+    velocity: Vector3
+    angular_velocity: Vector3
+    orientation: Orientation
+    throttle: float
+    boost_timer: float
+    boost_cooldown: float
+    damage: float
+    altitude_agl: float
+    bank_angle: float
+    stall_level: float
+
+    def capsule_points(self, parameters: FlightParameters) -> tuple[Vector3, Vector3]:
+        orientation = self.orientation.normalized()
+        forward = orientation.forward
+        tail_offset = vector.scale(forward, -7.5)
+        nose_offset = vector.scale(forward, 8.5)
+        tail = vector.add(self.position, tail_offset)
+        nose = vector.add(self.position, nose_offset)
+        return nose, tail
+
+
+# //6.- Utility computing aerodynamic drag per axis.
+def _quadratic_drag(component: float, coefficient: float) -> float:
+    return -math.copysign(component * component * coefficient, component)
+
+
+# //7.- Evaluate aerodynamic forces for the aircraft body.
+def _aerodynamic_forces(state: VehicleState, params: FlightParameters) -> Vector3:
+    orientation = state.orientation.normalized()
+    forward = orientation.forward
+    up = orientation.up
+    right = orientation.right()
+    v_forward = vector.dot(state.velocity, forward)
+    v_up = vector.dot(state.velocity, up)
+    v_right = vector.dot(state.velocity, right)
+    drag_forward = _quadratic_drag(v_forward, params.drag_forward)
+    drag_up = _quadratic_drag(v_up, params.drag_vertical)
+    drag_right = _quadratic_drag(v_right, params.drag_lateral)
+    drag = vector.add(
+        vector.scale(forward, drag_forward),
+        vector.add(vector.scale(up, drag_up), vector.scale(right, drag_right)),
+    )
+    aoa = math.atan2(v_up, abs(v_forward) + 1e-5)
+    lift = params.lift_coefficient * v_forward * v_forward * aoa
+    lift_vector = vector.scale(up, lift)
+    induced_drag = vector.scale(forward, -params.induced_drag * aoa * aoa * v_forward * v_forward)
+    return vector.add(drag, vector.add(lift_vector, induced_drag))
+
+
+# //8.- Apply ground effect modifiers as the vehicle nears the ground.
+def _apply_ground_effect(force: Vector3, altitude: float) -> Vector3:
+    if altitude >= 5.0:
+        return force
+    multiplier = 1.0 + (5.0 - altitude) * 0.08
+    drag_scale = 1.0 + (5.0 - altitude) * 0.05
+    up_component = vector.project(force, (0.0, 1.0, 0.0))
+    tangential = vector.subtract(force, up_component)
+    return vector.add(vector.scale(up_component, multiplier), vector.scale(tangential, drag_scale))
+
+
+# //9.- Update angular velocity given pilot input and control scheme.
+def _update_angular_velocity(state: VehicleState, inputs: FlightInput, params: FlightParameters, dt: float) -> Vector3:
+    orientation = state.orientation.normalized()
+    angular_velocity = vector.scale(state.angular_velocity, max(0.0, 1.0 - params.angular_damping * dt))
+    if inputs.mode is ControlMode.ARCADE:
+        desired = vector.normalize(inputs.aim_direction, orientation.forward)
+        axis = vector.cross(orientation.forward, desired)
+        alignment = vector.dot(orientation.forward, desired)
+        rate = (1.0 - alignment) * params.control_authority * 1.2
+        correction = vector.scale(axis, rate)
+        angular_velocity = vector.lerp(angular_velocity, correction, min(1.0, dt * 4.0))
+    else:
+        right = orientation.right()
+        forward = orientation.forward
+        up = orientation.up
+        airspeed = vector.length(state.velocity)
+        authority_scale = min(1.0, airspeed / 80.0)
+        pitch = vector.scale(right, inputs.pitch * params.control_authority * authority_scale)
+        yaw = vector.scale(up, inputs.yaw * params.control_authority * authority_scale)
+        roll = vector.scale(forward, inputs.roll * params.control_authority)
+        angular_velocity = vector.add(angular_velocity, vector.add(pitch, vector.add(yaw, roll)))
+    return angular_velocity
+
+
+# //10.- Integrate orientation using angular velocity and re-orthonormalize the basis.
+def _integrate_orientation(orientation: Orientation, angular_velocity: Vector3, dt: float) -> Orientation:
+    omega = angular_velocity
+    forward = orientation.forward
+    up = orientation.up
+    delta_forward = vector.cross(omega, forward)
+    delta_up = vector.cross(omega, up)
+    new_forward = vector.add(forward, vector.scale(delta_forward, dt))
+    new_up = vector.add(up, vector.scale(delta_up, dt))
+    return Orientation(forward=new_forward, up=new_up).normalized()
+
+
+# //11.- Compute throttle and boost state transitions.
+def _update_propulsion(state: VehicleState, inputs: FlightInput, params: FlightParameters, dt: float) -> tuple[float, float, float, float]:
+    throttle = min(1.0, max(0.0, state.throttle + inputs.throttle_delta * dt))
+    boost_timer = max(0.0, state.boost_timer - dt)
+    boost_cooldown = max(0.0, state.boost_cooldown - dt)
+    boost_active = False
+    if inputs.boost and boost_timer <= 0.0 and boost_cooldown <= 0.0 and throttle > 0.5:
+        boost_timer = params.boost_duration
+        boost_cooldown = params.boost_cooldown + params.boost_duration
+        boost_active = True
+    elif boost_timer > 0.0:
+        boost_active = True
+    return throttle, boost_timer, boost_cooldown, (params.boost_thrust if boost_active else 0.0)
+
+
+# //12.- Integrate the vehicle state applying aerodynamic forces and collisions externally.
+def integrate_flight(
+    state: VehicleState,
+    inputs: FlightInput,
+    terrain: TerrainSampler,
+    params: FlightParameters,
+    dt: float,
+) -> VehicleState:
+    orientation = state.orientation.normalized()
+    angular_velocity = _update_angular_velocity(state, inputs, params, dt)
+    orientation = _integrate_orientation(orientation, angular_velocity, dt)
+    throttle, boost_timer, boost_cooldown, boost_force = _update_propulsion(state, inputs, params, dt)
+    forward = orientation.forward
+    forces = _aerodynamic_forces(state, params)
+    altitude = terrain.sample(state.position[0], state.position[2]).ground_height
+    agl = state.position[1] - altitude
+    forces = _apply_ground_effect(forces, agl)
+    thrust = vector.scale(forward, params.thrust_max * throttle + boost_force)
+    net_force = vector.add(forces, thrust)
+    acceleration = vector.scale(net_force, 1.0 / params.mass)
+    velocity = vector.add(state.velocity, vector.scale(acceleration, dt))
+    if inputs.airbrake:
+        velocity = vector.scale(velocity, max(0.0, 1.0 - dt * 2.5))
+    position = vector.add(state.position, vector.scale(velocity, dt))
+    speed = vector.length(velocity)
+    stall_level = max(0.0, 1.0 - speed / 60.0)
+    bank_angle = math.atan2(vector.dot(orientation.right(), (0.0, 1.0, 0.0)), vector.dot(orientation.up, (0.0, 1.0, 0.0)))
+    damage = min(1.0, state.damage + stall_level * 0.01 * dt)
+    return VehicleState(
+        position=position,
+        velocity=velocity,
+        angular_velocity=angular_velocity,
+        orientation=orientation,
+        throttle=throttle,
+        boost_timer=boost_timer,
+        boost_cooldown=boost_cooldown,
+        damage=damage,
+        altitude_agl=agl,
+        bank_angle=bank_angle,
+        stall_level=stall_level,
+    )
+
+
+# //13.- Initialize vehicle state with sensible defaults at spawn time.
+def spawn_state(position: Vector3 = (0.0, 120.0, 0.0)) -> VehicleState:
+    orientation = Orientation(forward=(0.0, 0.0, 1.0), up=(0.0, 1.0, 0.0))
+    return VehicleState(
+        position=position,
+        velocity=(0.0, 0.0, 0.0),
+        angular_velocity=(0.0, 0.0, 0.0),
+        orientation=orientation,
+        throttle=0.6,
+        boost_timer=0.0,
+        boost_cooldown=0.0,
+        damage=0.0,
+        altitude_agl=position[1],
+        bank_angle=0.0,
+        stall_level=0.0,
+    )

--- a/tunnelcave_sandbox/src/gameplay/placeables.py
+++ b/tunnelcave_sandbox/src/gameplay/placeables.py
@@ -1,0 +1,140 @@
+"""Procedural placement of rocks, trees, and lakes for the gameplay world."""
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from .terrain import TerrainSampler
+from .vector import Vector3, add, length
+
+
+# //1.- Represent basic geometric proxies for obstacle queries.
+@dataclass(frozen=True)
+class RockInstance:
+    center: Vector3
+    radius: float
+
+
+# //2.- Model a tree using a capsule trunk and spherical canopy.
+@dataclass(frozen=True)
+class TreeInstance:
+    base_center: Vector3
+    trunk_height: float
+    crown_radius: float
+
+
+# //3.- Describe a lake surface and the associated water volume marker.
+@dataclass(frozen=True)
+class LakeInstance:
+    center: Vector3
+    radius: float
+    water_height: float
+
+
+# //4.- Bundle the generated props for a chunk to avoid recomputation.
+@dataclass(frozen=True)
+class PlaceableChunk:
+    rocks: Tuple[RockInstance, ...]
+    trees: Tuple[TreeInstance, ...]
+    lakes: Tuple[LakeInstance, ...]
+
+
+# //5.- Deterministically scatter points using a Poisson disk approximation.
+def _poisson_disk_points(
+    rng: random.Random,
+    origin: Vector3,
+    count: int,
+    radius: float,
+    sampler: TerrainSampler,
+) -> List[Vector3]:
+    accepted: List[Vector3] = []
+    attempts = 0
+    while len(accepted) < count and attempts < count * 20:
+        attempts += 1
+        offset = (rng.random(), 0.0, rng.random())
+        candidate = (
+            origin[0] + offset[0],
+            0.0,
+            origin[2] + offset[2],
+        )
+        ground = sampler.sample(candidate[0], candidate[2]).ground_height
+        candidate = (candidate[0], ground, candidate[2])
+        if all(length((candidate[0] - p[0], 0.0, candidate[2] - p[2])) >= radius for p in accepted):
+            accepted.append(candidate)
+    return accepted
+
+
+# //6.- Placeable field orchestrating prop distribution per chunk.
+class PlaceableField:
+    def __init__(self, sampler: TerrainSampler, seed: int, chunk_size: float = 200.0) -> None:
+        self._sampler = sampler
+        self._seed = int(seed)
+        self._chunk_size = float(chunk_size)
+        self._cache: dict[Tuple[int, int], PlaceableChunk] = {}
+
+    @property
+    def chunk_size(self) -> float:
+        return self._chunk_size
+
+    def _rng_for_chunk(self, chunk_x: int, chunk_z: int) -> random.Random:
+        value = (self._seed * 91815541 + chunk_x * 19349663 + chunk_z * 83492791) & 0xFFFFFFFF
+        return random.Random(value)
+
+    def _chunk_origin(self, chunk_x: int, chunk_z: int) -> Vector3:
+        return (chunk_x * self._chunk_size, 0.0, chunk_z * self._chunk_size)
+
+    def _spawn_rocks(self, rng: random.Random, origin: Vector3) -> Tuple[RockInstance, ...]:
+        points = _poisson_disk_points(rng, origin, 12, 8.0, self._sampler)
+        rocks: List[RockInstance] = []
+        for point in points:
+            size = 3.0 + rng.random() * 6.0
+            rocks.append(RockInstance(center=add(point, (0.0, size * 0.3, 0.0)), radius=size))
+        return tuple(rocks)
+
+    def _spawn_trees(self, rng: random.Random, origin: Vector3) -> Tuple[TreeInstance, ...]:
+        points = _poisson_disk_points(rng, origin, 15, 12.0, self._sampler)
+        trees: List[TreeInstance] = []
+        for point in points:
+            sample = self._sampler.sample(point[0], point[2])
+            if sample.slope_radians > math.radians(35):
+                continue
+            trunk = 6.0 + rng.random() * 9.0
+            crown = trunk * (0.6 + rng.random() * 0.2)
+            trees.append(TreeInstance(base_center=point, trunk_height=trunk, crown_radius=crown))
+        return tuple(trees)
+
+    def _spawn_lakes(self, rng: random.Random, origin: Vector3) -> Tuple[LakeInstance, ...]:
+        lakes: List[LakeInstance] = []
+        for _ in range(3):
+            sample_point = (
+                origin[0] + rng.random() * self._chunk_size,
+                0.0,
+                origin[2] + rng.random() * self._chunk_size,
+            )
+            sample = self._sampler.sample(sample_point[0], sample_point[2])
+            if sample.slope_radians > math.radians(10):
+                continue
+            if sample.ground_height > sample.water_height:
+                continue
+            radius = 25.0 + rng.random() * 20.0
+            lakes.append(
+                LakeInstance(
+                    center=(sample_point[0], sample.water_height, sample_point[2]),
+                    radius=radius,
+                    water_height=sample.water_height,
+                )
+            )
+        return tuple(lakes)
+
+    def chunk(self, chunk_x: int, chunk_z: int) -> PlaceableChunk:
+        key = (chunk_x, chunk_z)
+        if key not in self._cache:
+            rng = self._rng_for_chunk(chunk_x, chunk_z)
+            origin = self._chunk_origin(chunk_x, chunk_z)
+            rocks = self._spawn_rocks(rng, origin)
+            trees = self._spawn_trees(rng, origin)
+            lakes = self._spawn_lakes(rng, origin)
+            self._cache[key] = PlaceableChunk(rocks=rocks, trees=trees, lakes=lakes)
+        return self._cache[key]

--- a/tunnelcave_sandbox/src/gameplay/terrain.py
+++ b/tunnelcave_sandbox/src/gameplay/terrain.py
@@ -1,0 +1,126 @@
+"""Procedural terrain sampler powering the gameplay sandbox."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from . import vector
+from .vector import Vector3
+
+BIOMES = ("plains", "forest", "alpine", "lakeshore")
+
+
+# //1.- Provide structured information about ground conditions for flight logic.
+@dataclass(frozen=True)
+class TerrainSample:
+    ground_height: float
+    ceiling_height: float
+    surface_normal: Vector3
+    slope_radians: float
+    biome: str
+    water_height: float
+    is_water: bool
+
+
+# //2.- Generate deterministic gradient noise for world features.
+class _GradientNoise:
+    def __init__(self, seed: int, frequency: float, amplitude: float) -> None:
+        self._seed = int(seed)
+        self._frequency = float(frequency)
+        self._amplitude = float(amplitude)
+
+    def _hash(self, ix: int, iz: int) -> float:
+        value = (self._seed * 374761393 + ix * 668265263 + iz * 2147483647) & 0xFFFFFFFF
+        value ^= value >> 13
+        value = (value * 1274126177) & 0xFFFFFFFF
+        value ^= value >> 16
+        return value / 0xFFFFFFFF
+
+    def sample(self, x: float, z: float) -> float:
+        scaled_x = x * self._frequency
+        scaled_z = z * self._frequency
+        ix = math.floor(scaled_x)
+        iz = math.floor(scaled_z)
+        fx = scaled_x - ix
+        fz = scaled_z - iz
+        corners = {}
+        for dx in (0, 1):
+            for dz in (0, 1):
+                corners[(dx, dz)] = self._hash(ix + dx, iz + dz)
+        x0 = corners[(0, 0)] * (1 - fx) + corners[(1, 0)] * fx
+        x1 = corners[(0, 1)] * (1 - fx) + corners[(1, 1)] * fx
+        value = x0 * (1 - fz) + x1 * fz
+        return (value * 2.0 - 1.0) * self._amplitude
+
+
+# //3.- Combine multiple octaves of noise to synthesize varied terrain heights.
+def _fractal_height(noise_layers: Tuple[_GradientNoise, ...], x: float, z: float) -> float:
+    return sum(layer.sample(x, z) for layer in noise_layers)
+
+
+# //4.- Categorize biome types using a slower noise field.
+def _biome_tag(biome_noise: _GradientNoise, x: float, z: float) -> str:
+    value = biome_noise.sample(x, z)
+    normalized = (value + biome_noise._amplitude) / (2 * biome_noise._amplitude or 1.0)
+    index = int(normalized * len(BIOMES)) % len(BIOMES)
+    return BIOMES[index]
+
+
+# //5.- Estimate surface normals using central differences for lighting and collisions.
+def _estimate_normal(height_func, x: float, z: float, epsilon: float = 0.5) -> Vector3:
+    h_x1 = height_func(x + epsilon, z)
+    h_x0 = height_func(x - epsilon, z)
+    h_z1 = height_func(x, z + epsilon)
+    h_z0 = height_func(x, z - epsilon)
+    normal = vector.normalize((-(h_x1 - h_x0), 2 * epsilon, -(h_z1 - h_z0)))
+    return normal
+
+
+# //6.- Terrain sampler orchestrating height, slope, and biome calculations.
+class TerrainSampler:
+    def __init__(self, seed: int) -> None:
+        self._seed = int(seed)
+        self._height_layers = (
+            _GradientNoise(seed * 5 + 1, 0.003, 40.0),
+            _GradientNoise(seed * 7 + 2, 0.01, 12.0),
+            _GradientNoise(seed * 11 + 3, 0.05, 2.0),
+        )
+        self._ceiling_noise = _GradientNoise(seed * 13 + 4, 0.004, 20.0)
+        self._water_noise = _GradientNoise(seed * 17 + 5, 0.002, 6.0)
+        self._biome_noise = _GradientNoise(seed * 19 + 6, 0.001, 1.0)
+        self._cache: Dict[Tuple[int, int], TerrainSample] = {}
+
+    def _base_height(self, x: float, z: float) -> float:
+        return _fractal_height(self._height_layers, x, z)
+
+    def _water_height(self, x: float, z: float) -> float:
+        return self._water_noise.sample(x, z) - 5.0
+
+    def _ceiling_height(self, ground: float, x: float, z: float) -> float:
+        caverns = max(self._ceiling_noise.sample(x, z) + 30.0, 15.0)
+        return ground + caverns
+
+    def _sample_uncached(self, x: float, z: float) -> TerrainSample:
+        ground = self._base_height(x, z)
+        water = self._water_height(x, z)
+        ceiling = self._ceiling_height(ground, x, z)
+        normal = _estimate_normal(self._base_height, x, z)
+        slope = math.acos(max(min(vector.dot(normal, (0.0, 1.0, 0.0)), 1.0), -1.0))
+        biome = _biome_tag(self._biome_noise, x, z)
+        is_water = ground <= water
+        return TerrainSample(
+            ground_height=ground,
+            ceiling_height=ceiling,
+            surface_normal=normal,
+            slope_radians=slope,
+            biome=biome,
+            water_height=water,
+            is_water=is_water,
+        )
+
+    def sample(self, x: float, z: float) -> TerrainSample:
+        key = (int(math.floor(x)), int(math.floor(z)))
+        if key not in self._cache:
+            self._cache[key] = self._sample_uncached(x, z)
+        return self._cache[key]

--- a/tunnelcave_sandbox/src/gameplay/vector.py
+++ b/tunnelcave_sandbox/src/gameplay/vector.py
@@ -1,0 +1,95 @@
+"""Deterministic vector helpers avoiding external math dependencies."""
+from __future__ import annotations
+
+import math
+from typing import Iterable, Tuple
+
+Vector3 = Tuple[float, float, float]
+
+
+# //1.- Convert iterables into normalized three-component tuples for safety.
+def _to_vector(components: Iterable[float]) -> Vector3:
+    values = tuple(float(component) for component in components)
+    if len(values) != 3:
+        raise ValueError("Vector3 requires exactly three components")
+    return values  # type: ignore[return-value]
+
+
+# //2.- Add vectors component-wise returning a new tuple.
+def add(a: Iterable[float], b: Iterable[float]) -> Vector3:
+    ax, ay, az = _to_vector(a)
+    bx, by, bz = _to_vector(b)
+    return (ax + bx, ay + by, az + bz)
+
+
+# //3.- Subtract vectors component-wise returning a new tuple.
+def subtract(a: Iterable[float], b: Iterable[float]) -> Vector3:
+    ax, ay, az = _to_vector(a)
+    bx, by, bz = _to_vector(b)
+    return (ax - bx, ay - by, az - bz)
+
+
+# //4.- Multiply a vector by a scalar value.
+def scale(vector: Iterable[float], scalar: float) -> Vector3:
+    vx, vy, vz = _to_vector(vector)
+    factor = float(scalar)
+    return (vx * factor, vy * factor, vz * factor)
+
+
+# //5.- Compute the dot product between two vectors.
+def dot(a: Iterable[float], b: Iterable[float]) -> float:
+    ax, ay, az = _to_vector(a)
+    bx, by, bz = _to_vector(b)
+    return ax * bx + ay * by + az * bz
+
+
+# //6.- Compute the cross product following right-hand rule.
+def cross(a: Iterable[float], b: Iterable[float]) -> Vector3:
+    ax, ay, az = _to_vector(a)
+    bx, by, bz = _to_vector(b)
+    return (ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx)
+
+
+# //7.- Calculate the Euclidean length of a vector.
+def length(vector: Iterable[float]) -> float:
+    vx, vy, vz = _to_vector(vector)
+    return math.sqrt(vx * vx + vy * vy + vz * vz)
+
+
+# //8.- Normalize a vector guarding against zero length inputs.
+def normalize(vector: Iterable[float], fallback: Vector3 = (0.0, 0.0, 0.0)) -> Vector3:
+    vx, vy, vz = _to_vector(vector)
+    magnitude = math.sqrt(vx * vx + vy * vy + vz * vz)
+    if magnitude == 0:
+        return fallback
+    inv = 1.0 / magnitude
+    return (vx * inv, vy * inv, vz * inv)
+
+
+# //9.- Clamp vector length to a maximum magnitude while preserving direction.
+def clamp_length(vector: Iterable[float], maximum: float) -> Vector3:
+    vx, vy, vz = _to_vector(vector)
+    max_len = float(maximum)
+    current = math.sqrt(vx * vx + vy * vy + vz * vz)
+    if current <= max_len or current == 0:
+        return (vx, vy, vz)
+    scale_factor = max_len / current
+    return (vx * scale_factor, vy * scale_factor, vz * scale_factor)
+
+
+# //10.- Linearly interpolate between two vectors using parameter t.
+def lerp(a: Iterable[float], b: Iterable[float], t: float) -> Vector3:
+    ax, ay, az = _to_vector(a)
+    bx, by, bz = _to_vector(b)
+    factor = float(t)
+    return (ax + (bx - ax) * factor, ay + (by - ay) * factor, az + (bz - az) * factor)
+
+
+# //11.- Project vector a onto vector b returning the projection component.
+def project(a: Iterable[float], b: Iterable[float]) -> Vector3:
+    bx, by, bz = _to_vector(b)
+    denom = bx * bx + by * by + bz * bz
+    if denom == 0:
+        return (0.0, 0.0, 0.0)
+    scale_factor = dot(a, b) / denom
+    return (bx * scale_factor, by * scale_factor, bz * scale_factor)

--- a/tunnelcave_sandbox/src/gameplay/world.py
+++ b/tunnelcave_sandbox/src/gameplay/world.py
@@ -1,0 +1,182 @@
+"""High-level gameplay world loop stitching terrain, physics, and telemetry."""
+from __future__ import annotations
+
+import json
+import math
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .collision import Capsule, CollisionResult, CollisionSystem
+from .flight import ControlMode, FlightInput, FlightParameters, VehicleState, integrate_flight, spawn_state
+from .placeables import PlaceableField
+from .terrain import TerrainSampler
+from .vector import Vector3, add, scale
+
+
+# //1.- Lightweight telemetry client that posts events to the Go backend when configured.
+class TelemetryClient:
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self._base_url = base_url.rstrip("/") if base_url else None
+
+    def post_event(self, event_type: str, payload: Dict[str, object]) -> None:
+        if not self._base_url:
+            return
+        url = f"{self._base_url}/events/{event_type}"
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+        try:
+            urllib.request.urlopen(request, timeout=2.0)
+        except urllib.error.URLError:
+            pass
+
+
+# //2.- Aggregate match statistics for telemetry reporting.
+@dataclass
+class MatchStats:
+    time_alive: float = 0.0
+    distance: float = 0.0
+    max_speed: float = 0.0
+    collisions: int = 0
+
+    def as_payload(self, seed: int) -> Dict[str, object]:
+        return {
+            "seed": seed,
+            "time_alive": self.time_alive,
+            "distance": self.distance,
+            "max_speed": self.max_speed,
+            "collisions": self.collisions,
+        }
+
+
+# //3.- Orchestrate the gameplay simulation and crash handling.
+class GameplayWorld:
+    def __init__(
+        self,
+        seed: int,
+        telemetry: Optional[TelemetryClient] = None,
+        parameters: Optional[FlightParameters] = None,
+    ) -> None:
+        self.seed = int(seed)
+        self.telemetry = telemetry or TelemetryClient()
+        self.parameters = parameters or FlightParameters()
+        self.sampler = TerrainSampler(self.seed)
+        self.placeables = PlaceableField(self.sampler, self.seed)
+        self.collision = CollisionSystem(self.sampler, self.placeables)
+        self.stats = MatchStats()
+        self._match_active = False
+        self.flight_state = spawn_state(self._spawn_position())
+        self.previous_state = self.flight_state
+        self._send_start_event()
+
+    def _spawn_position(self) -> Vector3:
+        sample = self.sampler.sample(0.0, 0.0)
+        return (0.0, sample.ground_height + 120.0, 0.0)
+
+    def _send_start_event(self) -> None:
+        self.stats = MatchStats()
+        self.flight_state = spawn_state(self._spawn_position())
+        self.previous_state = self.flight_state
+        self.telemetry.post_event(
+            "start",
+            {
+                "seed": self.seed,
+                "position": self.flight_state.position,
+                "velocity": self.flight_state.velocity,
+            },
+        )
+        self._match_active = True
+
+    def reset(self) -> None:
+        self._send_start_event()
+
+    def _capsule_for_state(self, state: VehicleState) -> Capsule:
+        nose, tail = state.capsule_points(self.parameters)
+        return Capsule(nose=nose, tail=tail, radius=self.parameters.body_radius)
+
+    def _apply_collision(self, state: VehicleState, result: CollisionResult) -> VehicleState:
+        adjusted_position = add(state.position, scale(result.contact_normal, max(0.0, result.penetration_depth)))
+        damage = min(1.0, state.damage + result.damage)
+        return VehicleState(
+            position=adjusted_position,
+            velocity=result.new_velocity,
+            angular_velocity=state.angular_velocity,
+            orientation=state.orientation,
+            throttle=state.throttle,
+            boost_timer=state.boost_timer,
+            boost_cooldown=state.boost_cooldown,
+            damage=damage,
+            altitude_agl=state.altitude_agl,
+            bank_angle=state.bank_angle,
+            stall_level=state.stall_level,
+        )
+
+    def _should_crash(self, state: VehicleState, result: CollisionResult, vertical_speed: float) -> bool:
+        if result.kill:
+            return True
+        if abs(state.bank_angle) > math.radians(80):
+            return True
+        if result.penetration_depth > 2.5:
+            return True
+        if vertical_speed < -35.0:
+            return True
+        return False
+
+    def _record_crash(self, result: CollisionResult) -> None:
+        payload = self.stats.as_payload(self.seed)
+        payload.update(
+            {
+                "hazard": result.hazard,
+                "position": self.flight_state.position,
+                "velocity": self.flight_state.velocity,
+            }
+        )
+        self.telemetry.post_event("crash", payload)
+        self._match_active = False
+
+    def update(self, inputs: FlightInput, dt: float) -> VehicleState:
+        if not self._match_active:
+            self.reset()
+        current_inputs = inputs
+        if inputs.mode is ControlMode.ARCADE and inputs.aim_direction == (0.0, 0.0, 1.0):
+            current_inputs = FlightInput(
+                mode=ControlMode.ARCADE,
+                aim_direction=self.flight_state.orientation.forward,
+                pitch=inputs.pitch,
+                roll=inputs.roll,
+                yaw=inputs.yaw,
+                throttle_delta=inputs.throttle_delta,
+                boost=inputs.boost,
+                airbrake=inputs.airbrake,
+            )
+        next_state = integrate_flight(self.flight_state, current_inputs, self.sampler, self.parameters, dt)
+        previous_capsule = self._capsule_for_state(self.flight_state)
+        current_capsule = self._capsule_for_state(next_state)
+        vertical_speed = next_state.velocity[1]
+        speed = math.sqrt(sum(component * component for component in next_state.velocity))
+        result = self.collision.sweep(previous_capsule, current_capsule, self.flight_state.velocity, speed)
+        if result:
+            self.stats.collisions += 1
+            next_state = self._apply_collision(next_state, result)
+            if self._should_crash(next_state, result, vertical_speed):
+                self._record_crash(result)
+                self.reset()
+                return self.flight_state
+        self.stats.time_alive += dt
+        self.stats.distance += speed * dt
+        self.stats.max_speed = max(self.stats.max_speed, speed)
+        self.previous_state = self.flight_state
+        self.flight_state = next_state
+        return self.flight_state
+
+    def checkpoint(self, label: str, score: float) -> None:
+        payload = self.stats.as_payload(self.seed)
+        payload.update({"checkpoint": label, "score": score})
+        self.telemetry.post_event("checkpoint", payload)
+
+    def finish(self, score: float) -> None:
+        payload = self.stats.as_payload(self.seed)
+        payload.update({"score": score})
+        self.telemetry.post_event("finish", payload)
+        self._match_active = False

--- a/tunnelcave_sandbox/tests/test_gameplay_collision.py
+++ b/tunnelcave_sandbox/tests/test_gameplay_collision.py
@@ -1,0 +1,73 @@
+"""Collision system regression tests for gameplay."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from tunnelcave_sandbox.src.gameplay.collision import Capsule, CollisionSystem
+from tunnelcave_sandbox.src.gameplay.placeables import PlaceableChunk, RockInstance, TreeInstance
+from tunnelcave_sandbox.src.gameplay.terrain import TerrainSampler
+
+
+@dataclass
+class EmptyField:
+    chunk_size: float = 200.0
+
+    def chunk(self, chunk_x: int, chunk_z: int) -> PlaceableChunk:
+        return PlaceableChunk(rocks=(), trees=(), lakes=())
+
+
+def _dry_sample(sampler: TerrainSampler) -> tuple[float, float, float]:
+    for x in range(-5, 6):
+        for z in range(-5, 6):
+            px = x * 40.0
+            pz = z * 40.0
+            sample = sampler.sample(px, pz)
+            if not sample.is_water:
+                return px, sample.ground_height, pz
+    raise AssertionError("Expected at least one dry sample in search radius")
+
+
+def test_collision_ground_slide() -> None:
+    sampler = TerrainSampler(3)
+    field = EmptyField()
+    system = CollisionSystem(sampler, field)  # type: ignore[arg-type]
+    px, ground, pz = _dry_sample(sampler)
+    height = ground + 1.0
+    previous = Capsule(nose=(px, height + 1.0, pz), tail=(px, height - 6.0, pz), radius=3.0)
+    current = Capsule(nose=(px, height, pz), tail=(px, height - 7.0, pz), radius=3.0)
+    velocity = (0.0, -15.0, 20.0)
+    result = system.sweep(previous, current, velocity, math.sqrt(velocity[1] ** 2 + velocity[2] ** 2))
+    assert result is not None
+    assert result.hazard == "ground"
+    assert not result.kill
+    assert result.new_velocity[1] >= result.new_velocity[2] * -1.0
+
+
+@dataclass
+class HazardField:
+    rock_center: tuple[float, float, float]
+    tree_center: tuple[float, float, float]
+    chunk_size: float = 200.0
+
+    def chunk(self, chunk_x: int, chunk_z: int) -> PlaceableChunk:
+        rock = RockInstance(center=self.rock_center, radius=5.0)
+        tree = TreeInstance(base_center=self.tree_center, trunk_height=12.0, crown_radius=6.0)
+        return PlaceableChunk(rocks=(rock,), trees=(tree,), lakes=())
+
+
+def test_collision_rock_triggers_kill_at_speed() -> None:
+    sampler = TerrainSampler(4)
+    px, ground, pz = _dry_sample(sampler)
+    rock_center = (px, ground + 5.0, pz + 20.0)
+    tree_center = (px + 15.0, ground + 5.0, pz + 40.0)
+    field = HazardField(rock_center=rock_center, tree_center=tree_center)
+    system = CollisionSystem(sampler, field)  # type: ignore[arg-type]
+    base = ground + 10.0
+    previous = Capsule(nose=(px, base, pz), tail=(px, base - 7.0, pz - 15.0), radius=3.0)
+    current = Capsule(nose=(px, base, pz + 28.0), tail=(px, base - 7.0, pz + 13.0), radius=3.0)
+    velocity = (0.0, 0.0, 120.0)
+    result = system.sweep(previous, current, velocity, 120.0)
+    assert result is not None
+    assert result.hazard == "rock"
+    assert result.kill

--- a/tunnelcave_sandbox/tests/test_gameplay_flight.py
+++ b/tunnelcave_sandbox/tests/test_gameplay_flight.py
@@ -1,0 +1,34 @@
+"""Flight model behavioral tests covering control modes and boost."""
+from __future__ import annotations
+
+from tunnelcave_sandbox.src.gameplay.flight import ControlMode, FlightInput, FlightParameters, integrate_flight, spawn_state
+from tunnelcave_sandbox.src.gameplay.terrain import TerrainSampler
+
+
+def test_arcade_mode_tracks_aim_direction() -> None:
+    sampler = TerrainSampler(8)
+    params = FlightParameters()
+    state = spawn_state(position=(0.0, 200.0, 0.0))
+    aim = (0.0, 0.2, 1.0)
+    inputs = FlightInput(mode=ControlMode.ARCADE, aim_direction=aim)
+    next_state = integrate_flight(state, inputs, sampler, params, dt=0.1)
+    assert next_state.orientation.forward[1] > state.orientation.forward[1]
+
+
+def test_direct_controls_apply_roll_with_speed_scaling() -> None:
+    sampler = TerrainSampler(9)
+    params = FlightParameters()
+    state = spawn_state(position=(0.0, 250.0, 0.0))
+    high_speed_state = integrate_flight(state, FlightInput(mode=ControlMode.DIRECT, pitch=0.0, roll=0.0, yaw=0.0), sampler, params, dt=0.5)
+    inputs = FlightInput(mode=ControlMode.DIRECT, roll=1.0)
+    next_state = integrate_flight(high_speed_state, inputs, sampler, params, dt=0.2)
+    assert abs(next_state.bank_angle) > abs(high_speed_state.bank_angle)
+
+
+def test_boost_increases_forward_velocity() -> None:
+    sampler = TerrainSampler(10)
+    params = FlightParameters()
+    state = spawn_state(position=(0.0, 180.0, 0.0))
+    inputs = FlightInput(mode=ControlMode.DIRECT, throttle_delta=1.0, boost=True)
+    boosted = integrate_flight(state, inputs, sampler, params, dt=0.5)
+    assert boosted.velocity[2] > state.velocity[2]

--- a/tunnelcave_sandbox/tests/test_gameplay_placeables.py
+++ b/tunnelcave_sandbox/tests/test_gameplay_placeables.py
@@ -1,0 +1,36 @@
+"""Tests validating deterministic scattering for gameplay placeables."""
+from __future__ import annotations
+
+import math
+
+from tunnelcave_sandbox.src.gameplay.placeables import PlaceableField
+from tunnelcave_sandbox.src.gameplay.terrain import TerrainSampler
+
+
+def _horizontal_distance(a, b):
+    return math.sqrt((a[0] - b[0]) ** 2 + (a[2] - b[2]) ** 2)
+
+
+def test_placeables_deterministic_by_seed() -> None:
+    sampler = TerrainSampler(99)
+    field_a = PlaceableField(sampler, seed=77)
+    field_b = PlaceableField(sampler, seed=77)
+    chunk_a = field_a.chunk(0, 0)
+    chunk_b = field_b.chunk(0, 0)
+    assert chunk_a == chunk_b
+
+
+def test_placeables_respect_poisson_spacing() -> None:
+    sampler = TerrainSampler(21)
+    field = PlaceableField(sampler, seed=21)
+    chunk = field.chunk(1, -2)
+    for rock in chunk.rocks:
+        for other in chunk.rocks:
+            if rock is other:
+                continue
+            assert _horizontal_distance(rock.center, other.center) >= 6.0
+    for tree in chunk.trees:
+        for other in chunk.trees:
+            if tree is other:
+                continue
+            assert _horizontal_distance(tree.base_center, other.base_center) >= 8.0

--- a/tunnelcave_sandbox/tests/test_gameplay_terrain.py
+++ b/tunnelcave_sandbox/tests/test_gameplay_terrain.py
@@ -1,0 +1,32 @@
+"""Tests for gameplay terrain sampler determinism and structure."""
+from __future__ import annotations
+
+import math
+
+from tunnelcave_sandbox.src.gameplay.terrain import TerrainSampler
+
+
+def test_sampler_deterministic_across_instances() -> None:
+    sampler_a = TerrainSampler(1337)
+    sampler_b = TerrainSampler(1337)
+    sample_a = sampler_a.sample(120.5, -42.25)
+    sample_b = sampler_b.sample(120.5, -42.25)
+    assert sample_a == sample_b
+
+
+def test_sampler_produces_reasonable_normals() -> None:
+    sampler = TerrainSampler(7)
+    sample = sampler.sample(10.0, 10.0)
+    length = math.sqrt(sum(component * component for component in sample.surface_normal))
+    assert math.isclose(length, 1.0, rel_tol=1e-5)
+    assert 0.0 <= sample.slope_radians <= math.pi / 2
+
+
+def test_sampler_distinguishes_biomes_by_seed() -> None:
+    sampler_a = TerrainSampler(1)
+    sampler_b = TerrainSampler(2)
+    sample_a = sampler_a.sample(500.0, 500.0)
+    sample_b = sampler_b.sample(500.0, 500.0)
+    assert sample_a.biome in {"plains", "forest", "alpine", "lakeshore"}
+    # Seeds should decorrelate biomes for the same coordinates.
+    assert sample_a.biome != sample_b.biome or sample_a.ground_height != sample_b.ground_height

--- a/tunnelcave_sandbox/tests/test_gameplay_world.py
+++ b/tunnelcave_sandbox/tests/test_gameplay_world.py
@@ -1,0 +1,31 @@
+"""Integration-style tests for the gameplay world loop."""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from tunnelcave_sandbox.src.gameplay.flight import ControlMode, FlightInput
+from tunnelcave_sandbox.src.gameplay.world import GameplayWorld, TelemetryClient
+
+
+class RecordingTelemetry(TelemetryClient):
+    def __init__(self) -> None:
+        super().__init__(base_url=None)
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def post_event(self, event_type: str, payload: dict[str, object]) -> None:  # type: ignore[override]
+        self.events.append((event_type, payload))
+
+
+def test_world_crash_resets_and_reports() -> None:
+    telemetry = RecordingTelemetry()
+    world = GameplayWorld(seed=12, telemetry=telemetry)
+    sample = world.sampler.sample(0.0, 0.0)
+    crash_state = replace(
+        world.flight_state,
+        position=(0.0, sample.ground_height + 1.0, 0.0),
+        velocity=(0.0, -90.0, 0.0),
+    )
+    world.flight_state = crash_state
+    world.update(FlightInput(mode=ControlMode.DIRECT), dt=0.1)
+    assert any(event for event in telemetry.events if event[0] == "crash")
+    assert world.flight_state.position[1] > sample.ground_height + 50.0


### PR DESCRIPTION
## Summary
- add a gameplay package with procedural terrain sampling, placeable scattering, collision checks, and world orchestration for the arcade flight loop
- implement an arcade/direct flight model with boost, ground effect, and crash evaluation integrated with telemetry
- cover the new gameplay systems with unit tests for terrain, placeables, collisions, flight controls, and world crash handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2dfa1b2dc83298e2bd087e481ce36