### PR TITLE
Add models3d gameplay route listing available vehicles

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/models3d/page.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/models3d/page.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { VEHICLE_IDS, VEHICLE_LABELS } from '../vehicles'
+
+describe('Models3dPage', () => {
+  it('lists every available vehicle in the hangar grid', async () => {
+    const { default: Models3dPage } = await import('./page')
+    render(<Models3dPage />)
+    //1.- Ensure the grid wrapper renders so the gallery structure exists for navigation landmarks.
+    const grid = screen.getByTestId('models3d-grid')
+    expect(grid).toBeTruthy()
+    //2.- Confirm each vehicle entry appears exactly once with the expected label.
+    VEHICLE_IDS.forEach((vehicleId) => {
+      const card = screen.getByTestId(`models3d-${vehicleId}`)
+      expect(card).toBeTruthy()
+      expect(card.textContent).toContain(VEHICLE_LABELS[vehicleId])
+    })
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(VEHICLE_IDS.length)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/models3d/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/models3d/page.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { VEHICLE_DESCRIPTIONS, VEHICLE_IDS, VEHICLE_LABELS } from '../vehicles'
+
+export default function Models3dPage() {
+  //1.- Present the fleet hangar overview so pilots can browse every available craft.
+  return (
+    <main className="models3d-layout" data-testid="models3d-page">
+      <header className="models3d-intro">
+        <h1>Vehicle Hangar</h1>
+        <p>Inspect the current fleet and review the role of each prototype before launching into the cavern.</p>
+      </header>
+      <section aria-label="Vehicle catalogue" className="models3d-grid" data-testid="models3d-grid">
+        {/* //2.- Surface each craft with narrative context so visitors understand their battlefield role. */}
+        {VEHICLE_IDS.map((vehicleId) => (
+          <article className="models3d-card" data-testid={`models3d-${vehicleId}`} key={vehicleId}>
+            <h2>{VEHICLE_LABELS[vehicleId]}</h2>
+            <p>{VEHICLE_DESCRIPTIONS[vehicleId]}</p>
+            <dl>
+              <div>
+                <dt>Callsign</dt>
+                <dd>{vehicleId}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/tunnelcave_sandbox_web/app/gameplay/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.tsx
@@ -5,12 +5,11 @@ import { useMemo, useState } from 'react'
 
 import BattlefieldCanvas from './BattlefieldCanvas'
 import { generateBattlefield } from './generateBattlefield'
-import { SHARED_WORLD_SEED } from './worldLobby'
 import { createPlayerSessionId } from './playerSession'
+import { VEHICLE_IDS, type VehicleId } from './vehicles'
+import { SHARED_WORLD_SEED } from './worldLobby'
 
-const VEHICLES = ['arrowhead', 'aurora', 'duskfall', 'steelwing'] as const
-
-export type VehicleOption = (typeof VEHICLES)[number]
+export type VehicleOption = VehicleId
 
 export default function GameplayPage() {
   //1.- Track the progression through the join flow so the interface reveals the correct controls.
@@ -77,7 +76,7 @@ export default function GameplayPage() {
             </p>
           )}
           <div className="vehicle-grid" data-testid="vehicle-grid">
-            {VEHICLES.map((vehicle) => (
+            {VEHICLE_IDS.map((vehicle) => (
               <button
                 className={vehicle === vehicleId ? 'vehicle selected' : 'vehicle'}
                 data-testid={`vehicle-${vehicle}`}

--- a/tunnelcave_sandbox_web/app/gameplay/vehicles.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicles.ts
@@ -1,0 +1,22 @@
+//1.- Central registry of craft identifiers so gameplay routes stay in sync when the roster evolves.
+export const VEHICLE_IDS = ['arrowhead', 'aurora', 'duskfall', 'steelwing'] as const
+
+export type VehicleId = (typeof VEHICLE_IDS)[number]
+
+export const VEHICLE_LABELS: Record<VehicleId, string> = {
+  //1.- Human friendly names ensure interface copy feels immersive and approachable.
+  arrowhead: 'Arrowhead Interceptor',
+  aurora: 'Aurora Glider',
+  duskfall: 'Duskfall Raider',
+  steelwing: 'Steelwing Vanguard',
+}
+
+//2.- Narrative blurbs keep UI components consistent when referencing vehicle lore.
+export const VEHICLE_DESCRIPTIONS: Record<VehicleId, string> = {
+  //1.- Short flavour blurbs provide context for how each craft fits into the fleet roster.
+  arrowhead:
+    'Balanced interceptor tuned for precision strikes and agile responses deep within the cavern airspace.',
+  aurora: 'Glider platform engineered for graceful traversal and extended scouting runs across the stalactite fields.',
+  duskfall: 'Raid specialist featuring aggressive thrust and responsive handling for daring cavern swoops.',
+  steelwing: 'Armoured escort craft reinforced to weather subterranean debris and turbulent thermal drafts.',
+}


### PR DESCRIPTION
## Summary
- extract shared vehicle metadata so gameplay pages stay in sync
- add the /gameplay/models3d route that presents the fleet with descriptions
- cover the new route with a vitest suite verifying every vehicle renders

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e30cddbd78832995cf5d6d3f980120