### PR TITLE
Add gameplay minimap and update flight controls

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MiniMapOverlay, type MiniMapEntitySnapshot } from './miniMapOverlay'
+
+describe('MiniMapOverlay', () => {
+  it('centres the player marker when positioned at the origin', () => {
+    render(<MiniMapOverlay fieldSize={200} peers={[]} player={{ x: 0, z: 0 }} />)
+    const player = screen.getByTestId('minimap-player')
+    expect(player.getAttribute('cx')).toBe('50')
+    expect(player.getAttribute('cy')).toBe('50')
+  })
+
+  it('renders peer markers with their associated legend entries', () => {
+    const peers: MiniMapEntitySnapshot[] = [
+      { id: 'wing-1', label: 'Wing One', x: 80, z: -20 },
+      { id: 'wing-2', label: 'Wing Two', x: -50, z: 60 },
+    ]
+    render(<MiniMapOverlay fieldSize={200} peers={peers} player={{ x: 0, z: 0 }} />)
+    const markers = screen.getAllByTestId('minimap-peer')
+    expect(markers).toHaveLength(2)
+    const legend = screen.getByTestId('minimap-legend')
+    expect(legend.textContent).toContain('Wing One')
+    expect(legend.textContent).toContain('Wing Two')
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+
+export interface MiniMapEntitySnapshot {
+  //1.- Unique identifier so React can stabilise list rendering.
+  id: string
+  //2.- Friendly label displayed inside the legend.
+  label: string
+  //3.- Horizontal position in world metres relative to the battlefield centre.
+  x: number
+  //4.- Depth position in world metres relative to the battlefield centre.
+  z: number
+}
+
+export interface MiniMapOverlayProps {
+  //1.- Size of the square battlefield so coordinates can be normalised into percentages.
+  fieldSize: number
+  //2.- Player craft location rendered with a highlighted marker.
+  player: { x: number; z: number }
+  //3.- Other pilots rendered as secondary markers with a supporting legend.
+  peers: MiniMapEntitySnapshot[]
+}
+
+function clampPercent(value: number): number {
+  //1.- Restrict percentages into the drawable SVG range to avoid rendering artefacts.
+  return Math.min(100, Math.max(0, value))
+}
+
+function normaliseCoordinate(coordinate: number, fieldSize: number): number {
+  //1.- Translate from world units into a 0-100 range while guarding against zero-sized fields.
+  if (fieldSize <= 0) {
+    return 50
+  }
+  const half = fieldSize / 2
+  const normalised = ((coordinate + half) / fieldSize) * 100
+  return clampPercent(normalised)
+}
+
+export function MiniMapOverlay({ fieldSize, player, peers }: MiniMapOverlayProps) {
+  //1.- Convert world coordinates into map percentages for the player marker.
+  const playerX = normaliseCoordinate(player.x, fieldSize)
+  const playerY = 100 - normaliseCoordinate(player.z, fieldSize)
+  return (
+    <section aria-label="Battlefield minimap" className="hud-minimap" data-testid="hud-minimap">
+      <svg className="hud-minimap__canvas" viewBox="0 0 100 100">
+        {/* 1.- Draw the map background with rounded corners so the overlay fits the HUD theme. */}
+        <rect className="hud-minimap__background" height="100" rx="10" ry="10" width="100" x="0" y="0" />
+        {/* 2.- Render peer markers before the player so the local pilot always sits on top. */}
+        {peers.map((peer) => {
+          const peerX = normaliseCoordinate(peer.x, fieldSize)
+          const peerY = 100 - normaliseCoordinate(peer.z, fieldSize)
+          return (
+            <circle
+              className="hud-minimap__peer"
+              cx={peerX}
+              cy={peerY}
+              data-label={peer.label}
+              data-player-id={peer.id}
+              data-testid="minimap-peer"
+              key={peer.id}
+              r={4}
+            />
+          )
+        })}
+        {/* 3.- Highlight the local craft marker with a larger radius. */}
+        <circle className="hud-minimap__player" cx={playerX} cy={playerY} data-testid="minimap-player" r={6} />
+      </svg>
+      <div className="hud-minimap__legend" data-testid="minimap-legend">
+        {/* 4.- Label the legend entries so pilots can correlate markers to callsigns. */}
+        <p className="hud-minimap__legend-title">Formation</p>
+        <ul className="hud-minimap__legend-list">
+          <li className="hud-minimap__legend-item">You</li>
+          {peers.map((peer) => (
+            <li className="hud-minimap__legend-item" data-player-id={peer.id} key={`legend-${peer.id}`}>
+              {peer.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
@@ -30,7 +30,7 @@ describe('createVehicleController', () => {
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'LeftCtrl' }))
   })
 
-  it('accelerates toward the forward cap when W is held', () => {
+  it('accelerates toward the forward cap when the throttle key is held', () => {
     const controller = createVehicleController({
       baseAcceleration: 60,
       maxForwardSpeed: 100,
@@ -38,7 +38,7 @@ describe('createVehicleController', () => {
       bounds: 1000,
     })
     const craft = new THREE.Object3D()
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
     for (let index = 0; index < 60; index += 1) {
       controller.step(0.1, craft)
     }
@@ -54,9 +54,9 @@ describe('createVehicleController', () => {
       bounds: 1000,
     })
     const craft = new THREE.Object3D()
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
     controller.step(0.4, craft)
-    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp' }))
     const speedBeforeDrag = controller.getSpeed()
     controller.step(0.4, craft)
     const speedAfterDrag = controller.getSpeed()
@@ -72,7 +72,7 @@ describe('createVehicleController', () => {
       bounds: 1000,
     })
     const craft = new THREE.Object3D()
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
     controller.step(0.3, craft)
     window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }))
     controller.step(0.1, craft)
@@ -80,7 +80,7 @@ describe('createVehicleController', () => {
     controller.dispose()
   })
 
-  it('limits reverse speed even when S is held for a long duration', () => {
+  it('limits reverse speed even when PageDown is held for a long duration', () => {
     const controller = createVehicleController({
       baseAcceleration: 30,
       maxForwardSpeed: 120,
@@ -89,7 +89,7 @@ describe('createVehicleController', () => {
       bounds: 1000,
     })
     const craft = new THREE.Object3D()
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown' }))
     for (let index = 0; index < 40; index += 1) {
       controller.step(0.1, craft)
     }
@@ -107,11 +107,27 @@ describe('createVehicleController', () => {
     })
     const craft = new THREE.Object3D()
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }))
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
     for (let index = 0; index < 60; index += 1) {
       controller.step(0.1, craft)
     }
     expect(controller.getSpeed()).toBeCloseTo(135, 0)
+    controller.dispose()
+  })
+
+  it('accepts PageUp as a throttle input for forward acceleration', () => {
+    const controller = createVehicleController({
+      baseAcceleration: 40,
+      maxForwardSpeed: 90,
+      dragFactor: 1,
+      bounds: 1000,
+    })
+    const craft = new THREE.Object3D()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp' }))
+    for (let index = 0; index < 60; index += 1) {
+      controller.step(0.1, craft)
+    }
+    expect(controller.getSpeed()).toBeCloseTo(90, 0)
     controller.dispose()
   })
 
@@ -124,9 +140,9 @@ describe('createVehicleController', () => {
     })
     const craft = new THREE.Object3D()
     //1.- Engage upward thrust and confirm altitude increases beyond the default hover level.
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
     controller.step(0.6, craft)
-    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'r' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'w' }))
     expect(craft.position.y).toBeGreaterThan(0.1)
     const peakHeight = craft.position.y
     //2.- Release inputs and allow gravity to reel the craft toward the ground plane.
@@ -204,11 +220,11 @@ describe('createVehicleController', () => {
     })
     const craft = new THREE.Object3D()
     //1.- Build forward momentum above the waterline so we can observe the drag response.
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
     for (let index = 0; index < 10; index += 1) {
       controller.step(0.2, craft)
     }
-    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'w' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp' }))
     const speedBeforeWater = controller.getSpeed()
     craft.position.y = 2.4
     //2.- Step the simulation with the craft partially submerged and ensure buoyancy and drag clamp its motion.

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
@@ -147,15 +147,15 @@ export function createVehicleController(options: VehicleControllerOptions = {}):
     window.addEventListener('keyup', handleKeyUp)
   }
 
-  const forwardKeys = ['w', 'arrowup']
-  const backwardKeys = ['s', 'arrowdown']
+  const forwardKeys = ['arrowup', 'pageup']
+  const backwardKeys = ['arrowdown', 'pagedown']
   const leftKeys = ['a', 'arrowleft']
   const rightKeys = ['d', 'arrowright']
 
   const brakeKeys = [' ', 'space', 'spacebar']
   const boostKeys = ['shift']
-  const ascendKeys = ['r', 'pageup']
-  const descendKeys = ['f', 'pagedown', 'control', 'ctrl', 'leftctrl']
+  const ascendKeys = ['r', 'w']
+  const descendKeys = ['f', 's', 'control', 'ctrl', 'leftctrl']
 
   const step = (delta: number, object: THREE.Object3D) => {
     //1.- Determine the frame delta, active control intents, and whether boost or brake modifiers are engaged.

--- a/tunnelcave_sandbox_web/app/globals.css
+++ b/tunnelcave_sandbox_web/app/globals.css
@@ -209,3 +209,73 @@ body {
   font-size: 0.9rem;
   color: #cbd5f5;
 }
+
+.hud-minimap {
+  /* 1.- Position the minimap within the HUD stack without overwhelming the primary text. */
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hud-minimap__canvas {
+  /* 1.- Ensure the SVG scales cleanly with the layout grid. */
+  width: 120px;
+  height: 120px;
+  display: block;
+}
+
+.hud-minimap__background {
+  /* 1.- Apply subtle styling so the battlefield outline remains legible. */
+  fill: rgba(30, 41, 59, 0.85);
+  stroke: rgba(148, 163, 184, 0.4);
+  stroke-width: 1.5;
+}
+
+.hud-minimap__peer {
+  /* 1.- Render peers with a neutral hue that contrasts the player marker. */
+  fill: var(--radar-neutral, #38bdf8);
+  stroke: rgba(15, 23, 42, 0.8);
+  stroke-width: 1.2;
+}
+
+.hud-minimap__player {
+  /* 1.- Highlight the local pilot with a distinct accent colour. */
+  fill: var(--radar-friendly, #facc15);
+  stroke: rgba(15, 23, 42, 0.9);
+  stroke-width: 1.6;
+}
+
+.hud-minimap__legend {
+  /* 1.- Stack the legend items vertically beside the minimap canvas. */
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hud-minimap__legend-title {
+  /* 1.- Label the legend heading with a softer colour to match the HUD. */
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.hud-minimap__legend-list {
+  /* 1.- Remove default list styling and align entries with consistent spacing. */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hud-minimap__legend-item {
+  /* 1.- Present each callsign with legible typography inside the compact legend. */
+  color: #e2e8f0;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- add a battlefield minimap overlay that renders simulated peer positions alongside the player craft
- update vehicle controller key bindings so PageUp/PageDown adjust throttle and W/S handle vertical thrust
- style the minimap HUD block and add unit tests covering the new overlay and key mapping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2ef98085883299b00ac25284c6c20