### PR TITLE
Enhance arcade flight feedback and chase camera FX

### DIFF
--- a/tunnelcave_sandbox/src/gameplay/world.py
+++ b/tunnelcave_sandbox/src/gameplay/world.py
@@ -110,6 +110,7 @@ class GameplayWorld:
             altitude_agl=state.altitude_agl,
             bank_angle=state.bank_angle,
             stall_level=state.stall_level,
+            buffet_intensity=state.buffet_intensity,
         )
 
     def _should_crash(self, state: VehicleState, result: CollisionResult, vertical_speed: float) -> bool:
@@ -130,6 +131,8 @@ class GameplayWorld:
                 "hazard": result.hazard,
                 "position": self.flight_state.position,
                 "velocity": self.flight_state.velocity,
+                "loss": True,
+                "score": payload["distance"],
             }
         )
         self.telemetry.post_event("crash", payload)

--- a/tunnelcave_sandbox_web/src/camera/cameraDirector.test.ts
+++ b/tunnelcave_sandbox_web/src/camera/cameraDirector.test.ts
@@ -8,6 +8,9 @@ function createSpectatorCamera() {
     //1.- No-op rig methods because the countdown camera handles its own math in tests.
     setPosition: vi.fn(),
     lookAt: vi.fn(),
+    //2.- Provide optional roll/FOV handlers for compatibility with chase camera logic.
+    setRoll: vi.fn(),
+    setFov: vi.fn(),
   }
   const focus = { x: 0, y: 0, z: 0 }
   const camera = new CountdownSpectatorCamera(rig, {
@@ -36,6 +39,10 @@ describe('CameraDirector', () => {
   const vehicle: VehicleTransform = {
     position: { x: 1, y: 0, z: 0 },
     forward: { x: 0, y: 0, z: 1 },
+    up: { x: 0, y: 1, z: 0 },
+    velocity: { x: 0, y: 0, z: 0 },
+    speed: 0,
+    boostActive: false,
   }
 
   it('delegates chase updates when following a vehicle', () => {

--- a/tunnelcave_sandbox_web/src/camera/chaseCamera.ts
+++ b/tunnelcave_sandbox_web/src/camera/chaseCamera.ts
@@ -3,6 +3,14 @@ import type { CameraRig, Vector3 } from './countdownSpectator'
 export interface VehicleTransform {
   position: Vector3
   forward: Vector3
+  //1.- Up vector communicates the craft's bank orientation.
+  up: Vector3
+  //2.- Linear velocity enables look-ahead targeting and FOV tuning.
+  velocity: Vector3
+  //3.- Optional cached speed avoids recomputing magnitudes if available.
+  speed?: number
+  //4.- Flag indicating whether boost visuals should currently be active.
+  boostActive?: boolean
 }
 
 export interface ChaseCameraOffsets {
@@ -17,6 +25,33 @@ export interface ChaseCameraDamping {
   position: number
   //2.- Look-at damping controls interpolation speed for the focus point.
   lookAt: number
+}
+
+export interface ChaseCameraLookAheadSettings {
+  //1.- Distance multiplier applied to the velocity direction.
+  distance: number
+  //2.- Speed required to reach the full look-ahead distance.
+  maxSpeed: number
+}
+
+export interface ChaseCameraRollSettings {
+  //1.- Fraction of the craft's bank angle applied to the camera rig.
+  followStrength: number
+  //2.- Damping used when interpolating towards the desired roll.
+  damping: number
+}
+
+export interface ChaseCameraFovSettings {
+  //1.- Base field of view in degrees when stationary.
+  idle: number
+  //2.- Target field of view at or above the configured max speed.
+  max: number
+  //3.- Speed that maps to the maximum FOV.
+  maxSpeed: number
+  //4.- Additional FOV kick applied when boost is active.
+  boost: number
+  //5.- Damping when lerping between FOV targets.
+  damping: number
 }
 
 export interface CameraFxPlayer {
@@ -35,7 +70,7 @@ export interface CameraShakeSettings {
   duration: number
 }
 
-export type ChaseCameraEvent = 'boost' | 'hit' | 'nearMiss'
+export type ChaseCameraEvent = 'boost' | 'hit' | 'nearMiss' | 'touchdown' | 'ceilingBump' | 'highG' | 'crash'
 
 export interface ChaseCameraEventConfig {
   //1.- Shake specifies how intense the response should feel.
@@ -56,6 +91,12 @@ export interface ChaseCameraOptions extends ChaseCameraRuntimeOptions {
   eventFx: Partial<Record<ChaseCameraEvent, ChaseCameraEventConfig>>
   //2.- World up allows custom up vectors for non-standard gravity.
   worldUp?: Vector3
+  //3.- Look-ahead settings govern how aggressively the camera anticipates motion.
+  lookAhead: ChaseCameraLookAheadSettings
+  //4.- Roll behavior describes how much the camera leans with the craft.
+  roll: ChaseCameraRollSettings
+  //5.- Field-of-view response used for speed and boost cues.
+  fov: ChaseCameraFovSettings
 }
 
 interface ActiveShake {
@@ -77,6 +118,8 @@ export class ChaseCamera implements ChaseCameraController {
   private currentPosition: Vector3 | undefined
   private currentLookAt: Vector3 | undefined
   private activeShake: ActiveShake | undefined
+  private currentRoll: number | undefined
+  private currentFov: number | undefined
 
   constructor(
     private readonly rig: CameraRig,
@@ -94,28 +137,37 @@ export class ChaseCamera implements ChaseCameraController {
       offsets: overrides.offsets ?? this.options.offsets,
       damping: overrides.damping ?? this.options.damping,
     }
-    //2.- Derive a stable local frame from the vehicle's forward axis.
+    //2.- Derive a stable local frame from the vehicle orientation vectors.
     const forward = normalize(transform.forward)
-    const worldUp = normalize(this.options.worldUp ?? { x: 0, y: 1, z: 0 })
-    const right = normalize(cross(worldUp, forward))
+    const craftUp = normalize(transform.up)
+    const right = normalize(cross(craftUp, forward))
     const up = cross(forward, right)
+    const worldUp = normalize(this.options.worldUp ?? { x: 0, y: 1, z: 0 })
     //3.- Translate offsets from local space into world coordinates.
     const desiredPosition = applyOffset(transform.position, runtime.offsets.position, {
       forward,
       right,
       up,
     })
-    const desiredLookAt = applyOffset(transform.position, runtime.offsets.lookAt, {
+    const baseLookAt = applyOffset(transform.position, runtime.offsets.lookAt, {
       forward,
       right,
       up,
     })
+    const speed = transform.speed ?? length(transform.velocity)
+    const velocityDirection = normalize(transform.velocity)
+    const lookAheadScale = clamp(speed / Math.max(this.options.lookAhead.maxSpeed, 1e-3), 0, 1)
+    const lookAhead = scaleVector(velocityDirection, this.options.lookAhead.distance * lookAheadScale)
+    const desiredLookAt = addVectors(baseLookAt, lookAhead)
     //4.- Update and evaluate any active screen shake.
     const shakenPosition = this.applyShake(deltaSeconds, desiredPosition)
     //5.- Smoothly interpolate the camera rig using exponential damping.
     this.currentPosition = damp(this.currentPosition, shakenPosition, runtime.damping.position, deltaSeconds)
     this.currentLookAt = damp(this.currentLookAt, desiredLookAt, runtime.damping.lookAt, deltaSeconds)
-    //6.- Commit the smoothed transform to the underlying rig.
+    //6.- Update roll and FOV feedback before committing transform updates.
+    this.updateRoll(deltaSeconds, right, up, worldUp)
+    this.updateFov(deltaSeconds, speed, Boolean(transform.boostActive))
+    //7.- Commit the smoothed transform to the underlying rig.
     this.rig.setPosition(this.currentPosition)
     this.rig.lookAt(this.currentLookAt)
   }
@@ -134,6 +186,32 @@ export class ChaseCamera implements ChaseCameraController {
     //2.- Kick off the paired VFX and SFX cues.
     this.fx.playVisualFx(config.visualFx)
     this.fx.playAudioFx(config.audioFx)
+  }
+
+  private updateRoll(deltaSeconds: number, right: Vector3, up: Vector3, worldUp: Vector3): void {
+    if (!this.rig.setRoll) {
+      return
+    }
+    //1.- Measure the craft's bank angle relative to the world up axis.
+    const rollAngle = Math.atan2(dot(right, worldUp), dot(up, worldUp))
+    const targetRoll = rollAngle * this.options.roll.followStrength
+    //2.- Smoothly track the target roll using configurable damping.
+    this.currentRoll = dampScalar(this.currentRoll, targetRoll, this.options.roll.damping, deltaSeconds)
+    this.rig.setRoll(this.currentRoll)
+  }
+
+  private updateFov(deltaSeconds: number, speed: number, boostActive: boolean): void {
+    if (!this.rig.setFov) {
+      return
+    }
+    const settings = this.options.fov
+    //1.- Map the current speed onto the configured FOV range.
+    const speedRatio = clamp(speed / Math.max(settings.maxSpeed, 1e-3), 0, 1)
+    const baseFov = settings.idle + (settings.max - settings.idle) * speedRatio
+    const targetFov = baseFov + (boostActive ? settings.boost : 0)
+    //2.- Ease the FOV response so boosts feel punchy but controlled.
+    this.currentFov = dampScalar(this.currentFov, targetFov, settings.damping, deltaSeconds)
+    this.rig.setFov(this.currentFov)
   }
 
   private applyShake(deltaSeconds: number, basePosition: Vector3): Vector3 {
@@ -174,6 +252,16 @@ function damp(current: Vector3 | undefined, target: Vector3, damping: number, de
   }
 }
 
+function dampScalar(current: number | undefined, target: number, damping: number, deltaSeconds: number): number {
+  if (current === undefined) {
+    return target
+  }
+  //1.- Mirror the vector damping logic to keep roll/FOV transitions coherent.
+  const lambda = Math.max(0, Math.min(damping, 60))
+  const factor = 1 - Math.exp(-lambda * deltaSeconds)
+  return current + (target - current) * factor
+}
+
 interface Basis {
   forward: Vector3
   right: Vector3
@@ -200,4 +288,29 @@ function cross(a: Vector3, b: Vector3): Vector3 {
     y: a.z * b.x - a.x * b.z,
     z: a.x * b.y - a.y * b.x,
   }
+}
+
+function addVectors(a: Vector3, b: Vector3): Vector3 {
+  //1.- Combine components to offset look-at targets by the look-ahead vector.
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z }
+}
+
+function scaleVector(vector: Vector3, scalar: number): Vector3 {
+  //1.- Scale helper reused for thrusting the look-ahead along velocity.
+  return { x: vector.x * scalar, y: vector.y * scalar, z: vector.z * scalar }
+}
+
+function length(vector: Vector3): number {
+  //1.- Euclidean length of a vector, shared by speed and normalization logic.
+  return Math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z)
+}
+
+function dot(a: Vector3, b: Vector3): number {
+  //1.- Dot product used when computing roll relative to world up.
+  return a.x * b.x + a.y * b.y + a.z * b.z
+}
+
+function clamp(value: number, min: number, max: number): number {
+  //1.- Restrict values to avoid exceeding configured look-ahead and FOV ranges.
+  return Math.max(min, Math.min(max, value))
 }

--- a/tunnelcave_sandbox_web/src/camera/countdownSpectator.ts
+++ b/tunnelcave_sandbox_web/src/camera/countdownSpectator.ts
@@ -9,6 +9,10 @@ export interface CameraRig {
   setPosition(position: Vector3): void
   //2.- Re-aim the camera towards a target point.
   lookAt(target: Vector3): void
+  //3.- Optionally roll the camera to follow vehicle banking cues.
+  setRoll?(rollRadians: number): void
+  //4.- Optionally adjust the camera field of view for speed FX.
+  setFov?(degrees: number): void
 }
 
 export interface CountdownCameraOptions {


### PR DESCRIPTION
## Summary
- enrich the gameplay flight model with stall metrics, buffet feedback, and gentle arcade stall recovery while updating crash telemetry
- expand gameplay flight tests to cover stall softening and buffet behavior
- extend the chase camera rig with look-ahead targeting, roll/FOV responses, and broader shake events alongside updated TypeScript tests

## Testing
- pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2e3e946fc8329bbaf9a0c69402cf5