### PR TITLE
Refactor vehicle model generation into per-vehicle modules

### DIFF
--- a/typescript-client/src/world/models3d/defaultModel.ts
+++ b/typescript-client/src/world/models3d/defaultModel.ts
@@ -1,0 +1,8 @@
+import type { VehicleModelBuilder } from "./modelTypes";
+import { buildProceduralVehicleGeometry } from "./proceduralVehicleModel";
+
+//1.- Provide a fallback generator so experimental identifiers still yield preview geometry.
+export const buildDefaultVehicleModel: VehicleModelBuilder = (params) => {
+  //1.- Reuse the procedural pipeline with the supplied stats.
+  return buildProceduralVehicleGeometry(params);
+};

--- a/typescript-client/src/world/models3d/duneRunnerModel.ts
+++ b/typescript-client/src/world/models3d/duneRunnerModel.ts
@@ -1,0 +1,8 @@
+import type { VehicleModelBuilder } from "./modelTypes";
+import { buildProceduralVehicleGeometry } from "./proceduralVehicleModel";
+
+//1.- Generate placeholder geometry for the dune runner prototype using the shared pipeline.
+export const buildDuneRunnerModel: VehicleModelBuilder = (params) => {
+  //1.- Delegate to the procedural generator so placeholder stats still produce meshes.
+  return buildProceduralVehicleGeometry(params);
+};

--- a/typescript-client/src/world/models3d/modelRegistry.test.ts
+++ b/typescript-client/src/world/models3d/modelRegistry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { VehicleStats } from "../../gameplayConfig";
+import { VehicleGeometryFactory } from "../procedural/vehicleFactory";
+import { resolveVehicleModelBuilder } from "./modelRegistry";
+
+//1.- Provide a reusable stats payload representative of a nimble hovercraft.
+const sampleStats: VehicleStats = {
+  maxSpeedMps: 80,
+  maxAngularSpeedDegPerSec: 90,
+  forwardAccelerationMps2: 10,
+  reverseAccelerationMps2: 6,
+  strafeAccelerationMps2: 7,
+  verticalAccelerationMps2: 5,
+  boostAccelerationMps2: 18,
+  boostDurationSeconds: 4,
+  boostCooldownSeconds: 12,
+};
+
+describe("modelRegistry", () => {
+  //1.- Ensure registered vehicles resolve to their dedicated builders.
+  it("resolves specialised builders for known vehicles", async () => {
+    const THREE = await import("three");
+    const factory = new VehicleGeometryFactory();
+    const builder = resolveVehicleModelBuilder("skiff");
+
+    const result = builder({
+      stats: sampleStats,
+      context: { vehicleId: "skiff" },
+      config: factory.getConfig(),
+      THREE,
+    });
+
+    expect(result.metadata.vehicleId).toBe("skiff");
+    expect(result.body.boundingBox).toBeDefined();
+  });
+
+  //1.- Verify placeholder ground vehicles also resolve to dedicated builders.
+  it("resolves placeholder builders for unreleased ground vehicles", async () => {
+    const THREE = await import("three");
+    const factory = new VehicleGeometryFactory();
+    const builder = resolveVehicleModelBuilder("duneRunner");
+
+    const result = builder({
+      stats: { ...sampleStats, maxSpeedMps: 0 },
+      context: { vehicleId: "duneRunner" },
+      config: factory.getConfig(),
+      THREE,
+    });
+
+    expect(result.metadata.vehicleId).toBe("duneRunner");
+    expect(result.metadata.dimensions.length).toBeGreaterThan(0);
+  });
+
+  //1.- Confirm unknown identifiers fall back to the default procedural builder.
+  it("falls back to the default builder for experimental identifiers", async () => {
+    const THREE = await import("three");
+    const factory = new VehicleGeometryFactory();
+    const builder = resolveVehicleModelBuilder("prototype");
+
+    const result = builder({
+      stats: sampleStats,
+      context: { vehicleId: "prototype" },
+      config: factory.getConfig(),
+      THREE,
+    });
+
+    expect(result.metadata.vehicleId).toBe("prototype");
+    expect(result.metadata.dimensions.width).toBeGreaterThan(0);
+  });
+});

