### PR TITLE
Add FBM-based cubed-sphere displacement field

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/noiseDisplacement.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/noiseDisplacement.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { createFixedCubedSphereLods, generateCubedSphereMesh } from './cubedSphereMesh'
+import { applyNoiseDisplacement } from './noiseDisplacement'
+import type { PlanetConfiguration } from './planetSpecLoader'
+
+describe('applyNoiseDisplacement', () => {
+  it('scales unit sphere vertices by the base radius when amplitudes are zero', () => {
+    //1.- Assemble a coarse cubed-sphere mesh with deterministic noise layers of zero amplitude.
+    const mesh = generateCubedSphereMesh(2)
+    const configuration: PlanetConfiguration = {
+      seed: 1234,
+      radii: Object.freeze([90, 120]),
+      noiseLayers: Object.freeze([
+        Object.freeze({ frequency: 0.5, amplitude: 0 }),
+        Object.freeze({ frequency: 1.0, amplitude: 0 }),
+      ]),
+      lodThresholds: Object.freeze([0.1]),
+    }
+    //2.- Evaluate the displacement field and verify each vertex simply scales by the maximum radius.
+    const field = applyNoiseDisplacement(mesh, configuration)
+    expect(field.baseRadius).toBe(120)
+    for (let index = 0; index < mesh.vertices.length / 3; index += 1) {
+      const radius = field.radii[index]
+      expect(radius).toBeCloseTo(120, 6)
+      const x = mesh.vertices[index * 3] * 120
+      const y = mesh.vertices[index * 3 + 1] * 120
+      const z = mesh.vertices[index * 3 + 2] * 120
+      expect(field.positions[index * 3]).toBeCloseTo(x, 5)
+      expect(field.positions[index * 3 + 1]).toBeCloseTo(y, 5)
+      expect(field.positions[index * 3 + 2]).toBeCloseTo(z, 5)
+    }
+  })
+
+  it('applies deterministic FBM noise to produce varying displacements', () => {
+    //1.- Generate a moderately tessellated mesh and enable non-zero amplitudes for layered FBM sampling.
+    const mesh = generateCubedSphereMesh(3)
+    const configuration: PlanetConfiguration = {
+      seed: 98765,
+      radii: Object.freeze([150, 180, 210]),
+      noiseLayers: Object.freeze([
+        Object.freeze({ frequency: 0.75, amplitude: 6 }),
+        Object.freeze({ frequency: 1.5, amplitude: 3 }),
+      ]),
+      lodThresholds: Object.freeze([0.1, 0.05]),
+    }
+    //2.- Compute the displacement field and confirm the output varies while remaining stable across calls.
+    const fieldA = applyNoiseDisplacement(mesh, configuration)
+    const fieldB = applyNoiseDisplacement(mesh, configuration)
+    expect(fieldA.baseRadius).toBe(210)
+    expect(fieldA.baseRadius).toBe(fieldB.baseRadius)
+    let uniqueDisplacements = 0
+    for (let index = 0; index < fieldA.displacements.length; index += 1) {
+      const displacementA = fieldA.displacements[index]
+      const displacementB = fieldB.displacements[index]
+      expect(displacementA).toBeCloseTo(displacementB, 6)
+      if (Math.abs(displacementA) > 1e-6) {
+        uniqueDisplacements += 1
+      }
+      const expectedRadius = 210 + displacementA
+      expect(fieldA.radii[index]).toBeCloseTo(expectedRadius, 4)
+    }
+    expect(uniqueDisplacements).toBeGreaterThan(0)
+  })
+
+  it('shares LOD meshes while producing displacement buffers per vertex', () => {
+    //1.- Build a bundle of shared cubed-sphere LOD meshes and apply the displacement to one level.
+    const lods = createFixedCubedSphereLods([0, 1])
+    const mesh = lods[1]
+    const configuration: PlanetConfiguration = {
+      seed: 222,
+      radii: Object.freeze([50, 55, 62]),
+      noiseLayers: Object.freeze([Object.freeze({ frequency: 0.4, amplitude: 2.5 })]),
+      lodThresholds: Object.freeze([0.2]),
+    }
+    //2.- Verify the displacement output exposes immutable typed arrays sized to the vertex count.
+    const field = applyNoiseDisplacement(mesh, configuration)
+    expect(field.positions.length).toBe(mesh.vertices.length)
+    expect(field.radii.length).toBe(mesh.vertices.length / 3)
+    expect(field.displacements.length).toBe(mesh.vertices.length / 3)
+    expect(Object.isFrozen(field)).toBe(true)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/noiseDisplacement.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/noiseDisplacement.ts
@@ -1,0 +1,123 @@
+import * as THREE from 'three'
+import type { CubedSphereMesh } from './cubedSphereMesh'
+import type { PlanetConfiguration, PlanetNoiseLayer } from './planetSpecLoader'
+
+export interface RadialDisplacementField {
+  readonly baseRadius: number
+  readonly radii: Float32Array
+  readonly displacements: Float32Array
+  readonly positions: Float32Array
+}
+
+function hash3(seed: number, x: number, y: number, z: number): number {
+  //1.- Combine integer lattice coordinates with the seed via large primes to decorrelate axes.
+  let value = Math.imul(x, 374761393) ^ Math.imul(y, 668265263) ^ Math.imul(z, 2147483647) ^ seed
+  value = (value ^ (value >>> 13)) >>> 0
+  value = Math.imul(value, 1274126177)
+  value = (value ^ (value >>> 16)) >>> 0
+  return value / 4294967295
+}
+
+function smoothStep(t: number): number {
+  //1.- Apply the cubic smoothing curve used by classic Perlin noise for continuous gradients.
+  return t * t * (3 - 2 * t)
+}
+
+function valueNoise3D(seed: number, x: number, y: number, z: number): number {
+  //1.- Identify the surrounding unit cube and fetch pseudo-random values for each corner.
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const z0 = Math.floor(z)
+  const xf = x - x0
+  const yf = y - y0
+  const zf = z - z0
+  const x1 = x0 + 1
+  const y1 = y0 + 1
+  const z1 = z0 + 1
+  const v000 = hash3(seed, x0, y0, z0)
+  const v100 = hash3(seed, x1, y0, z0)
+  const v010 = hash3(seed, x0, y1, z0)
+  const v110 = hash3(seed, x1, y1, z0)
+  const v001 = hash3(seed, x0, y0, z1)
+  const v101 = hash3(seed, x1, y0, z1)
+  const v011 = hash3(seed, x0, y1, z1)
+  const v111 = hash3(seed, x1, y1, z1)
+  //2.- Interpolate along each axis using the smoothed fractional offsets to preserve continuity.
+  const sx = smoothStep(xf)
+  const sy = smoothStep(yf)
+  const sz = smoothStep(zf)
+  const i00 = v000 + (v100 - v000) * sx
+  const i10 = v010 + (v110 - v010) * sx
+  const i01 = v001 + (v101 - v001) * sx
+  const i11 = v011 + (v111 - v011) * sx
+  const j0 = i00 + (i10 - i00) * sy
+  const j1 = i01 + (i11 - i01) * sy
+  return j0 + (j1 - j0) * sz
+}
+
+function fbmNoise(seed: number, direction: THREE.Vector3, layers: readonly PlanetNoiseLayer[]): number {
+  //1.- Accumulate centred value noise contributions for each configured layer.
+  let total = 0
+  layers.forEach((layer, index) => {
+    const frequency = layer.frequency
+    const amplitude = layer.amplitude
+    const offsetSeed = seed + index * 1013904223
+    const sample = valueNoise3D(
+      offsetSeed,
+      direction.x * frequency,
+      direction.y * frequency,
+      direction.z * frequency,
+    )
+    total += (sample * 2 - 1) * amplitude
+  })
+  return total
+}
+
+function determineBaseRadius(configuration: PlanetConfiguration): number {
+  //1.- Extract the largest configured radius so the displacement expands upon the outer shell.
+  let base = -Infinity
+  configuration.radii.forEach((radius) => {
+    if (radius > base) {
+      base = radius
+    }
+  })
+  if (!Number.isFinite(base)) {
+    throw new Error('Planet configuration must define at least one radius value')
+  }
+  return base
+}
+
+export function applyNoiseDisplacement(
+  mesh: CubedSphereMesh,
+  configuration: PlanetConfiguration,
+): RadialDisplacementField {
+  //1.- Resolve the base radius and allocate typed buffers for the radial field and displaced geometry.
+  const baseRadius = determineBaseRadius(configuration)
+  const vertexCount = mesh.vertices.length / 3
+  const radii = new Float32Array(vertexCount)
+  const displacements = new Float32Array(vertexCount)
+  const positions = new Float32Array(mesh.vertices.length)
+  //2.- Reuse a shared direction vector to avoid heap churn inside the tight vertex loop.
+  const direction = new THREE.Vector3()
+  for (let index = 0; index < vertexCount; index += 1) {
+    const x = mesh.vertices[index * 3]
+    const y = mesh.vertices[index * 3 + 1]
+    const z = mesh.vertices[index * 3 + 2]
+    direction.set(x, y, z)
+    const displacement = fbmNoise(configuration.seed, direction, configuration.noiseLayers)
+    const radius = baseRadius + displacement
+    radii[index] = radius
+    displacements[index] = displacement
+    positions[index * 3] = direction.x * radius
+    positions[index * 3 + 1] = direction.y * radius
+    positions[index * 3 + 2] = direction.z * radius
+  }
+  const field: RadialDisplacementField = {
+    baseRadius,
+    radii,
+    displacements,
+    positions,
+  }
+  return Object.freeze(field)
+}
+


### PR DESCRIPTION
## Summary
- implement a deterministic FBM displacement generator for cubed-sphere meshes
- output radial distance, displacement, and updated vertex buffers for downstream systems
- cover zero-amplitude scaling, deterministic sampling, and LOD sizing with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3558f8f048329aaf17299307552ad