### PR TITLE
Add 3D nameplates and peer escort craft to battlefield view

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/nameplate.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/nameplate.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('three', () => {
+  class CanvasTexture {
+    //1.- Store the backing canvas so assertions can verify construction without GPU access.
+    image: HTMLCanvasElement
+    colorSpace: string | null = null
+    anisotropy = 0
+    constructor(image: HTMLCanvasElement) {
+      this.image = image
+    }
+    dispose() {}
+  }
+
+  class SpriteMaterial {
+    map: CanvasTexture | null
+    transparent: boolean
+    constructor({ map, transparent }: { map: CanvasTexture; transparent: boolean }) {
+      this.map = map
+      this.transparent = transparent
+    }
+    dispose() {
+      this.map = null
+    }
+  }
+
+  class Sprite {
+    material: SpriteMaterial
+    center = { x: 0.5, y: 0, set: (x: number, y: number) => { this.center.x = x; this.center.y = y } }
+    position = {
+      x: 0,
+      y: 0,
+      z: 0,
+      set: (x: number, y: number, z: number) => {
+        this.position.x = x
+        this.position.y = y
+        this.position.z = z
+      },
+    }
+    scale = {
+      x: 1,
+      y: 1,
+      z: 1,
+      set: (x: number, y: number, z: number) => {
+        this.scale.x = x
+        this.scale.y = y
+        this.scale.z = z
+      },
+    }
+    constructor(material: SpriteMaterial) {
+      this.material = material
+    }
+  }
+
+  return {
+    CanvasTexture,
+    Sprite,
+    SpriteMaterial,
+    SRGBColorSpace: 'srgb',
+  }
+})
+
+import { createNameplateSprite } from './nameplate'
+
+const contextStub: Partial<CanvasRenderingContext2D> = {
+  //1.- Provide no-op drawing primitives so jsdom tests can exercise sprite creation logic without a real canvas implementation.
+  clearRect: () => {},
+  beginPath: () => {},
+  moveTo: () => {},
+  lineTo: () => {},
+  quadraticCurveTo: () => {},
+  closePath: () => {},
+  fill: () => {},
+  fillText: () => {},
+  set fillStyle(_value: string) {},
+  set font(_value: string) {},
+  set textAlign(_value: CanvasTextAlign) {},
+  set textBaseline(_value: CanvasTextBaseline) {},
+}
+
+beforeAll(() => {
+  //1.- Shim the canvas context getter so sprite construction succeeds under jsdom.
+  vi.spyOn(window.HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => contextStub as CanvasRenderingContext2D)
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createNameplateSprite', () => {
+  it('creates a sprite anchored from the bottom centre so it floats above the craft', () => {
+    //1.- Build the sprite and ensure it positions correctly relative to its parent craft.
+    const { sprite, dispose } = createNameplateSprite('Falcon Leader')
+    expect(sprite.center.x).toBeCloseTo(0.5)
+    expect(sprite.center.y).toBe(0)
+    expect(sprite.position.y).toBeGreaterThan(0)
+    const material = sprite.material
+    expect(material.map).not.toBeNull()
+    dispose()
+  })
+
+  it('falls back to a generic callsign when provided with blank input', () => {
+    //1.- Blank values should not throw and should still generate a texture for rendering.
+    const { sprite, dispose } = createNameplateSprite('   ')
+    const material = sprite.material
+    expect(material.map).not.toBeNull()
+    dispose()
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/nameplate.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/nameplate.ts
@@ -1,0 +1,65 @@
+import * as THREE from 'three'
+
+export interface NameplateSprite {
+  //1.- The sprite instance attached to a scene graph node.
+  sprite: THREE.Sprite
+  //2.- Cleanup callback releasing GPU resources when the parent entity despawns.
+  dispose: () => void
+}
+
+function drawBackground(context: CanvasRenderingContext2D, width: number, height: number) {
+  //1.- Paint a semi-transparent rounded rectangle so the text remains legible atop the scene.
+  const radius = 24
+  context.fillStyle = 'rgba(12, 18, 32, 0.76)'
+  context.beginPath()
+  context.moveTo(radius, 0)
+  context.lineTo(width - radius, 0)
+  context.quadraticCurveTo(width, 0, width, radius)
+  context.lineTo(width, height - radius)
+  context.quadraticCurveTo(width, height, width - radius, height)
+  context.lineTo(radius, height)
+  context.quadraticCurveTo(0, height, 0, height - radius)
+  context.lineTo(0, radius)
+  context.quadraticCurveTo(0, 0, radius, 0)
+  context.closePath()
+  context.fill()
+}
+
+function drawText(context: CanvasRenderingContext2D, label: string, width: number, height: number) {
+  //1.- Render the pilot callsign using a bold typeface centred within the badge.
+  context.font = 'bold 48px "Segoe UI", sans-serif'
+  context.textAlign = 'center'
+  context.textBaseline = 'middle'
+  context.fillStyle = '#f6fbff'
+  context.fillText(label, width / 2, height / 2)
+}
+
+export function createNameplateSprite(rawLabel: string): NameplateSprite {
+  //1.- Normalise blank labels so every sprite renders a friendly identifier.
+  const label = rawLabel.trim() || 'Squadmate'
+  const canvas = document.createElement('canvas')
+  canvas.width = 512
+  canvas.height = 256
+  const context = canvas.getContext('2d')
+  if (!context) {
+    throw new Error('Unable to allocate 2D canvas context for nameplate sprite')
+  }
+  context.clearRect(0, 0, canvas.width, canvas.height)
+  drawBackground(context, canvas.width, canvas.height)
+  drawText(context, label, canvas.width, canvas.height)
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.colorSpace = THREE.SRGBColorSpace
+  texture.anisotropy = 4
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true })
+  const sprite = new THREE.Sprite(material)
+  sprite.center.set(0.5, 0)
+  sprite.scale.set(9, 3.2, 1)
+  sprite.position.set(0, 4, 0)
+  return {
+    sprite,
+    dispose: () => {
+      texture.dispose()
+      material.dispose()
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- render a reusable canvas-based nameplate sprite for pilots and attach it to the player's craft
- instantiate escort vehicle meshes for remote pilots and sync their motion with minimap updates
- cover the nameplate factory with unit tests using a lightweight Three.js shim

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2f4191f588329a5b766b90d243c4a