--- a/typescript-client/src/world/models3d/modelRegistry.ts
+++ b/typescript-client/src/world/models3d/modelRegistry.ts
@@ -1,0 +1,21 @@
+import { buildDefaultVehicleModel } from "./defaultModel";
+import { buildDuneRunnerModel } from "./duneRunnerModel";
+import type { VehicleModelBuilder } from "./modelTypes";
+import { buildSkiffModel } from "./skiffModel";
+import { buildTrailBlazerModel } from "./trailBlazerModel";
+
+//1.- Catalogue the available vehicle model builders keyed by roster identifier.
+const registry: Record<string, VehicleModelBuilder> = {
+  //1.- Skiff geometry for the current playable hovercraft.
+  skiff: buildSkiffModel,
+  //2.- Placeholder dune runner geometry using the procedural defaults.
+  duneRunner: buildDuneRunnerModel,
+  //3.- Placeholder trail blazer geometry using the procedural defaults.
+  trailBlazer: buildTrailBlazerModel,
+};
+
+//1.- Resolve the correct vehicle model builder with a fallback for experimental identifiers.
+export function resolveVehicleModelBuilder(vehicleId: string): VehicleModelBuilder {
+  //1.- Return the registered builder when present otherwise use the default generator.
+  return registry[vehicleId] ?? buildDefaultVehicleModel;
+}

