### PR TITLE
Enable shared sandbox session code to join same world

### DIFF
--- a/tunnelcave_sandbox_web/app/components/ClientBootstrap.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/ClientBootstrap.test.tsx
@@ -81,9 +81,11 @@ describe('ClientBootstrap', () => {
     const statusText = message?.textContent ?? ''
     expect(statusText).toContain('ws://localhost:43127/ws')
     expect(statusText).toContain('Pilot: sandbox-player')
+    expect(statusText).toContain('Session: shared-sandbox')
     expect(statusText).toContain('Vehicle: arrowhead')
     expect(mountClientShell).toHaveBeenCalledWith({
       brokerUrl: 'ws://localhost:43127/ws',
+      brokerSubject: 'shared-sandbox',
       playerProfile: { pilotName: '', vehicleId: 'arrowhead' },
     })
     await teardown()
@@ -115,15 +117,20 @@ describe('ClientBootstrap', () => {
     })
 
     const nameInput = container.querySelector<HTMLInputElement>('[data-testid="pilot-name-input"]')
+    const sessionInput = container.querySelector<HTMLInputElement>('[data-testid="session-code-input"]')
     const vehicleSelect = container.querySelector<HTMLSelectElement>('[data-testid="vehicle-select"]')
     const startButton = container.querySelector<HTMLButtonElement>('[data-testid="start-session-button"]')
 
     expect(nameInput).not.toBeNull()
+    expect(sessionInput).not.toBeNull()
     expect(vehicleSelect).not.toBeNull()
     expect(startButton).not.toBeNull()
 
     if (nameInput) {
       fireEvent.change(nameInput, { target: { value: 'Nova Seeker' } })
+    }
+    if (sessionInput) {
+      fireEvent.change(sessionInput, { target: { value: 'squad-alpha' } })
     }
     if (vehicleSelect) {
       fireEvent.change(vehicleSelect, { target: { value: 'aurora' } })
@@ -137,11 +144,13 @@ describe('ClientBootstrap', () => {
     })
     expect(mountClientShell).toHaveBeenLastCalledWith({
       brokerUrl: 'ws://localhost:43127/ws',
+      brokerSubject: 'squad-alpha',
       playerProfile: { pilotName: 'Nova Seeker', vehicleId: 'aurora' },
     })
     const params = new URLSearchParams(window.location.search)
     expect(params.get('pilot')).toBe('Nova Seeker')
     expect(params.get('vehicle')).toBe('aurora')
+    expect(params.get('session')).toBe('squad-alpha')
 
     await teardown()
   })
@@ -159,6 +168,7 @@ describe('ClientBootstrap', () => {
 
     expect(shareInput?.value ?? '').toMatch(/^http:\/\/localhost(?::\d+)?\/play/)
     expect(shareInput?.value ?? '').toContain('vehicle=arrowhead')
+    expect(shareInput?.value ?? '').toContain('session=shared-sandbox')
 
     if (nameInput) {
       fireEvent.change(nameInput, { target: { value: 'Nova Seeker' } })
@@ -171,6 +181,7 @@ describe('ClientBootstrap', () => {
       expect(shareUrl.pathname).toBe('/play')
       expect(shareUrl.searchParams.get('pilot')).toBe('Nova Seeker')
       expect(shareUrl.searchParams.get('vehicle')).toBe('arrowhead')
+      expect(shareUrl.searchParams.get('session')).toBe('shared-sandbox')
     })
 
     await teardown()

--- a/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.test.tsx
@@ -25,29 +25,35 @@ describe('SessionLaunchPanel', () => {
 
   it('propagates pilot and vehicle changes then triggers the start callback', () => {
     const onPlayerNameChange = vi.fn()
+    const onSessionCodeChange = vi.fn()
     const onVehicleIdChange = vi.fn()
     const onStart = vi.fn()
 
     render(
       <SessionLaunchPanel
         playerName=""
+        sessionCode="shared"
         vehicleId="arrowhead"
         onPlayerNameChange={onPlayerNameChange}
+        onSessionCodeChange={onSessionCodeChange}
         onVehicleIdChange={onVehicleIdChange}
         onStart={onStart}
         shareUrl="http://localhost:3000/?vehicle=arrowhead"
-      />,
+      />, 
     )
 
     const nameInput = screen.getByTestId('pilot-name-input') as HTMLInputElement
+    const sessionInput = screen.getByTestId('session-code-input') as HTMLInputElement
     const vehicleSelect = screen.getByTestId('vehicle-select') as HTMLSelectElement
     const startButton = screen.getByTestId('start-session-button') as HTMLButtonElement
 
     fireEvent.change(nameInput, { target: { value: 'Nova Seeker' } })
+    fireEvent.change(sessionInput, { target: { value: 'squad-alpha' } })
     fireEvent.change(vehicleSelect, { target: { value: 'aurora' } })
     fireEvent.click(startButton)
 
     expect(onPlayerNameChange).toHaveBeenCalledWith('Nova Seeker')
+    expect(onSessionCodeChange).toHaveBeenCalledWith('squad-alpha')
     expect(onVehicleIdChange).toHaveBeenCalledWith('aurora')
     expect(onStart).toHaveBeenCalledTimes(1)
   })
@@ -59,12 +65,14 @@ describe('SessionLaunchPanel', () => {
     render(
       <SessionLaunchPanel
         playerName="Nova"
+        sessionCode="squad"
         vehicleId="aurora"
         onPlayerNameChange={() => {}}
+        onSessionCodeChange={() => {}}
         onVehicleIdChange={() => {}}
         onStart={() => {}}
         shareUrl="http://localhost:3000/?pilot=Nova&vehicle=aurora"
-      />,
+      />, 
     )
 
     const copyButton = screen.getByTestId('copy-share-url') as HTMLButtonElement
@@ -82,11 +90,13 @@ describe('SessionLaunchPanel', () => {
     render(
       <SessionLaunchPanel
         playerName=""
+        sessionCode="shared"
         vehicleId="arrowhead"
         onPlayerNameChange={() => {}}
+        onSessionCodeChange={() => {}}
         onVehicleIdChange={() => {}}
         onStart={() => {}}
-      />,
+      />, 
     )
 
     const copyButton = screen.getByTestId('copy-share-url') as HTMLButtonElement

--- a/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.tsx
+++ b/tunnelcave_sandbox_web/app/components/SessionLaunchPanel.tsx
@@ -7,10 +7,14 @@ import type { VehiclePresetName } from '../../src/world/procedural/vehicles'
 interface SessionLaunchPanelProps {
   //1.- Current pilot handle supplied by the hosting bootstrap component.
   playerName: string
+  //2.- Identifier for the shared broker subject that groups pilots into the same world.
+  sessionCode: string
   //2.- Currently selected vehicle preset identifier.
   vehicleId: VehiclePresetName
   //3.- Callback invoked when the pilot updates their chosen handle.
   onPlayerNameChange: (name: string) => void
+  //4.- Callback invoked when the squad/session code changes.
+  onSessionCodeChange: (code: string) => void
   //4.- Callback invoked when the pilot selects a different vehicle preset.
   onVehicleIdChange: (vehicle: VehiclePresetName) => void
   //5.- Callback fired when the pilot confirms they are ready to enter the session.
@@ -29,8 +33,10 @@ const VEHICLE_LABELS: Record<VehiclePresetName, string> = {
 
 export default function SessionLaunchPanel({
   playerName,
+  sessionCode,
   vehicleId,
   onPlayerNameChange,
+  onSessionCodeChange,
   onVehicleIdChange,
   onStart,
   shareUrl,
@@ -101,6 +107,18 @@ export default function SessionLaunchPanel({
             onChange={(event) => onPlayerNameChange(event.target.value)}
             placeholder="e.g. Aurora Rider"
             data-testid="pilot-name-input"
+          />
+        </div>
+        <div>
+          <label htmlFor="session-code">Session Code</label>
+          <input
+            id="session-code"
+            name="session"
+            type="text"
+            value={sessionCode}
+            onChange={(event) => onSessionCodeChange(event.target.value)}
+            placeholder="e.g. squad-alpha"
+            data-testid="session-code-input"
           />
         </div>
         <div>

--- a/tunnelcave_sandbox_web/src/runtime/clientShell.test.ts
+++ b/tunnelcave_sandbox_web/src/runtime/clientShell.test.ts
@@ -97,4 +97,22 @@ describe('clientShell', () => {
     expect(hudConstructor).not.toHaveBeenCalled()
     expect(sandboxSession).not.toHaveBeenCalled()
   })
+
+  it('forwards broker subject overrides to the sandbox session', async () => {
+    document.body.innerHTML = [
+      '<div id="canvas-root"></div>',
+      '<div id="hud-root"></div>',
+    ].join('')
+    Object.defineProperty(document, 'readyState', { configurable: true, value: 'complete' })
+    const module = await import('./clientShell')
+    const mounted = await module.mountClientShell({
+      brokerUrl: 'ws://localhost:43127/ws',
+      brokerSubject: 'squad-delta',
+    })
+    expect(mounted).toBe('active')
+    expect(sandboxSession).toHaveBeenCalledTimes(1)
+    const options = sandboxSession.mock.calls[0]?.[0]
+    expect(options?.brokerSubject).toBe('squad-delta')
+    module.unmountClientShell()
+  })
 })

--- a/tunnelcave_sandbox_web/src/runtime/clientShell.ts
+++ b/tunnelcave_sandbox_web/src/runtime/clientShell.ts
@@ -25,6 +25,8 @@ export interface ClientShellOptions {
   document?: Document
   //2.- Broker endpoint enables future networking setup without hardcoding environment globals.
   brokerUrl?: string
+  //3.- Optional broker subject override so callers can target a specific shared world.
+  brokerSubject?: string
   //3.- Asynchronous world session factory invoked once DOM anchors are ready.
   createWorldSession?: () => Promise<HudSession>
   //4.- Lobby provided pilot and vehicle selections used when establishing sandbox sessions.
@@ -126,6 +128,7 @@ async function instantiateControllers(
       createSandboxHudSession({
         canvas: renderer.getCanvas(),
         brokerUrl: options.brokerUrl,
+        brokerSubject: options.brokerSubject,
         pilotName: options.playerProfile?.pilotName,
         vehicleId: options.playerProfile?.vehicleId,
       }))


### PR DESCRIPTION
## Summary
- add a session code lobby field so players can share a single sandbox world
- propagate the chosen session code into the client shell and sandbox session boot flow
- extend the client bootstrap, launch panel, and client shell tests to cover the shared world behaviour

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e3034a107c8329a6cbc05591202891