### PR TITLE
Model terrain on spherical planet

### DIFF
--- a/tunnelcave_sandbox/tests/test_gameplay_terrain.py
+++ b/tunnelcave_sandbox/tests/test_gameplay_terrain.py
@@ -30,3 +30,36 @@ def test_sampler_distinguishes_biomes_by_seed() -> None:
     assert sample_a.biome in {"plains", "forest", "alpine", "lakeshore"}
     # Seeds should decorrelate biomes for the same coordinates.
     assert sample_a.biome != sample_b.biome or sample_a.ground_height != sample_b.ground_height
+
+
+def test_sampler_ground_hugs_planet_shell() -> None:
+    sampler = TerrainSampler(9)
+    x, z = 320.0, -240.0
+    sample = sampler.sample(x, z)
+    center = sampler.planet_center
+    # //1.- Compute the analytical shell height to confirm the sampler tracks the spherical planet.
+    dx = x - center[0]
+    dz = z - center[2]
+    shell_height = center[1] + math.sqrt(max(sampler.planet_radius ** 2 - dx * dx - dz * dz, 0.0))
+    deviation = abs(sample.ground_height - shell_height)
+    # //2.- Allow for procedural noise while requiring the deviation to stay within mountain amplitude.
+    assert deviation <= 70.0
+
+
+def test_sampler_normal_points_outward_from_planet_center() -> None:
+    sampler = TerrainSampler(21)
+    x, z = -180.0, 410.0
+    sample = sampler.sample(x, z)
+    center = sampler.planet_center
+    # //1.- Build the radial direction from the planet center to the surface point.
+    radial = (
+        x - center[0],
+        sample.ground_height - center[1],
+        z - center[2],
+    )
+    length = math.sqrt(sum(component * component for component in radial))
+    assert length > 0.0
+    radial_normal = tuple(component / length for component in radial)
+    alignment = sum(a * b for a, b in zip(sample.surface_normal, radial_normal))
+    # //2.- Require normals to closely align with the radial vector for a convincing spherical planet.
+    assert alignment > 0.9


### PR DESCRIPTION
## Summary
- reshape the tunnelcave terrain sampler so its heights follow a configurable spherical planet shell
- expose the planet radius and center while keeping lakes, ceilings, and normals aligned with the new curvature
- add regression tests that confirm samples hug the planet interior and normals point outward

## Testing
- pytest tunnelcave_sandbox/tests/test_gameplay_terrain.py
- pytest tunnelcave_sandbox/tests


------
https://chatgpt.com/codex/tasks/task_e_68e34bf27f808329a2543f87bf169153