### PR TITLE
Add gameplay world explorer and vehicle preview galleries

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/3dmodel/vehicles/index.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/3dmodel/vehicles/index.test.ts
@@ -1,0 +1,23 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { VEHICLE_IDS } from '../../vehicles'
+import { createVehicleModel, listVehicleModelDefinitions } from './index'
+
+describe('vehicle model definitions', () => {
+  it('exposes a definition for every registered vehicle', () => {
+    const definitions = listVehicleModelDefinitions()
+    //1.- The hangar preview should surface the same roster of vehicles as the gameplay flow.
+    expect(definitions).toHaveLength(VEHICLE_IDS.length)
+    expect(definitions.map((definition) => definition.id)).toEqual(VEHICLE_IDS)
+  })
+
+  it('creates distinct mesh groups for each craft', () => {
+    VEHICLE_IDS.forEach((vehicleId) => {
+      const model = createVehicleModel(vehicleId)
+      //1.- Ensure the mesh factory returns a populated group ready for rendering.
+      expect(model).toBeInstanceOf(THREE.Group)
+      expect(model.children.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/3dmodel/vehicles/index.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/3dmodel/vehicles/index.ts
@@ -1,0 +1,161 @@
+import * as THREE from 'three'
+
+import { VEHICLE_IDS, VEHICLE_LABELS, type VehicleId } from '../../vehicles'
+
+export interface VehicleModelDefinition {
+  id: VehicleId
+  label: string
+  buildModel: () => THREE.Group
+}
+
+const primaryPalette: Record<VehicleId, number> = {
+  arrowhead: 0xff7f50,
+  aurora: 0x87cefa,
+  duskfall: 0xcd5c5c,
+  steelwing: 0xc0c0c0,
+}
+
+const canopyPalette: Record<VehicleId, number> = {
+  arrowhead: 0x1c1c1c,
+  aurora: 0x0f1c3f,
+  duskfall: 0x1a0d0d,
+  steelwing: 0x111111,
+}
+
+const thrusterPalette: Record<VehicleId, number> = {
+  arrowhead: 0xffd700,
+  aurora: 0x00ffff,
+  duskfall: 0xff4500,
+  steelwing: 0xb0e0e6,
+}
+
+const hullGeometryFactories: Record<VehicleId, () => THREE.BufferGeometry> = {
+  arrowhead: () => new THREE.ConeGeometry(1.2, 3.2, 6),
+  aurora: () => new THREE.CylinderGeometry(0.8, 1.5, 3.8, 12),
+  duskfall: () => new THREE.BoxGeometry(2.6, 0.8, 1.2),
+  steelwing: () => new THREE.CapsuleGeometry(1.1, 2.8, 6, 12),
+}
+
+const createHull = (vehicleId: VehicleId) => {
+  //1.- Author the core fuselage mesh so every craft receives a distinct silhouette.
+  const geometry = hullGeometryFactories[vehicleId]()
+  const material = new THREE.MeshStandardMaterial({ color: primaryPalette[vehicleId], flatShading: true })
+  const mesh = new THREE.Mesh(geometry, material)
+  mesh.castShadow = true
+  return mesh
+}
+
+const createCanopy = (vehicleId: VehicleId) => {
+  //1.- Top the fuselage with a canopy to give depth and emphasise cockpit placement.
+  const canopyGeometry = new THREE.SphereGeometry(0.7, 16, 16)
+  const canopyMaterial = new THREE.MeshStandardMaterial({
+    color: canopyPalette[vehicleId],
+    metalness: 0.4,
+    roughness: 0.25,
+  })
+  const canopy = new THREE.Mesh(canopyGeometry, canopyMaterial)
+  canopy.position.set(0, 0.4, 0)
+  canopy.castShadow = true
+  return canopy
+}
+
+const createThruster = (vehicleId: VehicleId) => {
+  //1.- Attach a thruster glow mesh to hint at propulsion systems.
+  const thrusterGeometry = new THREE.ConeGeometry(0.4, 0.9, 12)
+  const thrusterMaterial = new THREE.MeshStandardMaterial({
+    color: thrusterPalette[vehicleId],
+    emissive: thrusterPalette[vehicleId],
+    emissiveIntensity: 0.6,
+  })
+  const thruster = new THREE.Mesh(thrusterGeometry, thrusterMaterial)
+  thruster.rotation.x = Math.PI
+  thruster.position.set(0, -1.4, 0)
+  return thruster
+}
+
+const createWingPair = (vehicleId: VehicleId) => {
+  //1.- Mirror a low poly wing for additional visual interest.
+  const wingGeometry = new THREE.BoxGeometry(2.4, 0.2, 0.6)
+  const wingMaterial = new THREE.MeshStandardMaterial({
+    color: primaryPalette[vehicleId],
+    roughness: 0.6,
+  })
+  const leftWing = new THREE.Mesh(wingGeometry, wingMaterial)
+  leftWing.position.set(-1.8, -0.2, 0)
+  const rightWing = leftWing.clone()
+  rightWing.position.x *= -1
+  const wingGroup = new THREE.Group()
+  wingGroup.add(leftWing)
+  wingGroup.add(rightWing)
+  return wingGroup
+}
+
+const augmentors: Partial<Record<VehicleId, (group: THREE.Group) => void>> = {
+  aurora: (group) => {
+    //1.- Add a vertical stabiliser for the glider-inspired craft silhouette.
+    const stabiliser = new THREE.Mesh(
+      new THREE.BoxGeometry(0.2, 1.4, 0.8),
+      new THREE.MeshStandardMaterial({ color: primaryPalette.aurora })
+    )
+    stabiliser.position.set(0, 0.5, -0.6)
+    group.add(stabiliser)
+  },
+  duskfall: (group) => {
+    //1.- Introduce forward prongs to emphasise the raider profile.
+    const prongMaterial = new THREE.MeshStandardMaterial({ color: primaryPalette.duskfall })
+    const leftProng = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.12, 1.2, 12), prongMaterial)
+    leftProng.rotation.z = Math.PI / 2
+    leftProng.position.set(-0.8, 0.1, 1)
+    const rightProng = leftProng.clone()
+    rightProng.position.x *= -1
+    group.add(leftProng)
+    group.add(rightProng)
+  },
+  steelwing: (group) => {
+    //1.- Mount defensive plates to underline the heavy escort design.
+    const plateMaterial = new THREE.MeshStandardMaterial({ color: 0x708090 })
+    const leftPlate = new THREE.Mesh(new THREE.BoxGeometry(0.4, 1.2, 2.4), plateMaterial)
+    leftPlate.position.set(-1.4, -0.1, 0)
+    const rightPlate = leftPlate.clone()
+    rightPlate.position.x *= -1
+    group.add(leftPlate)
+    group.add(rightPlate)
+  },
+}
+
+export const vehicleModelDefinitions: Record<VehicleId, VehicleModelDefinition> = VEHICLE_IDS.reduce((registry, id) => {
+  //1.- Create a factory entry per craft so callers can instantiate the meshes on demand.
+  registry[id] = {
+    id,
+    label: VEHICLE_LABELS[id],
+    buildModel: () => {
+      const group = new THREE.Group()
+      const hull = createHull(id)
+      const canopy = createCanopy(id)
+      const thruster = createThruster(id)
+      const wings = createWingPair(id)
+      group.add(hull)
+      group.add(canopy)
+      group.add(thruster)
+      group.add(wings)
+      const augment = augmentors[id]
+      if (augment) {
+        augment(group)
+      }
+      group.rotation.x = -Math.PI / 2.8
+      group.rotation.z = Math.PI / 16
+      return group
+    },
+  }
+  return registry
+}, {} as Record<VehicleId, VehicleModelDefinition>)
+
+export const listVehicleModelDefinitions = (): VehicleModelDefinition[] => {
+  //1.- Surface the registry as an ordered array that mirrors the core vehicle listing.
+  return VEHICLE_IDS.map((id) => vehicleModelDefinitions[id])
+}
+
+export const createVehicleModel = (vehicleId: VehicleId) => {
+  //1.- Produce a dedicated mesh group for the requested craft so preview canvases stay pure.
+  return vehicleModelDefinitions[vehicleId].buildModel()
+}

--- a/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/VehiclePreviewCanvas.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/VehiclePreviewCanvas.test.tsx
@@ -1,0 +1,21 @@
+import * as THREE from 'three'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const createVehicleModelMock = vi.fn(() => new THREE.Group())
+
+vi.mock('../3dmodel/vehicles', () => ({
+  createVehicleModel: (...args: unknown[]) => createVehicleModelMock(...args),
+}))
+
+describe('VehiclePreviewCanvas', () => {
+  it('renders a fallback message when WebGL is unavailable', async () => {
+    const { default: VehiclePreviewCanvas } = await import('./VehiclePreviewCanvas')
+    render(<VehiclePreviewCanvas vehicleId="arrowhead" />)
+    //1.- Validate that test environments lacking WebGL receive a descriptive message instead of crashing.
+    const frame = screen.getByTestId('vehicle-preview-arrowhead')
+    expect(frame.dataset.webgl).toBe('unavailable')
+    expect(frame.textContent).toContain('Interactive preview unavailable in this environment.')
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/VehiclePreviewCanvas.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/VehiclePreviewCanvas.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import React, { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+
+import { createVehicleModel } from '../3dmodel/vehicles'
+import type { VehicleId } from '../vehicles'
+
+const isWebGLAvailable = () => {
+  //1.- Attempt to acquire a WebGL context to determine whether rendering is possible in the host environment.
+  try {
+    const canvas = document.createElement('canvas')
+    return Boolean(canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+  } catch (error) {
+    return false
+  }
+}
+
+export interface VehiclePreviewCanvasProps {
+  vehicleId: VehicleId
+}
+
+const setupRenderer = (container: HTMLDivElement) => {
+  //1.- Initialise the renderer and append the canvas to the host card.
+  const width = container.clientWidth || 320
+  const height = container.clientHeight || 220
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+  renderer.setPixelRatio(window.devicePixelRatio || 1)
+  renderer.setSize(width, height)
+  container.appendChild(renderer.domElement)
+  return renderer
+}
+
+const createCamera = (aspect: number) => {
+  //1.- Position a perspective camera so the craft fits comfortably within the viewport.
+  const camera = new THREE.PerspectiveCamera(50, aspect, 0.1, 100)
+  camera.position.set(4.5, 3.2, 5.4)
+  camera.lookAt(new THREE.Vector3(0, 0, 0))
+  return camera
+}
+
+export default function VehiclePreviewCanvas({ vehicleId }: VehiclePreviewCanvasProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+
+    if (!isWebGLAvailable()) {
+      //1.- Provide a graceful fallback for test environments without WebGL support.
+      container.dataset.webgl = 'unavailable'
+      container.textContent = 'Interactive preview unavailable in this environment.'
+      return
+    }
+
+    const renderer = setupRenderer(container)
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(0x05070a)
+    const camera = createCamera(renderer.getSize(new THREE.Vector2()).width / renderer.getSize(new THREE.Vector2()).height)
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.7)
+    const keyLight = new THREE.DirectionalLight(0xffffff, 0.8)
+    keyLight.position.set(5, 8, 6)
+    const backLight = new THREE.DirectionalLight(0xffffff, 0.4)
+    backLight.position.set(-4, -6, -5)
+    scene.add(ambient)
+    scene.add(keyLight)
+    scene.add(backLight)
+
+    const model = createVehicleModel(vehicleId)
+    scene.add(model)
+
+    let frameId = 0
+    const renderLoop = () => {
+      model.rotation.y += 0.01
+      renderer.render(scene, camera)
+      frameId = requestAnimationFrame(renderLoop)
+    }
+    renderLoop()
+
+    const handleResize = () => {
+      const { clientWidth, clientHeight } = container
+      renderer.setSize(clientWidth, clientHeight)
+      camera.aspect = clientWidth / clientHeight
+      camera.updateProjectionMatrix()
+    }
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      cancelAnimationFrame(frameId)
+      window.removeEventListener('resize', handleResize)
+      scene.remove(model)
+      model.traverse((child) => {
+        if ('geometry' in child && child.geometry) {
+          child.geometry.dispose()
+        }
+        if ('material' in child) {
+          const material = child.material as THREE.Material | THREE.Material[]
+          if (Array.isArray(material)) {
+            material.forEach((entry) => entry.dispose())
+          } else {
+            material.dispose()
+          }
+        }
+      })
+      renderer.dispose()
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement)
+      }
+    }
+  }, [vehicleId])
+
+  return (
+    <div
+      aria-label={`${vehicleId} vehicle preview`}
+      className="vehicle-preview-frame"
+      data-testid={`vehicle-preview-${vehicleId}`}
+      ref={containerRef}
+      role="img"
+    />
+  )
+}

--- a/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/page.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/page.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { VEHICLE_DESCRIPTIONS, VEHICLE_IDS, VEHICLE_LABELS } from '../vehicles'
+
+vi.mock('./VehiclePreviewCanvas', () => ({
+  __esModule: true,
+  default: ({ vehicleId }: { vehicleId: string }) => <div data-testid={`mock-canvas-${vehicleId}`}>{vehicleId}</div>,
+}))
+
+describe('VehiclePreviewPage', () => {
+  it('displays a card for every registered vehicle', async () => {
+    const { default: VehiclePreviewPage } = await import('./page')
+    render(<VehiclePreviewPage />)
+    //1.- Ensure each vehicle has a dedicated preview card.
+    VEHICLE_IDS.forEach((vehicleId) => {
+      const card = screen.getByTestId(`vehicle-preview-card-${vehicleId}`)
+      expect(card).toBeTruthy()
+      expect(card.textContent).toContain(VEHICLE_LABELS[vehicleId])
+      expect(card.textContent).toContain(VEHICLE_DESCRIPTIONS[vehicleId])
+    })
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(VEHICLE_IDS.length)
+  })
+
+  it('delegates rendering to the preview canvas component', async () => {
+    const { default: VehiclePreviewPage } = await import('./page')
+    render(<VehiclePreviewPage />)
+    //1.- Verify the canvas stub is instantiated for each vehicle option.
+    VEHICLE_IDS.forEach((vehicleId) => {
+      expect(screen.getByTestId(`mock-canvas-${vehicleId}`)).toBeTruthy()
+    })
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/page.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { listVehicleModelDefinitions } from '../3dmodel/vehicles'
+import { VEHICLE_DESCRIPTIONS } from '../vehicles'
+import VehiclePreviewCanvas from './VehiclePreviewCanvas'
+
+export default function VehiclePreviewPage() {
+  //1.- Gather the fleet definitions once so the UI can iterate without recomputing geometry factories.
+  const vehicleDefinitions = listVehicleModelDefinitions()
+
+  return (
+    <main className="vehicle-preview-layout" data-testid="vehicle-preview-page">
+      <header className="vehicle-preview-intro">
+        <h1>Vehicle Preview Gallery</h1>
+        <p>
+          Tour the full fleet in an interactive bay. Each craft renders immediately so you can compare silhouettes
+          and canopy profiles before committing to a loadout.
+        </p>
+      </header>
+      <section aria-label="Vehicle previews" className="vehicle-preview-grid" data-testid="vehicle-preview-grid">
+        {vehicleDefinitions.map((definition) => (
+          <article className="vehicle-preview-card" data-testid={`vehicle-preview-card-${definition.id}`} key={definition.id}>
+            <h2>{definition.label}</h2>
+            {/* //2.- Delegate drawing to the dedicated canvas so each card manages its own renderer lifecycle. */}
+            <VehiclePreviewCanvas vehicleId={definition.id} />
+            <p>{VEHICLE_DESCRIPTIONS[definition.id]}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/tunnelcave_sandbox_web/app/gameplay/world/page.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/world/page.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SHARED_WORLD_SEED } from '../worldLobby'
+
+const generateBattlefieldMock = vi.fn(() => ({
+  fieldSize: 400,
+  spawnPoint: { x: 0, y: 0, z: 0 },
+}) as unknown)
+
+vi.mock('../generateBattlefield', () => ({
+  generateBattlefield: (...args: unknown[]) => generateBattlefieldMock(...args),
+}))
+
+vi.mock('../BattlefieldCanvas', () => ({
+  __esModule: true,
+  default: ({ playerName, vehicleId }: { playerName: string; vehicleId: string }) => (
+    <div data-testid="mock-world-canvas">
+      {playerName}-{vehicleId}
+    </div>
+  ),
+}))
+
+describe('WorldExplorerPage', () => {
+  it('mounts the battlefield immediately with the spectator defaults', async () => {
+    const { default: WorldExplorerPage } = await import('./page')
+    render(<WorldExplorerPage />)
+    //1.- Confirm the sandbox renders without prompting for player metadata.
+    expect(screen.getByTestId('world-explorer-page')).toBeTruthy()
+    expect(screen.getByTestId('mock-world-canvas').textContent).toContain('Cavern Explorer')
+  })
+
+  it('shares the procedural terrain seed with the main lobby', async () => {
+    const { default: WorldExplorerPage } = await import('./page')
+    render(<WorldExplorerPage />)
+    //1.- Ensure the same battlefield seed is used so exploration matches the combat environment.
+    expect(generateBattlefieldMock).toHaveBeenCalledWith(SHARED_WORLD_SEED)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/world/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/world/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import React, { useMemo } from 'react'
+
+import BattlefieldCanvas from '../BattlefieldCanvas'
+import { generateBattlefield } from '../generateBattlefield'
+import { createPlayerSessionId } from '../playerSession'
+import { VEHICLE_IDS } from '../vehicles'
+import { SHARED_WORLD_SEED } from '../worldLobby'
+
+const DEFAULT_EXPLORER_NAME = 'Cavern Explorer'
+const DEFAULT_EXPLORER_VEHICLE = VEHICLE_IDS[0]
+
+export default function WorldExplorerPage() {
+  //1.- Memoise the battlefield so the free-roam scene remains stable between re-renders.
+  const battlefield = useMemo(() => generateBattlefield(SHARED_WORLD_SEED), [])
+  //2.- Allocate a light-weight spectator identifier to satisfy systems expecting a session id.
+  const sessionId = useMemo(() => createPlayerSessionId(), [])
+
+  return (
+    <main className="world-explorer-layout" data-testid="world-explorer-page">
+      <header className="world-explorer-intro">
+        <h1>World Explorer</h1>
+        <p>
+          Drift freely through the shared cavern without committing to the combat roster. This sandbox loads
+          instantly with a spectator handle so you can focus on surveying the landscape.
+        </p>
+      </header>
+      <section aria-label="Free roam canvas" className="world-explorer-canvas" data-testid="world-explorer-canvas">
+        {/* //3.- Mount the same battlefield renderer but seed it with a default spectator profile. */}
+        <BattlefieldCanvas
+          config={battlefield}
+          playerName={DEFAULT_EXPLORER_NAME}
+          sessionId={sessionId}
+          vehicleId={DEFAULT_EXPLORER_VEHICLE}
+        />
+      </section>
+    </main>
+  )
+}

--- a/tunnelcave_sandbox_web/test/mocks/three.ts
+++ b/tunnelcave_sandbox_web/test/mocks/three.ts
@@ -48,6 +48,20 @@ export class Vector3 {
     this.z += (target.z - this.z) * alpha
     return this
   }
+
+  lengthSq(): number {
+    //1.- Provide squared length calculations so terrain sampling logic can detect zero vectors.
+    return this.x * this.x + this.y * this.y + this.z * this.z
+  }
+
+  normalize(): this {
+    //2.- Normalise the vector while guarding against division by zero for deterministic slopes.
+    const length = Math.sqrt(this.lengthSq()) || 1
+    this.x /= length
+    this.y /= length
+    this.z /= length
+    return this
+  }
 }
 
 export class Euler {
@@ -377,6 +391,27 @@ export class SphereGeometry extends BufferGeometry {
 export class ConeGeometry extends BufferGeometry {
   //1.- Capture cone dimensions for stalactite generation assertions.
   constructor(public radius: number, public height: number, public radialSegments: number) {
+    super()
+  }
+}
+
+export class BoxGeometry extends BufferGeometry {
+  //1.- Record box dimensions so previews can inspect fuselage proportions.
+  constructor(public width: number, public height: number, public depth: number) {
+    super()
+  }
+}
+
+export class CylinderGeometry extends BufferGeometry {
+  //1.- Track top/bottom radii for glider fuselage approximations.
+  constructor(public radiusTop: number, public radiusBottom: number, public height: number, public radialSegments: number) {
+    super()
+  }
+}
+
+export class CapsuleGeometry extends BufferGeometry {
+  //1.- Persist capsule parameters so heavy escort meshes can be asserted without full geometry buffers.
+  constructor(public radius: number, public length: number, public capSegments: number, public radialSegments: number) {
     super()
   }
 }


### PR DESCRIPTION
## Summary
- add a world explorer gameplay route that launches the battlefield sandbox without requiring lobby input
- build a vehicle preview gallery backed by lightweight three.js models for each craft
- extend the three.js test stub and add coverage for the new explorer and preview views

## Testing
- npm test --prefix tunnelcave_sandbox_web

------
https://chatgpt.com/codex/tasks/task_e_68e3336d0bec8329bf7f21e5c05bcb27