### PR TITLE
feat: add planetary battlefield lighting and boosted flight

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/createPlanetShell.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/createPlanetShell.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('createPlanetShell', () => {
+  it('creates a back-faced sphere sized to the requested radius', async () => {
+    vi.resetModules()
+    const geometryDispose = vi.fn()
+    const materialDispose = vi.fn()
+    class StubSphereGeometry {
+      parameters: { radius: number }
+      type = 'SphereGeometry'
+      constructor(radius: number) {
+        this.parameters = { radius }
+      }
+      dispose = geometryDispose
+    }
+    class StubMeshStandardMaterial {
+      side: unknown
+      constructor(options: { side: unknown }) {
+        this.side = options.side
+      }
+      dispose = materialDispose
+    }
+    class StubMesh {
+      name = ''
+      constructor(public geometry: StubSphereGeometry, public material: StubMeshStandardMaterial) {}
+    }
+    class StubColor {
+      constructor(public value: unknown) {}
+    }
+    const stub = {
+      SphereGeometry: StubSphereGeometry,
+      MeshStandardMaterial: StubMeshStandardMaterial,
+      Mesh: StubMesh,
+      Color: StubColor,
+      BackSide: 'back-face',
+    }
+    vi.doMock('three', () => stub)
+    const { createPlanetShell } = await import('./createPlanetShell')
+    const { mesh, dispose } = createPlanetShell({
+      radius: 180,
+      color: 0x0b1d3b,
+      emissive: 0x112b58,
+      opacity: 0.82,
+    })
+    //1.- Ensure the geometry uses the spherical primitive requested for the planetary enclosure.
+    expect((mesh.geometry as StubSphereGeometry).parameters.radius).toBe(180)
+    //2.- Confirm the material renders the interior faces to keep the shell from hiding gameplay elements.
+    expect((mesh.material as StubMeshStandardMaterial).side).toBe('back-face')
+    dispose()
+    expect(geometryDispose).toHaveBeenCalled()
+    expect(materialDispose).toHaveBeenCalled()
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/createPlanetShell.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/createPlanetShell.ts
@@ -1,0 +1,39 @@
+import * as THREE from 'three'
+
+export interface PlanetShellOptions {
+  radius: number
+  color: THREE.ColorRepresentation
+  emissive: THREE.ColorRepresentation
+  opacity: number
+}
+
+export interface PlanetShell {
+  mesh: THREE.Mesh
+  dispose: () => void
+}
+
+export function createPlanetShell(options: PlanetShellOptions): PlanetShell {
+  //1.- Sculpt a hollow sphere that envelopes the battlefield so the cavern reads as a planetary interior.
+  const geometry = new THREE.SphereGeometry(options.radius, 48, 32)
+  //2.- Tint the shell with a subtle emissive glow and render only the inner faces to avoid occluding the scene.
+  const material = new THREE.MeshStandardMaterial({
+    color: options.color,
+    emissive: new THREE.Color(options.emissive),
+    side: THREE.BackSide,
+    transparent: true,
+    opacity: options.opacity,
+    metalness: 0.15,
+    roughness: 0.7,
+  })
+  const mesh = new THREE.Mesh(geometry, material)
+  mesh.name = 'planet-shell'
+  return {
+    mesh,
+    dispose: () => {
+      //3.- Release GPU buffers when the shell is removed so hot reloads do not leak memory.
+      geometry.dispose()
+      material.dispose()
+    },
+  }
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/lightOrbs.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/lightOrbs.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('light orbs', () => {
+  const installThreeStub = () => {
+    class StubVector3 {
+      constructor(public x = 0, public y = 0, public z = 0) {}
+      copy(vector: StubVector3): StubVector3 {
+        this.x = vector.x
+        this.y = vector.y
+        this.z = vector.z
+        return this
+      }
+      setScalar(value: number): StubVector3 {
+        this.x = value
+        this.y = value
+        this.z = value
+        return this
+      }
+    }
+    class StubObject3D {
+      type = 'Object3D'
+      position = new StubVector3()
+      children: StubObject3D[] = []
+      add(child: StubObject3D): void {
+        this.children.push(child)
+      }
+    }
+    class StubGroup extends StubObject3D {
+      override type = 'Group'
+    }
+    class StubMesh extends StubObject3D {
+      override type = 'Mesh'
+      scale = new StubVector3(1, 1, 1)
+      constructor(public geometry: unknown, public material: unknown) {
+        super()
+      }
+    }
+    class StubPointLight extends StubObject3D {
+      override type = 'PointLight'
+      constructor(public color: unknown, public intensity: number, public distance: number, public decay: number) {
+        super()
+      }
+    }
+    class StubSphereGeometry {}
+    class StubMeshBasicMaterial {}
+    class StubColor {
+      constructor(public value: unknown) {}
+    }
+    const stub = {
+      Vector3: StubVector3,
+      Group: StubGroup,
+      Mesh: StubMesh,
+      PointLight: StubPointLight,
+      SphereGeometry: StubSphereGeometry,
+      MeshBasicMaterial: StubMeshBasicMaterial,
+      Color: StubColor,
+    }
+    vi.doMock('three', () => stub)
+    return stub
+  }
+
+  it('generates deterministic orb placements within the battlefield bounds', async () => {
+    vi.resetModules()
+    installThreeStub()
+    const { generateOrbSpecifications } = await import('./lightOrbs')
+    const specs = generateOrbSpecifications({
+      seed: 42,
+      fieldSize: 400,
+      altitudeRange: { min: 6, max: 22 },
+      radiusRange: { min: 1.2, max: 3 },
+      count: 6,
+    })
+    //1.- Confirm the generator returns the requested number of placements.
+    expect(specs).toHaveLength(6)
+    //2.- Validate the placements fall inside the planetary volume and stay above the floor plane.
+    specs.forEach((spec) => {
+      expect(Math.hypot(spec.position.x, spec.position.z)).toBeLessThanOrEqual(400 * 0.5)
+      expect(spec.position.y).toBeGreaterThanOrEqual(6)
+      expect(spec.position.y).toBeLessThanOrEqual(22)
+    })
+    //3.- Ensure the same seed reproduces identical positions for synchronised lighting between clients.
+    const repeat = generateOrbSpecifications({
+      seed: 42,
+      fieldSize: 400,
+      altitudeRange: { min: 6, max: 22 },
+      radiusRange: { min: 1.2, max: 3 },
+      count: 6,
+    })
+    repeat.forEach((spec, index) => {
+      expect(spec.position.x).toBeCloseTo(specs[index].position.x)
+      expect(spec.position.y).toBeCloseTo(specs[index].position.y)
+      expect(spec.position.z).toBeCloseTo(specs[index].position.z)
+    })
+  })
+
+  it('creates a disposable group so the orb field can be torn down cleanly', async () => {
+    vi.resetModules()
+    const stub = installThreeStub()
+    const { generateOrbSpecifications, createOrbField } = await import('./lightOrbs')
+    const specs = generateOrbSpecifications({
+      seed: 7,
+      fieldSize: 300,
+      altitudeRange: { min: 5, max: 15 },
+      radiusRange: { min: 1, max: 2 },
+      count: 2,
+    })
+    const { group } = createOrbField(specs)
+    //1.- Verify each spec creates a matching point light within the group hierarchy.
+    const lightCount = group.children.filter((child) => child.type === 'PointLight').length
+    expect(lightCount).toBe(specs.length)
+    expect(stub.PointLight).toBeDefined()
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/lightOrbs.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/lightOrbs.ts
@@ -1,0 +1,118 @@
+import * as THREE from 'three'
+
+interface MulberryRandom {
+  (): number
+}
+
+function mulberry32(seed: number): MulberryRandom {
+  //1.- Recreate the deterministic RNG from other systems so orb placement is reproducible across clients.
+  let t = seed >>> 0
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0
+    let r = Math.imul(t ^ (t >>> 15), t | 1)
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61)
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export interface OrbSpecification {
+  position: THREE.Vector3
+  radius: number
+  intensity: number
+  color: THREE.Color
+}
+
+export interface OrbGeneratorOptions {
+  seed: number
+  fieldSize: number
+  altitudeRange: { min: number; max: number }
+  radiusRange: { min: number; max: number }
+  count: number
+}
+
+function hslToColor(h: number, s: number, l: number): THREE.Color {
+  //1.- Convert HSL to RGB manually so the generator works in headless test environments lacking setHSL helpers.
+  const hue = ((h % 1) + 1) % 1
+  if (s === 0) {
+    return new THREE.Color(l, l, l)
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  const hueComponent = (t: number) => {
+    let channel = t
+    if (channel < 0) {
+      channel += 1
+    }
+    if (channel > 1) {
+      channel -= 1
+    }
+    if (channel < 1 / 6) {
+      return p + (q - p) * 6 * channel
+    }
+    if (channel < 1 / 2) {
+      return q
+    }
+    if (channel < 2 / 3) {
+      return p + (q - p) * (2 / 3 - channel) * 6
+    }
+    return p
+  }
+  return new THREE.Color(hueComponent(hue + 1 / 3), hueComponent(hue), hueComponent(hue - 1 / 3))
+}
+
+export function generateOrbSpecifications(options: OrbGeneratorOptions): OrbSpecification[] {
+  //2.- Generate soft illumination anchors distributed around the battlefield to support visibility while flying.
+  const random = mulberry32(options.seed)
+  const half = options.fieldSize / 2
+  const specs: OrbSpecification[] = []
+  for (let index = 0; index < options.count; index += 1) {
+    const angle = random() * Math.PI * 2
+    const distance = (0.35 + random() * 0.6) * half
+    const x = Math.cos(angle) * distance
+    const z = Math.sin(angle) * distance
+    const altitude = options.altitudeRange.min +
+      random() * Math.max(0, options.altitudeRange.max - options.altitudeRange.min)
+    const radius = options.radiusRange.min +
+      random() * Math.max(0, options.radiusRange.max - options.radiusRange.min)
+    const color = hslToColor(0.55 + random() * 0.15, 0.6, 0.6 + random() * 0.2)
+    const intensity = 2.6 + random() * 1.8
+    specs.push({ position: new THREE.Vector3(x, altitude, z), radius, intensity, color })
+  }
+  return specs
+}
+
+export interface OrbField {
+  group: THREE.Group
+  dispose: () => void
+}
+
+export function createOrbField(specs: OrbSpecification[]): OrbField {
+  //3.- Convert the orb specifications into point lights with emissive meshes so the scene inherits ambient glow.
+  const group = new THREE.Group()
+  const sphereGeometry = new THREE.SphereGeometry(1, 12, 12)
+  specs.forEach((spec) => {
+    const light = new THREE.PointLight(spec.color, spec.intensity, spec.radius * 20, 2)
+    light.position.copy(spec.position)
+    const material = new THREE.MeshBasicMaterial({ color: spec.color, transparent: true, opacity: 0.8 })
+    const orb = new THREE.Mesh(sphereGeometry, material)
+    orb.scale.setScalar(spec.radius)
+    orb.position.copy(spec.position)
+    group.add(light)
+    group.add(orb)
+  })
+  return {
+    group,
+    dispose: () => {
+      //4.- Dispose the shared geometry and all dynamically created materials once the orb field is removed.
+      const materials = new Set<THREE.Material>()
+      group.traverse((child) => {
+        if (child instanceof THREE.Mesh) {
+          materials.add(child.material as THREE.Material)
+        }
+      })
+      materials.forEach((material) => material.dispose())
+      sphereGeometry.dispose()
+    },
+  }
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/rocks/createRockGeometry.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/rocks/createRockGeometry.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('createRockGeometry', () => {
+  it('produces indexed geometries with stable noise displacement', async () => {
+    vi.resetModules()
+    class StubBufferAttribute {
+      array: Float32Array
+      itemSize: number
+      count: number
+      constructor(array: number[], itemSize: number) {
+        this.array = Float32Array.from(array)
+        this.itemSize = itemSize
+        this.count = this.array.length / itemSize
+      }
+      setXYZ(index: number, x: number, y: number, z: number): void {
+        const offset = index * this.itemSize
+        this.array[offset] = x
+        this.array[offset + 1] = y
+        this.array[offset + 2] = z
+      }
+      getX(index: number): number {
+        return this.array[index * this.itemSize]
+      }
+      getY(index: number): number {
+        return this.array[index * this.itemSize + 1]
+      }
+      getZ(index: number): number {
+        return this.array[index * this.itemSize + 2]
+      }
+    }
+    class StubBufferGeometry {
+      type = 'BufferGeometry'
+      attributes: Record<string, StubBufferAttribute> = {}
+      index: number[] | null = null
+      setAttribute(name: string, attribute: StubBufferAttribute): void {
+        this.attributes[name] = attribute
+      }
+      getAttribute(name: string): StubBufferAttribute {
+        return this.attributes[name]
+      }
+      setIndex(value: number[] | null): void {
+        this.index = value
+      }
+      toNonIndexed(): this {
+        this.index = null
+        return this
+      }
+      clone(): StubBufferGeometry {
+        const clone = new StubBufferGeometry()
+        clone.attributes = { ...this.attributes }
+        clone.index = this.index ? [...this.index] : null
+        return clone
+      }
+      computeVertexNormals(): void {}
+    }
+    class StubBoxGeometry extends StubBufferGeometry {
+      constructor() {
+        super()
+        this.type = 'BoxGeometry'
+        this.setAttribute('position', new StubBufferAttribute(Array(24 * 3).fill(0), 3))
+      }
+    }
+    class StubCylinderGeometry extends StubBufferGeometry {
+      constructor() {
+        super()
+        this.type = 'CylinderGeometry'
+        this.setAttribute('position', new StubBufferAttribute(Array(24 * 3).fill(0), 3))
+      }
+    }
+    class StubIcosahedronGeometry extends StubBufferGeometry {
+      constructor() {
+        super()
+        this.type = 'IcosahedronGeometry'
+        this.setAttribute('position', new StubBufferAttribute(Array(20 * 3).fill(0), 3))
+      }
+    }
+    const stub = {
+      BufferGeometry: StubBufferGeometry,
+      BufferAttribute: StubBufferAttribute,
+      BoxGeometry: StubBoxGeometry,
+      CylinderGeometry: StubCylinderGeometry,
+      IcosahedronGeometry: StubIcosahedronGeometry,
+      MathUtils: { degToRad: (degrees: number) => (degrees * Math.PI) / 180 },
+    }
+    vi.doMock('three', () => stub)
+    const { assetRegistry } = await import('../assets/assetCatalog')
+    const { createRockGeometry } = await import('./createRockGeometry')
+    const geometry = createRockGeometry(0, 101, assetRegistry)
+    const repeat = createRockGeometry(0, 101, assetRegistry)
+    const positions = geometry.getAttribute('position')
+    const repeatPositions = repeat.getAttribute('position')
+    expect(positions.count).toBe(repeatPositions.count)
+    for (let index = 0; index < positions.count; index += 1) {
+      expect(positions.getX(index)).toBeCloseTo(repeatPositions.getX(index))
+      expect(positions.getY(index)).toBeCloseTo(repeatPositions.getY(index))
+      expect(positions.getZ(index)).toBeCloseTo(repeatPositions.getZ(index))
+    }
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/rocks/createRockGeometry.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/rocks/createRockGeometry.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three'
+
+import type { BattlefieldConfig } from '../generateBattlefield'
+
+function mulberry32(seed: number) {
+  //1.- Match the deterministic random generator used elsewhere so geometry stays stable across sessions.
+  let t = seed >>> 0
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0
+    let r = Math.imul(t ^ (t >>> 15), t | 1)
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61)
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export function createRockGeometry(
+  archetypeIndex: number,
+  seed: number,
+  assets: BattlefieldConfig['assets'],
+): THREE.BufferGeometry {
+  //2.- Build base primitives and displace vertices with noise to generate believable rock silhouettes.
+  const archetype = assets.rocks[archetypeIndex]
+  let geometry: THREE.BufferGeometry
+  if (archetype.geometry === 'box') {
+    geometry = new THREE.BoxGeometry(1, 1, 1, 2, 2, 2)
+  } else if (archetype.geometry === 'cylinder') {
+    geometry = new THREE.CylinderGeometry(1, 1, 1, 8, 4)
+  } else {
+    geometry = new THREE.IcosahedronGeometry(1, 1)
+  }
+  if (typeof (geometry as THREE.BufferGeometry).toNonIndexed === 'function') {
+    geometry = (geometry as THREE.BufferGeometry).toNonIndexed()
+  } else if (geometry.index) {
+    //3.- Fallback for environments missing toNonIndexed so instancing still receives unique vertices.
+    geometry = geometry.clone()
+    geometry.setIndex(null)
+  }
+  const random = mulberry32(seed)
+  const positions = geometry.getAttribute('position') as THREE.BufferAttribute
+  for (let index = 0; index < positions.count; index += 1) {
+    const nx = random() * 2 - 1
+    const ny = random() * 2 - 1
+    const nz = random() * 2 - 1
+    const displacement = (random() * 0.5 + 0.5) * archetype.noiseAmplitude
+    positions.setXYZ(
+      index,
+      positions.getX(index) + nx * displacement,
+      positions.getY(index) + ny * displacement,
+      positions.getZ(index) + nz * displacement,
+    )
+  }
+  positions.needsUpdate = true
+  geometry.computeVertexNormals()
+  return geometry
+}
+


### PR DESCRIPTION
## Summary
- wrap the battlefield scene with a glowing planetary shell and deterministic light orbs for better visibility
- tune the vehicle controller to support boosted ascents and optional terrain penetration for the planetary map mode
- extract reusable rock geometry helpers and add focused tests for the new planetary utilities and movement behaviour

## Testing
- pnpm vitest run app/gameplay/planet/createPlanetShell.test.ts app/gameplay/planet/lightOrbs.test.ts app/gameplay/rocks/createRockGeometry.test.ts
- pnpm vitest run app/gameplay/vehicleController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3431478608329b521fef6f46f8761