--- a/typescript-client/src/world/models3d/modelTypes.ts
+++ b/typescript-client/src/world/models3d/modelTypes.ts
@@ -1,0 +1,125 @@
+import type { VehicleStats } from "../../gameplayConfig";
+import type { VehicleLoadoutSummary } from "../../vehicleRoster";
+import type * as THREE from "three";
+
+//1.- Capture the resolved configuration applied during geometry generation so builders receive consistent values.
+export interface ResolvedVehicleFactoryConfig {
+  //1.- Uniform scale factor applied to every derived measurement.
+  scale: number;
+  //2.- Baseline chassis length offset prior to stat contributions.
+  lengthBias: number;
+  //3.- Scalar mapping maximum speed into chassis length adjustments.
+  lengthFactor: number;
+  //4.- Baseline chassis width offset.
+  widthBias: number;
+  //5.- Scalar mapping lateral acceleration into width adjustments.
+  widthFactor: number;
+  //6.- Baseline chassis height offset.
+  heightBias: number;
+  //7.- Scalar mapping vertical acceleration into height adjustments.
+  heightFactor: number;
+  //8.- Minimum allowable chassis length.
+  minLength: number;
+  //9.- Minimum allowable chassis width.
+  minWidth: number;
+  //10.- Minimum allowable chassis height.
+  minHeight: number;
+  //11.- Multiplier deriving spoiler width from chassis width.
+  spoilerWidthMultiplier: number;
+  //12.- Multiplier deriving spoiler depth from chassis length.
+  spoilerDepthMultiplier: number;
+  //13.- Multiplier deriving spoiler height from chassis height.
+  spoilerHeightMultiplier: number;
+  //14.- Additional multiplier exaggerating spoiler height.
+  spoilerScale: number;
+  //15.- Baseline wheel radius prior to stat contributions.
+  wheelRadiusBias: number;
+  //16.- Scalar mapping vertical acceleration into wheel radius adjustments.
+  wheelRadiusFactor: number;
+  //17.- Baseline wheel width prior to stat contributions.
+  wheelWidthBias: number;
+  //18.- Scalar mapping angular speed into wheel width adjustments.
+  wheelWidthFactor: number;
+  //19.- Minimum allowable wheel radius.
+  minWheelRadius: number;
+  //20.- Minimum allowable wheel width.
+  minWheelWidth: number;
+  //21.- Multiplier mapping chassis length to wheel base.
+  wheelBaseMultiplier: number;
+  //22.- Multiplier mapping chassis width to wheel track.
+  wheelTrackMultiplier: number;
+  //23.- Suspension travel added on top of wheel radius.
+  suspensionTravel: number;
+  //24.- Radial segmentation used when constructing wheels.
+  wheelSegments: number;
+}
+
+//1.- Shape describing metadata that accompanies geometry for previews and testing.
+export interface VehicleGeometryDimensions {
+  //1.- Overall chassis length.
+  length: number;
+  //2.- Overall chassis width.
+  width: number;
+  //3.- Overall chassis height.
+  height: number;
+  //4.- Distance between front and rear axles.
+  wheelBase: number;
+  //5.- Distance between left and right wheels.
+  wheelTrack: number;
+  //6.- Wheel radius including suspension travel.
+  wheelRadius: number;
+  //7.- Wheel width along the rotation axis.
+  wheelWidth: number;
+  //8.- Spoiler width along the lateral axis.
+  spoilerWidth: number;
+  //9.- Spoiler depth along the longitudinal axis.
+  spoilerDepth: number;
+  //10.- Spoiler height above the chassis roof.
+  spoilerHeight: number;
+}
+
+//1.- Context describing which vehicle and loadout triggered the geometry build.
+export interface VehicleModelBuildContext {
+  //1.- Roster identifier for the vehicle entry.
+  vehicleId: string;
+  //2.- Optional loadout shaping passive modifiers.
+  loadout?: VehicleLoadoutSummary;
+}
+
+//1.- Input payload consumed by vehicle model builders.
+export interface VehicleModelBuildParams {
+  //1.- Stats payload steering the procedural measurements.
+  stats: VehicleStats;
+  //2.- Context describing the originating vehicle request.
+  context: VehicleModelBuildContext;
+  //3.- Resolved configuration defining heuristics.
+  config: ResolvedVehicleFactoryConfig;
+  //4.- Preloaded three.js module used to instantiate BufferGeometry instances.
+  THREE: typeof THREE;
+}
+
+//1.- Bundle generated meshes with metadata so callers can reason about the results.
+export interface VehicleGeometryResult {
+  //1.- Procedurally generated body geometry.
+  body: THREE.BufferGeometry;
+  //2.- Wheel geometry that can be instanced per axle.
+  wheel: THREE.BufferGeometry;
+  //3.- Spoiler geometry positioned relative to the chassis.
+  spoiler: THREE.BufferGeometry;
+  //4.- Metadata describing provenance and measurements.
+  metadata: {
+    //1.- Roster identifier for the generated vehicle.
+    vehicleId: string;
+    //2.- Optional loadout identifier influencing geometry.
+    loadoutId?: string;
+    //3.- Snapshot of the resolved configuration.
+    config: ResolvedVehicleFactoryConfig;
+    //4.- Derived dimension summary used by previews and tests.
+    dimensions: VehicleGeometryDimensions;
+  };
+}
+
+//1.- Function signature implemented by individual vehicle model builders.
+export type VehicleModelBuilder = (
+  params: VehicleModelBuildParams,
+) => VehicleGeometryResult;

