### PR TITLE
feat: add seamless battlefield wrapping

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/generateBattlefield.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/generateBattlefield.ts
@@ -33,6 +33,7 @@ export interface BattlefieldEnvironment {
   waterBuoyancy: number
   waterMinDepth: number
   maxWaterSpeedScale: number
+  wrapSize: number
 }
 
 export interface BattlefieldTerrain {
@@ -306,6 +307,7 @@ export function generateBattlefield(seed = Date.now() & 0xffffffff): Battlefield
     waterBuoyancy: 14,
     waterMinDepth: 1.6,
     maxWaterSpeedScale: 0.55,
+    wrapSize: fieldSize,
   }
 
   return {

--- a/tunnelcave_sandbox_web/app/gameplay/terrain/terrainSamplerWrap.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/terrain/terrainSamplerWrap.test.ts
@@ -1,0 +1,82 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { createTerrainSampler } from './terrainSampler'
+
+describe('terrainSampler wrapping', () => {
+  it('mirrors ground samples across seamless tiles', () => {
+    //1.- Initialise a sampler with deterministic parameters and matching wrap expectations.
+    const fieldSize = 120
+    const sampler = createTerrainSampler({
+      seed: 12345,
+      fieldSize,
+      spawnPoint: new THREE.Vector3(0, 0, 0),
+      spawnRadius: 18,
+      terrain: {
+        baseAmplitude: 20,
+        baseFrequency: 1.1,
+        octaves: 4,
+        lacunarity: 2,
+        gain: 0.48,
+        warpStrength: 18,
+        warpFrequency: 1.4,
+      },
+      mountains: {
+        intensity: 24,
+        threshold: 0.32,
+        gain: 0.4,
+        lacunarity: 2.2,
+        octaves: 3,
+        maskRadius: 64,
+      },
+      water: {
+        level: -4,
+        basinThreshold: 0.28,
+        basinDepth: 12,
+        shorelineSmoothness: 0.06,
+      },
+    })
+    const originSample = sampler.sampleGround(20, -15)
+    const wrappedSample = sampler.sampleGround(20 + fieldSize, -15 - fieldSize)
+    expect(originSample.height).toBeCloseTo(wrappedSample.height)
+    expect(originSample.normal.y).toBeCloseTo(wrappedSample.normal.y, 3)
+  })
+
+  it('wraps registered water overrides so lakes repeat seamlessly', () => {
+    //1.- Register a water override outside the primary tile and verify the mirrored coordinate samples it.
+    const fieldSize = 120
+    const sampler = createTerrainSampler({
+      seed: 54321,
+      fieldSize,
+      spawnPoint: new THREE.Vector3(0, 0, 0),
+      spawnRadius: 16,
+      terrain: {
+        baseAmplitude: 18,
+        baseFrequency: 1.2,
+        octaves: 4,
+        lacunarity: 2.1,
+        gain: 0.5,
+        warpStrength: 16,
+        warpFrequency: 1.6,
+      },
+      mountains: {
+        intensity: 22,
+        threshold: 0.3,
+        gain: 0.38,
+        lacunarity: 2.3,
+        octaves: 3,
+        maskRadius: 60,
+      },
+      water: {
+        level: -5,
+        basinThreshold: 0.3,
+        basinDepth: 10,
+        shorelineSmoothness: 0.05,
+      },
+    })
+    sampler.registerWaterOverride(fieldSize / 2 + 8, 0, -2, 10)
+    const mirroredHeight = sampler.sampleWater(-fieldSize / 2 + 8, 0)
+    expect(mirroredHeight).toBeCloseTo(-2)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/worldWrapping.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/worldWrapping.test.ts
@@ -1,0 +1,28 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { wrapToInterval, wrappedDelta, wrapVector3 } from './worldWrapping'
+
+describe('worldWrapping', () => {
+  it('wrapToInterval re-enters the tile bounds while preserving offset direction', () => {
+    //1.- Sample positions far outside the tile and ensure they land within [-size/2, size/2).
+    expect(wrapToInterval(230, 200)).toBeCloseTo(30)
+    expect(wrapToInterval(-270, 200)).toBeCloseTo(-70)
+  })
+
+  it('wrappedDelta returns the shortest seam-aware difference', () => {
+    //1.- Use points straddling the seam and confirm the delta reflects the continuous path.
+    expect(wrappedDelta(-90, 90, 200)).toBeCloseTo(20)
+    expect(wrappedDelta(90, -90, 200)).toBeCloseTo(-20)
+  })
+
+  it('wrapVector3 mutates vectors so repeated world tiles align perfectly', () => {
+    //1.- Wrap both axes and confirm Y remains untouched for vertical positioning.
+    const vector = new THREE.Vector3(210, 5, -230)
+    wrapVector3(vector, 200)
+    expect(vector.x).toBeCloseTo(10)
+    expect(vector.y).toBe(5)
+    expect(vector.z).toBeCloseTo(-30)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/worldWrapping.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/worldWrapping.ts
@@ -1,0 +1,34 @@
+import * as THREE from 'three'
+
+//1.- Wrap a scalar coordinate into the interval [-size/2, size/2) so tiling worlds stay seamless.
+export function wrapToInterval(value: number, size: number): number {
+  if (!Number.isFinite(size) || size <= 0) {
+    return value
+  }
+  const half = size / 2
+  const wrapped = ((value + half) % size + size) % size - half
+  return wrapped
+}
+
+//2.- Compute the shortest wrapped delta so velocity calculations ignore seamless teleport seams.
+export function wrappedDelta(current: number, previous: number, size: number): number {
+  if (!Number.isFinite(size) || size <= 0) {
+    return current - previous
+  }
+  let delta = current - previous
+  const half = size / 2
+  if (delta > half) {
+    delta -= size
+  } else if (delta < -half) {
+    delta += size
+  }
+  return delta
+}
+
+//3.- Wrap a THREE vector in-place so each axis lands inside the repeating world tile.
+export function wrapVector3(target: THREE.Vector3, size: number): void {
+  target.x = wrapToInterval(target.x, size)
+  target.y = target.y
+  target.z = wrapToInterval(target.z, size)
+}
+


### PR DESCRIPTION
## Summary
- add world wrapping helpers so gameplay coordinates repeat without visible seams
- wrap vehicle control, lobby snapshots, and terrain sampling to keep pilots and scenery inside the reusable tile
- cover the new wrapping behaviour with focused tests for controllers, samplers, and helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e315c896048329ab5ef3eafe0b5d66