### PR TITLE
Implement cubed-sphere mesh generator and LOD set

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/cubedSphereMesh.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/cubedSphereMesh.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest'
+import { createFixedCubedSphereLods, generateCubedSphereMesh } from './cubedSphereMesh'
+
+type EdgeName = 'left' | 'right' | 'top' | 'bottom'
+
+interface Vec3 {
+  readonly x: number
+  readonly y: number
+  readonly z: number
+}
+
+function getVertex(vertices: Float32Array, index: number): Vec3 {
+  //1.- Extract the xyz triplet stored in the packed buffer for vector math in assertions.
+  return {
+    x: vertices[index * 3],
+    y: vertices[index * 3 + 1],
+    z: vertices[index * 3 + 2],
+  }
+}
+
+function vectorLength(vector: Vec3): number {
+  //1.- Measure the magnitude directly to avoid pulling in heavyweight math utilities for tests.
+  return Math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z)
+}
+
+function subtract(a: Vec3, b: Vec3): Vec3 {
+  //1.- Compute directional offsets for edge walking heuristics.
+  return {
+    x: a.x - b.x,
+    y: a.y - b.y,
+    z: a.z - b.z,
+  }
+}
+
+function dot(a: Vec3, b: Vec3): number {
+  //1.- Evaluate vector agreement for tangent alignment checks.
+  return a.x * b.x + a.y * b.y + a.z * b.z
+}
+
+function normalize(vector: Vec3): Vec3 {
+  //1.- Return a unit vector while guarding against degenerate inputs.
+  const length = vectorLength(vector)
+  if (length === 0) {
+    return vector
+  }
+  return {
+    x: vector.x / length,
+    y: vector.y / length,
+    z: vector.z / length,
+  }
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  //1.- Produce the orthogonal tangent used for directional traversal.
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  }
+}
+
+function getEdge(face: readonly (readonly number[])[], edge: EdgeName): readonly number[] {
+  //1.- Slice an ordered list of vertex indices for the requested face perimeter.
+  const lastRow = face.length - 1
+  const lastColumn = face[0].length - 1
+  switch (edge) {
+    case 'left':
+      return face.map((row) => row[0])
+    case 'right':
+      return face.map((row) => row[lastColumn])
+    case 'top':
+      return face[lastRow]
+    case 'bottom':
+      return face[0]
+  }
+}
+
+describe('generateCubedSphereMesh', () => {
+  it('produces a unit-radius cubed sphere with shared seam vertices', () => {
+    //1.- Build a moderately tessellated sphere to stress vertex deduplication along cube edges.
+    const mesh = generateCubedSphereMesh(6)
+    const uniqueKeys = new Set<string>()
+    for (let index = 0; index < mesh.vertices.length / 3; index += 1) {
+      const vertex = getVertex(mesh.vertices, index)
+      //2.- Validate the vertex resides on the unit sphere and that seams are not double-booked.
+      expect(vectorLength(vertex)).toBeCloseTo(1, 6)
+      const key = `${vertex.x.toFixed(6)},${vertex.y.toFixed(6)},${vertex.z.toFixed(6)}`
+      expect(uniqueKeys.has(key)).toBe(false)
+      uniqueKeys.add(key)
+    }
+    expect(uniqueKeys.size).toBe(mesh.vertices.length / 3)
+  })
+
+  it('aligns edge strips across adjacent faces', () => {
+    //1.- Generate the base mesh and catalogue every face perimeter run.
+    const mesh = generateCubedSphereMesh(4)
+    const edgeIndexMap = new Map<string, number[][]>()
+    const edgeNames: EdgeName[] = ['left', 'right', 'top', 'bottom']
+    mesh.faces.forEach((face) => {
+      edgeNames.forEach((edgeName) => {
+        const indices = [...getEdge(face.vertexIndices, edgeName)]
+        const key = [...indices].sort((a, b) => a - b).join(',')
+        const runs = edgeIndexMap.get(key)
+        if (runs) {
+          runs.push(indices)
+        } else {
+          edgeIndexMap.set(key, [indices])
+        }
+      })
+    })
+    //2.- Confirm every seam is owned by exactly two faces and they reference identical vertices.
+    edgeIndexMap.forEach((runs) => {
+      expect(runs.length).toBe(2)
+      const [a, b] = runs
+      const reversedB = [...b].reverse()
+      const directMatch = a.every((value, index) => value === b[index])
+      const reverseMatch = a.every((value, index) => value === reversedB[index])
+      expect(directMatch || reverseMatch).toBe(true)
+    })
+  })
+
+  it('supports great-circle traversal without deviating from the surface', () => {
+    //1.- Assemble adjacency lists so the integration can hop between shared edge vertices.
+    const mesh = generateCubedSphereMesh(8)
+    const adjacency = new Map<number, Set<number>>()
+    for (let i = 0; i < mesh.indices.length; i += 3) {
+      const a = mesh.indices[i]
+      const b = mesh.indices[i + 1]
+      const c = mesh.indices[i + 2]
+      const triPairs: [number, number][] = [
+        [a, b],
+        [b, c],
+        [c, a],
+      ]
+      triPairs.forEach(([from, to]) => {
+        const list = adjacency.get(from)
+        if (list) {
+          list.add(to)
+        } else {
+          adjacency.set(from, new Set([to]))
+        }
+      })
+      triPairs.forEach(([from, to]) => {
+        const list = adjacency.get(to)
+        if (list) {
+          list.add(from)
+        } else {
+          adjacency.set(to, new Set([from]))
+        }
+      })
+    }
+    //2.- Pick a vertex on the equator and march along neighbours that best align with the tangent direction.
+    let startIndex = 0
+    let bestX = -Infinity
+    for (let index = 0; index < mesh.vertices.length / 3; index += 1) {
+      const vertex = getVertex(mesh.vertices, index)
+      if (Math.abs(vertex.z) < 1e-6 && vertex.x > bestX) {
+        bestX = vertex.x
+        startIndex = index
+      }
+    }
+    const axis: Vec3 = { x: 0, y: 0, z: 1 }
+    const visited: number[] = []
+    let currentIndex = startIndex
+    let totalAngle = 0
+    const maxSteps = mesh.subdivisions * 8
+    for (let step = 0; step < maxSteps; step += 1) {
+      visited.push(currentIndex)
+      const current = getVertex(mesh.vertices, currentIndex)
+      const tangent = normalize(cross(axis, current))
+      let nextIndex: number | undefined
+      let bestDot = -Infinity
+      const neighbours = adjacency.get(currentIndex)
+      if (!neighbours) {
+        throw new Error('Great-circle traversal failed: missing adjacency data')
+      }
+      neighbours.forEach((candidate) => {
+        const candidateVertex = getVertex(mesh.vertices, candidate)
+        const offset = normalize(subtract(candidateVertex, current))
+        const alignment = dot(offset, tangent)
+        if (alignment > bestDot) {
+          bestDot = alignment
+          nextIndex = candidate
+        }
+      })
+      if (nextIndex === undefined) {
+        throw new Error('Great-circle traversal failed: unable to select a neighbour')
+      }
+      const next = getVertex(mesh.vertices, nextIndex)
+      const angleDot = Math.max(-1, Math.min(1, dot(current, next)))
+      totalAngle += Math.acos(angleDot)
+      if (nextIndex === startIndex) {
+        currentIndex = nextIndex
+        break
+      }
+      currentIndex = nextIndex
+    }
+    //3.- Ensure the walker closed the loop, covered the full circumference, and never left the surface.
+    expect(currentIndex).toBe(startIndex)
+    expect(visited.length).toBeGreaterThan(0)
+    visited.forEach((index) => {
+      expect(vectorLength(getVertex(mesh.vertices, index))).toBeCloseTo(1, 6)
+    })
+    expect(totalAngle).toBeCloseTo(2 * Math.PI, 2)
+  })
+})
+
+describe('createFixedCubedSphereLods', () => {
+  it('builds unique, ordered LOD meshes shared across faces', () => {
+    //1.- Request a trio of levels with duplicates to exercise ordering and deduplication logic.
+    const lods = createFixedCubedSphereLods([2, 0, 1, 1])
+    expect(lods.length).toBe(3)
+    expect(lods[0].subdivisions).toBe(1)
+    expect(lods[1].subdivisions).toBe(2)
+    expect(lods[2].subdivisions).toBe(4)
+    //2.- Confirm each mesh exposes face metadata for shared lookup and that buffers are immutable views.
+    lods.forEach((mesh) => {
+      expect(Object.isFrozen(mesh)).toBe(true)
+      expect(mesh.faces.length).toBe(6)
+    })
+  })
+
+  it('rejects empty LOD collections', () => {
+    //1.- Safeguard against accidental empty arrays that would stall the streaming system.
+    expect(() => createFixedCubedSphereLods([])).toThrow()
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planet/cubedSphereMesh.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/cubedSphereMesh.ts
@@ -1,0 +1,151 @@
+import * as THREE from 'three'
+
+export interface CubedSphereFace {
+  readonly vertexIndices: readonly (readonly number[])[]
+}
+
+export interface CubedSphereMesh {
+  readonly subdivisions: number
+  readonly vertices: Float32Array
+  readonly indices: Uint32Array
+  readonly faces: readonly CubedSphereFace[]
+}
+
+interface FaceDefinition {
+  readonly normal: THREE.Vector3
+  readonly uAxis: THREE.Vector3
+  readonly vAxis: THREE.Vector3
+}
+
+const FACE_DEFINITIONS: readonly FaceDefinition[] = [
+  //1.- Six axis-aligned cube faces with a right-handed (u, v, normal) basis.
+  { normal: new THREE.Vector3(1, 0, 0), uAxis: new THREE.Vector3(0, 0, -1), vAxis: new THREE.Vector3(0, 1, 0) },
+  { normal: new THREE.Vector3(-1, 0, 0), uAxis: new THREE.Vector3(0, 0, 1), vAxis: new THREE.Vector3(0, 1, 0) },
+  { normal: new THREE.Vector3(0, 1, 0), uAxis: new THREE.Vector3(-1, 0, 0), vAxis: new THREE.Vector3(0, 0, 1) },
+  { normal: new THREE.Vector3(0, -1, 0), uAxis: new THREE.Vector3(-1, 0, 0), vAxis: new THREE.Vector3(0, 0, -1) },
+  { normal: new THREE.Vector3(0, 0, 1), uAxis: new THREE.Vector3(1, 0, 0), vAxis: new THREE.Vector3(0, 1, 0) },
+  { normal: new THREE.Vector3(0, 0, -1), uAxis: new THREE.Vector3(-1, 0, 0), vAxis: new THREE.Vector3(0, 1, 0) },
+]
+
+function buildVertexKey(vector: THREE.Vector3): string {
+  //1.- Quantise direction vectors to guarantee seam vertices resolve to a shared key.
+  return `${vector.x.toFixed(10)},${vector.y.toFixed(10)},${vector.z.toFixed(10)}`
+}
+
+function computeFacePoint(
+  face: FaceDefinition,
+  uIndex: number,
+  vIndex: number,
+  subdivisions: number,
+  scratch: THREE.Vector3
+): THREE.Vector3 {
+  //1.- Remap lattice coordinates into the canonical [-1, 1] parametric domain.
+  const u = subdivisions === 0 ? 0 : -1 + (2 * uIndex) / subdivisions
+  const v = subdivisions === 0 ? 0 : -1 + (2 * vIndex) / subdivisions
+  //2.- Assemble the cube point before projecting onto the unit sphere.
+  scratch.copy(face.normal)
+  scratch.x += face.uAxis.x * u + face.vAxis.x * v
+  scratch.y += face.uAxis.y * u + face.vAxis.y * v
+  scratch.z += face.uAxis.z * u + face.vAxis.z * v
+  scratch.normalize()
+  return scratch
+}
+
+function pushTriangle(
+  indices: number[],
+  a: number,
+  b: number,
+  c: number,
+  vertices: number[]
+): void {
+  //1.- Fetch vertex positions for winding analysis.
+  const ax = vertices[a * 3]
+  const ay = vertices[a * 3 + 1]
+  const az = vertices[a * 3 + 2]
+  const bx = vertices[b * 3]
+  const by = vertices[b * 3 + 1]
+  const bz = vertices[b * 3 + 2]
+  const cx = vertices[c * 3]
+  const cy = vertices[c * 3 + 1]
+  const cz = vertices[c * 3 + 2]
+  //2.- Evaluate the triangle normal to ensure the winding points away from the origin.
+  const abx = bx - ax
+  const aby = by - ay
+  const abz = bz - az
+  const acx = cx - ax
+  const acy = cy - ay
+  const acz = cz - az
+  const nx = aby * acz - abz * acy
+  const ny = abz * acx - abx * acz
+  const nz = abx * acy - aby * acx
+  const dot = nx * (ax + bx + cx) + ny * (ay + by + cy) + nz * (az + bz + cz)
+  if (dot < 0) {
+    indices.push(a, c, b)
+  } else {
+    indices.push(a, b, c)
+  }
+}
+
+export function generateCubedSphereMesh(subdivisions: number): CubedSphereMesh {
+  //1.- Accumulate vertices while deduplicating seams across cube faces.
+  const vertices: number[] = []
+  const indices: number[] = []
+  const vertexLookup = new Map<string, number>()
+  const faces: CubedSphereFace[] = []
+  const scratch = new THREE.Vector3()
+  for (const faceDefinition of FACE_DEFINITIONS) {
+    const grid: number[][] = []
+    for (let v = 0; v <= subdivisions; v += 1) {
+      const row: number[] = []
+      for (let u = 0; u <= subdivisions; u += 1) {
+        const point = computeFacePoint(faceDefinition, u, v, subdivisions, scratch)
+        const key = buildVertexKey(point)
+        let index = vertexLookup.get(key)
+        if (index === undefined) {
+          index = vertices.length / 3
+          vertices.push(point.x, point.y, point.z)
+          vertexLookup.set(key, index)
+        }
+        row.push(index)
+      }
+      grid.push(row)
+    }
+    faces.push({ vertexIndices: grid.map((entries) => Object.freeze([...entries])) })
+  }
+  //2.- Create triangles for each quad cell while enforcing outward-facing winding.
+  for (const face of faces) {
+    const grid = face.vertexIndices
+    const rows = grid.length - 1
+    const columns = grid[0].length - 1
+    for (let v = 0; v < rows; v += 1) {
+      for (let u = 0; u < columns; u += 1) {
+        const a = grid[v][u]
+        const b = grid[v][u + 1]
+        const c = grid[v + 1][u]
+        const d = grid[v + 1][u + 1]
+        pushTriangle(indices, a, b, c, vertices)
+        pushTriangle(indices, b, d, c, vertices)
+      }
+    }
+  }
+  return Object.freeze({
+    subdivisions,
+    vertices: new Float32Array(vertices),
+    indices: new Uint32Array(indices),
+    faces: Object.freeze(faces.map((face) => Object.freeze({ vertexIndices: face.vertexIndices }))),
+  })
+}
+
+export function createFixedCubedSphereLods(levels: readonly number[]): readonly CubedSphereMesh[] {
+  //1.- Validate the requested LOD set so downstream systems do not work with an empty catalogue.
+  if (levels.length === 0) {
+    throw new Error('At least one LOD level is required to build cubed-sphere meshes')
+  }
+  //2.- Deduplicate exponents while preserving caller intent before generating meshes.
+  const uniqueLevels = Array.from(new Set(levels)).sort((a, b) => a - b)
+  const meshes = uniqueLevels.map((level) => {
+    const subdivisions = Math.max(1, 2 ** level)
+    return generateCubedSphereMesh(subdivisions)
+  })
+  return Object.freeze(meshes)
+}


### PR DESCRIPTION
## Summary
- add a cubed-sphere mesh generator that deduplicates shared edges and enforces outward-facing triangles
- expose a fixed LOD catalogue builder for consistent subdivision levels across faces
- add comprehensive vitest coverage including seam validation and great-circle traversal checks

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e352965538832997aa20e4078ec6bc