--- a/typescript-client/src/world/models3d/proceduralVehicleModel.ts
+++ b/typescript-client/src/world/models3d/proceduralVehicleModel.ts
@@ -1,0 +1,144 @@
+import type { VehicleStats } from "../../gameplayConfig";
+import type {
+  VehicleGeometryDimensions,
+  VehicleGeometryResult,
+  VehicleModelBuildParams,
+} from "./modelTypes";
+
+//1.- Guard against degenerate geometry by enforcing minimum values.
+function clampMinimum(value: number, minimum: number): number {
+  //1.- Preserve proportional relationships while respecting lower bounds.
+  return value < minimum ? minimum : value;
+}
+
+//1.- Derive chassis and accessory dimensions from the incoming stats payload.
+function computeDimensions(
+  stats: VehicleStats,
+  params: VehicleModelBuildParams,
+): VehicleGeometryDimensions {
+  //1.- Capture the resolved configuration for convenience within this scope.
+  const config = params.config;
+  //2.- Apply the uniform scale across all derived measurements.
+  const scale = config.scale;
+  //3.- Inspect the passive modifiers supplied by the active loadout if available.
+  const speedModifier = params.context.loadout?.passiveModifiers?.speedMultiplier ?? 1;
+  const agilityModifier = params.context.loadout?.passiveModifiers?.agilityMultiplier ?? 1;
+  //4.- Compute raw chassis dimensions directly from the stats payload.
+  const rawLength =
+    (config.lengthBias + stats.maxSpeedMps * config.lengthFactor * speedModifier) * scale;
+  const rawWidth =
+    (config.widthBias + stats.strafeAccelerationMps2 * config.widthFactor) * scale * agilityModifier;
+  const rawHeight =
+    (config.heightBias + stats.verticalAccelerationMps2 * config.heightFactor) * scale;
+  //5.- Clamp the chassis dimensions to prevent near-zero geometry artefacts.
+  const length = clampMinimum(rawLength, config.minLength * scale);
+  const width = clampMinimum(rawWidth, config.minWidth * scale);
+  const height = clampMinimum(rawHeight, config.minHeight * scale);
+  //6.- Compute wheel radii and widths derived from acceleration and rotation stats.
+  const rawWheelRadius =
+    (config.wheelRadiusBias + stats.verticalAccelerationMps2 * config.wheelRadiusFactor) * scale;
+  const rawWheelWidth =
+    (config.wheelWidthBias + stats.maxAngularSpeedDegPerSec * config.wheelWidthFactor) * scale;
+  //7.- Clamp wheel dimensions and add suspension travel to the radius for bounding boxes.
+  const wheelRadius =
+    clampMinimum(rawWheelRadius, config.minWheelRadius * scale) + config.suspensionTravel;
+  const wheelWidth = clampMinimum(rawWheelWidth, config.minWheelWidth * scale);
+  //8.- Compute wheel placement metrics re-used by gameplay previews.
+  const wheelBase = length * config.wheelBaseMultiplier;
+  const wheelTrack = width * config.wheelTrackMultiplier;
+  //9.- Determine spoiler dimensions influenced by loadout speed modifiers.
+  const spoilerWidth = width * config.spoilerWidthMultiplier;
+  const spoilerDepth = length * config.spoilerDepthMultiplier;
+  const spoilerHeight =
+    height * config.spoilerHeightMultiplier * config.spoilerScale * speedModifier;
+  //10.- Return the derived dimension summary for downstream geometry builders.
+  return {
+    length,
+    width,
+    height,
+    wheelBase,
+    wheelTrack,
+    wheelRadius,
+    wheelWidth,
+    spoilerWidth,
+    spoilerDepth,
+    spoilerHeight,
+  };
+}
+
+//1.- Construct the BufferGeometry representing a single wheel instance.
+function buildWheelGeometry(
+  THREE: typeof import("three"),
+  dimensions: VehicleGeometryDimensions,
+  segments: number,
+): import("three").BufferGeometry {
+  //1.- Start with a cylinder aligned along the Y axis.
+  const rawWheel = new THREE.CylinderGeometry(
+    dimensions.wheelRadius,
+    dimensions.wheelRadius,
+    dimensions.wheelWidth,
+    segments,
+  );
+  //2.- Rotate the wheel so the rotation axis aligns with the X axis.
+  rawWheel.rotateZ(Math.PI / 2);
+  //3.- Translate the wheel upwards so the base touches the origin plane.
+  const offsetMatrix = new THREE.Matrix4().makeTranslation(0, dimensions.wheelRadius, 0);
+  rawWheel.applyMatrix4(offsetMatrix);
+  //4.- Ensure the bounding box reflects the applied rotation and translation.
+  rawWheel.computeBoundingBox();
+  return rawWheel;
+}
+
+//1.- Construct the BufferGeometry representing the spoiler accessory.
+function buildSpoilerGeometry(
+  THREE: typeof import("three"),
+  dimensions: VehicleGeometryDimensions,
+): import("three").BufferGeometry {
+  //1.- Create the spoiler volume from the derived dimensions.
+  const spoiler = new THREE.BoxGeometry(
+    dimensions.spoilerDepth,
+    dimensions.spoilerHeight,
+    dimensions.spoilerWidth,
+  );
+  //2.- Translate the spoiler above and behind the chassis midpoint.
+  const translation = new THREE.Matrix4().makeTranslation(
+    dimensions.length / 2 - dimensions.spoilerDepth / 2,
+    dimensions.height / 2 + dimensions.spoilerHeight / 2,
+    0,
+  );
+  spoiler.applyMatrix4(translation);
+  //3.- Cache the bounding box to simplify downstream processing.
+  spoiler.computeBoundingBox();
+  return spoiler;
+}
+
+//1.- Shared procedural pipeline used by multiple vehicles that derive geometry from stats.
+export function buildProceduralVehicleGeometry(
+  params: VehicleModelBuildParams,
+): VehicleGeometryResult {
+  //1.- Derive the dimension summary taking loadout modifiers into account.
+  const dimensions = computeDimensions(params.stats, params);
+  //2.- Build the chassis geometry as a simple box aligned with the world axes.
+  const body = new params.THREE.BoxGeometry(
+    dimensions.length,
+    dimensions.height,
+    dimensions.width,
+  );
+  //3.- Precompute the bounding box for the body to aid selection previews.
+  body.computeBoundingBox();
+  //4.- Construct the accessory geometries using the derived dimensions.
+  const wheel = buildWheelGeometry(params.THREE, dimensions, params.config.wheelSegments);
+  const spoiler = buildSpoilerGeometry(params.THREE, dimensions);
+  //5.- Return the geometry bundle along with metadata capturing provenance.
+  return {
+    body,
+    wheel,
+    spoiler,
+    metadata: {
+      vehicleId: params.context.vehicleId,
+      loadoutId: params.context.loadout?.id,
+      config: { ...params.config },
+      dimensions,
+    },
+  };
+}

