### PR TITLE
Fix vehicle preview cleanup type guard

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/VehiclePreviewCanvas.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicle-preview/VehiclePreviewCanvas.test.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { isMeshLikeObject } from './VehiclePreviewCanvas'
+
 const createVehicleModelMock = vi.fn(() => new THREE.Group())
 
 vi.mock('../3dmodel/vehicles', () => ({
@@ -17,5 +19,27 @@ describe('VehiclePreviewCanvas', () => {
     const frame = screen.getByTestId('vehicle-preview-arrowhead')
     expect(frame.dataset.webgl).toBe('unavailable')
     expect(frame.textContent).toContain('Interactive preview unavailable in this environment.')
+  })
+})
+
+describe('isMeshLikeObject', () => {
+  it('recognises mesh-derived primitives that expose disposable resources', () => {
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial())
+    //1.- Confirm the helper acknowledges meshes so cleanup logic can release their buffers and materials.
+    expect(isMeshLikeObject(mesh)).toBe(true)
+    const geometry = mesh.geometry as { dispose?: () => void }
+    if (typeof geometry.dispose === 'function') {
+      geometry.dispose()
+    }
+    const material = mesh.material as { dispose?: () => void }
+    if (typeof material.dispose === 'function') {
+      material.dispose()
+    }
+  })
+
+  it('rejects generic scene graph nodes without disposable geometry', () => {
+    const object = new THREE.Object3D()
+    //1.- Ensure scene graph nodes without geometry are ignored to prevent runtime errors.
+    expect(isMeshLikeObject(object)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- add a reusable helper to check for mesh-like objects and dispose geometry/material only when the API is available
- cover the new mesh guard with Vitest unit tests to ensure the cleanup remains safe in mocked environments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3472862808329a55e3664b34859c7