### PR TITLE
Implement PlanetSpec loader and validation tests

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  PlanetSpecValidationError,
+  createPlanetConfiguration,
+  loadPlanetConfiguration,
+  loadPlanetConfigurationFromJson,
+  parsePlanetSpec,
+} from './planetSpecLoader'
+
+describe('planetSpecLoader', () => {
+  it('parses raw JSON objects into immutable PlanetSpecs', () => {
+    //1.- Compose a representative payload that mirrors the PlanetSpec contract.
+    const raw = {
+      seed: 1337,
+      radii: [180, 185, 200],
+      frequencies: [0.25, 0.5, 1.0],
+      amplitudes: [12, 6, 2],
+      lodThresholds: [0.08, 0.04, 0.02],
+    }
+    //2.- Execute the parser to normalise shape and freeze arrays for sharing across systems.
+    const spec = parsePlanetSpec(raw)
+    expect(spec.seed).toBe(1337)
+    expect(spec.radii).toEqual([180, 185, 200])
+    expect(Object.isFrozen(spec.radii)).toBe(true)
+    expect(spec.frequencies).toEqual([0.25, 0.5, 1.0])
+    expect(spec.amplitudes).toEqual([12, 6, 2])
+    expect(spec.lodThresholds).toEqual([0.08, 0.04, 0.02])
+  })
+
+  it('refuses to parse when amplitude and frequency counts diverge', () => {
+    //1.- Deliver a malformed payload with mismatched FBM layers.
+    const raw = {
+      seed: 42,
+      radii: [100],
+      frequencies: [1, 2],
+      amplitudes: [3],
+      lodThresholds: [0.1],
+    }
+    //2.- Verify the loader surfaces a targeted validation error for the caller.
+    expect(() => parsePlanetSpec(raw)).toThrow(PlanetSpecValidationError)
+  })
+
+  it('creates deterministic configuration bundles from parsed specs', () => {
+    //1.- Build a valid spec and produce the runtime configuration view.
+    const raw = {
+      seed: 9001,
+      radii: [210, 240],
+      frequencies: [0.4, 0.8],
+      amplitudes: [5.5, 2.75],
+      lodThresholds: [0.12, 0.06],
+    }
+    const spec = parsePlanetSpec(raw)
+    const configuration = createPlanetConfiguration(spec)
+    //2.- Confirm noise layers pair amplitudes and frequencies while keeping slices immutable.
+    expect(configuration).toEqual({
+      seed: 9001,
+      radii: spec.radii,
+      noiseLayers: [
+        { frequency: 0.4, amplitude: 5.5 },
+        { frequency: 0.8, amplitude: 2.75 },
+      ],
+      lodThresholds: spec.lodThresholds,
+    })
+    expect(Object.isFrozen(configuration.noiseLayers)).toBe(true)
+  })
+
+  it('parses PlanetSpecs from JSON strings', () => {
+    //1.- Provide a JSON document as it would be shipped from disk.
+    const json = JSON.stringify({
+      seed: 77,
+      radii: [150],
+      frequencies: [0.6],
+      amplitudes: [4.2],
+      lodThresholds: [0.05],
+    })
+    //2.- Ensure loader surfaces the composed configuration and respects the numeric payload.
+    const configuration = loadPlanetConfigurationFromJson(json)
+    expect(configuration.seed).toBe(77)
+    expect(configuration.radii).toEqual([150])
+  })
+
+  it('raises a descriptive error on invalid JSON syntax', () => {
+    //1.- Attempt to parse a broken payload to ensure syntax feedback is actionable.
+    expect(() => loadPlanetConfigurationFromJson('{"seed"')).toThrow(PlanetSpecValidationError)
+  })
+
+  it('fetches PlanetSpecs over HTTP using a caller supplied fetch implementation', async () => {
+    //1.- Prepare a deterministic fetch stub that returns a viable specification document.
+    const fetchStub = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        seed: 314,
+        radii: [175, 190],
+        frequencies: [0.3, 0.9],
+        amplitudes: [8, 3],
+        lodThresholds: [0.07, 0.035],
+      }),
+    }))
+    //2.- Load the configuration and verify the fetch call contract and parsed data.
+    const configuration = await loadPlanetConfiguration('/planet/spec.json', fetchStub)
+    expect(fetchStub).toHaveBeenCalledWith('/planet/spec.json')
+    expect(configuration.noiseLayers).toEqual([
+      { frequency: 0.3, amplitude: 8 },
+      { frequency: 0.9, amplitude: 3 },
+    ])
+  })
+
+  it('reports network failures with the HTTP status text', async () => {
+    //1.- Simulate an HTTP error to ensure the loader emits actionable diagnostics.
+    const fetchStub = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    }))
+    //2.- Confirm the rejected promise propagates as a PlanetSpecValidationError.
+    await expect(
+      loadPlanetConfiguration('/missing/spec.json', fetchStub)
+    ).rejects.toThrow(PlanetSpecValidationError)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.ts
@@ -1,0 +1,145 @@
+export interface PlanetSpec {
+  readonly seed: number
+  readonly radii: readonly number[]
+  readonly frequencies: readonly number[]
+  readonly amplitudes: readonly number[]
+  readonly lodThresholds: readonly number[]
+}
+
+export interface PlanetNoiseLayer {
+  readonly frequency: number
+  readonly amplitude: number
+}
+
+export interface PlanetConfiguration {
+  readonly seed: number
+  readonly radii: readonly number[]
+  readonly noiseLayers: readonly PlanetNoiseLayer[]
+  readonly lodThresholds: readonly number[]
+}
+
+export interface FetchResponseLike {
+  ok: boolean
+  status: number
+  statusText: string
+  json(): Promise<unknown>
+}
+
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<FetchResponseLike>
+
+export class PlanetSpecValidationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'PlanetSpecValidationError'
+  }
+}
+
+function ensureRecord(value: unknown): Record<string, unknown> {
+  //1.- Confirm the payload is an object literal before attempting to read its properties.
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new PlanetSpecValidationError('PlanetSpec must be a JSON object')
+  }
+  return value as Record<string, unknown>
+}
+
+function ensureNumber(value: unknown, field: string): number {
+  //1.- Promote numeric fields into deterministic floating point values.
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new PlanetSpecValidationError(`${field} must be a finite number`)
+  }
+  return value
+}
+
+function ensureNumberArray(value: unknown, field: string): number[] {
+  //1.- Validate that the provided collection is an array of finite numbers ready for GPU uploads.
+  if (!Array.isArray(value)) {
+    throw new PlanetSpecValidationError(`${field} must be an array of numbers`)
+  }
+  //2.- Copy elements into a fresh list so downstream callers cannot mutate the source reference.
+  const numbers = value.map((entry, index) => {
+    if (typeof entry !== 'number' || !Number.isFinite(entry)) {
+      throw new PlanetSpecValidationError(`${field}[${index}] must be a finite number`)
+    }
+    return entry
+  })
+  if (numbers.length === 0) {
+    throw new PlanetSpecValidationError(`${field} requires at least one value`)
+  }
+  return numbers
+}
+
+export function parsePlanetSpec(raw: unknown): PlanetSpec {
+  //1.- Convert untyped JSON into a strongly-typed record for validation.
+  const record = ensureRecord(raw)
+  const seed = ensureNumber(record.seed, 'seed')
+  const radii = ensureNumberArray(record.radii, 'radii')
+  const frequencies = ensureNumberArray(record.frequencies, 'frequencies')
+  const amplitudes = ensureNumberArray(record.amplitudes, 'amplitudes')
+  const lodThresholds = ensureNumberArray(record.lodThresholds, 'lodThresholds')
+  //2.- Guarantee that noise parameters remain paired by length to avoid runtime mismatches during FBM evaluation.
+  if (frequencies.length !== amplitudes.length) {
+    throw new PlanetSpecValidationError('frequencies and amplitudes must have matching lengths')
+  }
+  return {
+    seed,
+    radii: Object.freeze([...radii]),
+    frequencies: Object.freeze([...frequencies]),
+    amplitudes: Object.freeze([...amplitudes]),
+    lodThresholds: Object.freeze([...lodThresholds]),
+  }
+}
+
+export function createPlanetConfiguration(spec: PlanetSpec): PlanetConfiguration {
+  //1.- Bundle paired noise parameters into ready-to-sample layers for the displacement pipeline.
+  const noiseLayers = spec.frequencies.map((frequency, index) =>
+    Object.freeze({
+      frequency,
+      amplitude: spec.amplitudes[index],
+    })
+  )
+  //2.- Freeze each slice so consumers receive immutable views across render and worker threads.
+  return {
+    seed: spec.seed,
+    radii: spec.radii,
+    noiseLayers: Object.freeze(noiseLayers),
+    lodThresholds: spec.lodThresholds,
+  }
+}
+
+export function loadPlanetConfigurationFromJson(json: string): PlanetConfiguration {
+  //1.- Parse the text payload so syntax errors surface as validation feedback.
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch (error) {
+    throw new PlanetSpecValidationError('Unable to parse PlanetSpec JSON', { cause: error })
+  }
+  //2.- Delegate to the typed conversion routines to reuse the validation rules.
+  const spec = parsePlanetSpec(parsed)
+  return createPlanetConfiguration(spec)
+}
+
+export async function loadPlanetConfiguration(
+  url: string,
+  fetcher?: FetchLike
+): Promise<PlanetConfiguration> {
+  //1.- Resolve the fetch implementation from the caller or fall back to the runtime global.
+  const activeFetcher = fetcher ?? (globalThis.fetch as FetchLike | undefined)
+  if (!activeFetcher) {
+    throw new PlanetSpecValidationError('A fetch implementation is required to load a PlanetSpec')
+  }
+  //2.- Retrieve the JSON file and bubble up HTTP failures with contextual diagnostics.
+  const response = await activeFetcher(url)
+  if (!response.ok) {
+    throw new PlanetSpecValidationError(
+      `Failed to load PlanetSpec from ${url}: ${response.status} ${response.statusText}`
+    )
+  }
+  //3.- Convert the remote payload into the immutable configuration bundle shared by the planet systems.
+  const raw = await response.json()
+  const spec = parsePlanetSpec(raw)
+  return createPlanetConfiguration(spec)
+}


### PR DESCRIPTION
## Summary
- add a PlanetSpec loader that validates numeric fields and freezes immutable configuration slices
- provide helpers for parsing JSON strings and fetching specs before building runtime noise layers
- add vitest coverage for success paths, error handling, and fetch integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e35054422483299439ce5b4fa4a604