### PR TITLE
feat: render minimap as planet sphere

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.test.tsx
@@ -24,4 +24,17 @@ describe('MiniMapOverlay', () => {
     expect(legend.textContent).toContain('Wing One')
     expect(legend.textContent).toContain('Wing Two')
   })
+
+  it('renders a spherical backdrop with a gradient clip mask', () => {
+    const { container } = render(<MiniMapOverlay fieldSize={200} peers={[]} player={{ x: 0, z: 0 }} />)
+    const background = container.querySelector('circle.hud-minimap__background')
+    expect(background).not.toBeNull()
+    expect(background?.getAttribute('fill')).toBe('url(#hud-minimap-planet-gradient)')
+    const gradient = container.querySelector('radialGradient#hud-minimap-planet-gradient')
+    expect(gradient).not.toBeNull()
+    const clipPath = container.querySelector('clipPath#hud-minimap-planet-clip')
+    expect(clipPath).not.toBeNull()
+    const entityGroup = container.querySelector('g[data-testid="minimap-entities"]')
+    expect(entityGroup?.getAttribute('clip-path')).toBe('url(#hud-minimap-planet-clip)')
+  })
 })

--- a/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/miniMapOverlay.tsx
@@ -20,6 +20,11 @@ export interface MiniMapOverlayProps {
   peers: MiniMapEntitySnapshot[]
 }
 
+//1.- Unique ID for the minimap planet gradient so multiple overlays do not clash in the DOM.
+const PLANET_GRADIENT_ID = 'hud-minimap-planet-gradient'
+//2.- Clip path identifier ensuring entity markers respect the spherical boundary.
+const PLANET_CLIP_ID = 'hud-minimap-planet-clip'
+
 function clampPercent(value: number): number {
   //1.- Restrict percentages into the drawable SVG range to avoid rendering artefacts.
   return Math.min(100, Math.max(0, value))
@@ -39,33 +44,50 @@ export function MiniMapOverlay({ fieldSize, player, peers }: MiniMapOverlayProps
   //1.- Convert world coordinates into map percentages for the player marker.
   const playerX = normaliseCoordinate(player.x, fieldSize)
   const playerY = 100 - normaliseCoordinate(player.z, fieldSize)
+  //2.- Prepare a reusable circle geometry definition so gradients and clip paths stay consistent.
+  const planetCircle = <circle cx="50" cy="50" r="48" />
   return (
     <section aria-label="Battlefield minimap" className="hud-minimap" data-testid="hud-minimap">
       <svg className="hud-minimap__canvas" viewBox="0 0 100 100">
-        {/* 1.- Draw the map background with rounded corners so the overlay fits the HUD theme. */}
-        <rect className="hud-minimap__background" height="100" rx="10" ry="10" width="100" x="0" y="0" />
-        {/* 2.- Render peer markers before the player so the local pilot always sits on top. */}
-        {peers.map((peer) => {
-          const peerX = normaliseCoordinate(peer.x, fieldSize)
-          const peerY = 100 - normaliseCoordinate(peer.z, fieldSize)
-          return (
-            <circle
-              className="hud-minimap__peer"
-              cx={peerX}
-              cy={peerY}
-              data-label={peer.label}
-              data-player-id={peer.id}
-              data-testid="minimap-peer"
-              key={peer.id}
-              r={4}
-            />
-          )
+        <defs>
+          {/* 1.- Paint a subtle radial gradient so the minimap reads as a glowing planet. */}
+          <radialGradient cx="50%" cy="42%" id={PLANET_GRADIENT_ID} r="75%">
+            <stop offset="0%" stopColor="#1e3a8a" stopOpacity="0.95" />
+            <stop offset="55%" stopColor="#172554" stopOpacity="0.92" />
+            <stop offset="100%" stopColor="#0f172a" stopOpacity="0.88" />
+          </radialGradient>
+          {/* 2.- Reuse the same circle for clipping so entity markers remain inside the planetary silhouette. */}
+          <clipPath id={PLANET_CLIP_ID}>{planetCircle}</clipPath>
+        </defs>
+        {/* 3.- Render the atmospheric glow circle first so markers sit on top of the planet body. */}
+        {React.cloneElement(planetCircle, {
+          className: 'hud-minimap__background',
+          fill: `url(#${PLANET_GRADIENT_ID})`,
         })}
-        {/* 3.- Highlight the local craft marker with a larger radius. */}
-        <circle className="hud-minimap__player" cx={playerX} cy={playerY} data-testid="minimap-player" r={6} />
+        <g clipPath={`url(#${PLANET_CLIP_ID})`} data-testid="minimap-entities">
+          {/* 4.- Render peer markers before the player so the local pilot always sits on top. */}
+          {peers.map((peer) => {
+            const peerX = normaliseCoordinate(peer.x, fieldSize)
+            const peerY = 100 - normaliseCoordinate(peer.z, fieldSize)
+            return (
+              <circle
+                className="hud-minimap__peer"
+                cx={peerX}
+                cy={peerY}
+                data-label={peer.label}
+                data-player-id={peer.id}
+                data-testid="minimap-peer"
+                key={peer.id}
+                r={4}
+              />
+            )
+          })}
+          {/* 5.- Highlight the local craft marker with a larger radius. */}
+          <circle className="hud-minimap__player" cx={playerX} cy={playerY} data-testid="minimap-player" r={6} />
+        </g>
       </svg>
       <div className="hud-minimap__legend" data-testid="minimap-legend">
-        {/* 4.- Label the legend entries so pilots can correlate markers to callsigns. */}
+        {/* 6.- Label the legend entries so pilots can correlate markers to callsigns. */}
         <p className="hud-minimap__legend-title">Formation</p>
         <ul className="hud-minimap__legend-list">
           <li className="hud-minimap__legend-item">You</li>

--- a/tunnelcave_sandbox_web/app/globals.css
+++ b/tunnelcave_sandbox_web/app/globals.css
@@ -230,8 +230,7 @@ body {
 }
 
 .hud-minimap__background {
-  /* 1.- Apply subtle styling so the battlefield outline remains legible. */
-  fill: rgba(30, 41, 59, 0.85);
+  /* 1.- Outline the spherical minimap while allowing the SVG gradient to supply the fill. */
   stroke: rgba(148, 163, 184, 0.4);
   stroke-width: 1.5;
 }


### PR DESCRIPTION
## Summary
- render the HUD minimap on a radial-gradient planet with a clipping mask
- update HUD styling to outline the new spherical minimap presentation
- add coverage confirming the gradient background and clip path are produced

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e349c8e5d883299aeb95a4ffe33859