--- a/typescript-client/src/world/models3d/skiffModel.ts
+++ b/typescript-client/src/world/models3d/skiffModel.ts
@@ -1,0 +1,8 @@
+import type { VehicleModelBuilder } from "./modelTypes";
+import { buildProceduralVehicleGeometry } from "./proceduralVehicleModel";
+
+//1.- Generate geometry for the agile skiff hovercraft using the shared procedural pipeline.
+export const buildSkiffModel: VehicleModelBuilder = (params) => {
+  //1.- Delegate to the procedural generator tuned by the caller supplied configuration.
+  return buildProceduralVehicleGeometry(params);
+};

--- a/typescript-client/src/world/models3d/trailBlazerModel.ts
+++ b/typescript-client/src/world/models3d/trailBlazerModel.ts
@@ -1,0 +1,8 @@
+import type { VehicleModelBuilder } from "./modelTypes";
+import { buildProceduralVehicleGeometry } from "./proceduralVehicleModel";
+
+//1.- Generate placeholder geometry for the trail blazer entry using the shared pipeline.
+export const buildTrailBlazerModel: VehicleModelBuilder = (params) => {
+  //1.- Use the procedural generator so the placeholder remains visually represented.
+  return buildProceduralVehicleGeometry(params);
+};


### PR DESCRIPTION
## Summary
- move the procedural vehicle geometry generation into dedicated models3d modules for each roster entry
- add a registry that maps vehicle identifiers to their builders while delegating to a shared procedural pipeline
- cover the registry with targeted tests to ensure known, placeholder, and fallback identifiers resolve correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e30fb288d88329b002770b53d404f0