### PR TITLE
Add sea level classification utilities for planet gameplay

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/noiseDisplacement.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/noiseDisplacement.test.ts
@@ -15,6 +15,9 @@ describe('applyNoiseDisplacement', () => {
         Object.freeze({ frequency: 1.0, amplitude: 0 }),
       ]),
       lodThresholds: Object.freeze([0.1]),
+      seaLevel: 60,
+      surfaceClearance: 2,
+      atmosphereHeight: 50,
     }
     //2.- Evaluate the displacement field and verify each vertex simply scales by the maximum radius.
     const field = applyNoiseDisplacement(mesh, configuration)
@@ -42,6 +45,9 @@ describe('applyNoiseDisplacement', () => {
         Object.freeze({ frequency: 1.5, amplitude: 3 }),
       ]),
       lodThresholds: Object.freeze([0.1, 0.05]),
+      seaLevel: 140,
+      surfaceClearance: 5,
+      atmosphereHeight: 70,
     }
     //2.- Compute the displacement field and confirm the output varies while remaining stable across calls.
     const fieldA = applyNoiseDisplacement(mesh, configuration)
@@ -71,6 +77,9 @@ describe('applyNoiseDisplacement', () => {
       radii: Object.freeze([50, 55, 62]),
       noiseLayers: Object.freeze([Object.freeze({ frequency: 0.4, amplitude: 2.5 })]),
       lodThresholds: Object.freeze([0.2]),
+      seaLevel: 40,
+      surfaceClearance: 1.5,
+      atmosphereHeight: 25,
     }
     //2.- Verify the displacement output exposes immutable typed arrays sized to the vertex count.
     const field = applyNoiseDisplacement(mesh, configuration)

--- a/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.test.ts
@@ -16,6 +16,9 @@ describe('planetSpecLoader', () => {
       frequencies: [0.25, 0.5, 1.0],
       amplitudes: [12, 6, 2],
       lodThresholds: [0.08, 0.04, 0.02],
+      seaLevel: 150,
+      surfaceClearance: 2,
+      atmosphereHeight: 35,
     }
     //2.- Execute the parser to normalise shape and freeze arrays for sharing across systems.
     const spec = parsePlanetSpec(raw)
@@ -35,6 +38,9 @@ describe('planetSpecLoader', () => {
       frequencies: [1, 2],
       amplitudes: [3],
       lodThresholds: [0.1],
+      seaLevel: 80,
+      surfaceClearance: 1.5,
+      atmosphereHeight: 20,
     }
     //2.- Verify the loader surfaces a targeted validation error for the caller.
     expect(() => parsePlanetSpec(raw)).toThrow(PlanetSpecValidationError)
@@ -48,6 +54,9 @@ describe('planetSpecLoader', () => {
       frequencies: [0.4, 0.8],
       amplitudes: [5.5, 2.75],
       lodThresholds: [0.12, 0.06],
+      seaLevel: 200,
+      surfaceClearance: 3.5,
+      atmosphereHeight: 60,
     }
     const spec = parsePlanetSpec(raw)
     const configuration = createPlanetConfiguration(spec)
@@ -60,6 +69,9 @@ describe('planetSpecLoader', () => {
         { frequency: 0.8, amplitude: 2.75 },
       ],
       lodThresholds: spec.lodThresholds,
+      seaLevel: spec.seaLevel,
+      surfaceClearance: spec.surfaceClearance,
+      atmosphereHeight: spec.atmosphereHeight,
     })
     expect(Object.isFrozen(configuration.noiseLayers)).toBe(true)
   })
@@ -72,11 +84,15 @@ describe('planetSpecLoader', () => {
       frequencies: [0.6],
       amplitudes: [4.2],
       lodThresholds: [0.05],
+      seaLevel: 120,
+      surfaceClearance: 1.2,
+      atmosphereHeight: 25,
     })
     //2.- Ensure loader surfaces the composed configuration and respects the numeric payload.
     const configuration = loadPlanetConfigurationFromJson(json)
     expect(configuration.seed).toBe(77)
     expect(configuration.radii).toEqual([150])
+    expect(configuration.seaLevel).toBe(120)
   })
 
   it('raises a descriptive error on invalid JSON syntax', () => {
@@ -96,6 +112,9 @@ describe('planetSpecLoader', () => {
         frequencies: [0.3, 0.9],
         amplitudes: [8, 3],
         lodThresholds: [0.07, 0.035],
+        seaLevel: 140,
+        surfaceClearance: 2.2,
+        atmosphereHeight: 45,
       }),
     }))
     //2.- Load the configuration and verify the fetch call contract and parsed data.
@@ -105,6 +124,7 @@ describe('planetSpecLoader', () => {
       { frequency: 0.3, amplitude: 8 },
       { frequency: 0.9, amplitude: 3 },
     ])
+    expect(configuration.seaLevel).toBe(140)
   })
 
   it('reports network failures with the HTTP status text', async () => {

--- a/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/planetSpecLoader.ts
@@ -4,6 +4,9 @@ export interface PlanetSpec {
   readonly frequencies: readonly number[]
   readonly amplitudes: readonly number[]
   readonly lodThresholds: readonly number[]
+  readonly seaLevel: number
+  readonly surfaceClearance: number
+  readonly atmosphereHeight: number
 }
 
 export interface PlanetNoiseLayer {
@@ -16,6 +19,9 @@ export interface PlanetConfiguration {
   readonly radii: readonly number[]
   readonly noiseLayers: readonly PlanetNoiseLayer[]
   readonly lodThresholds: readonly number[]
+  readonly seaLevel: number
+  readonly surfaceClearance: number
+  readonly atmosphereHeight: number
 }
 
 export interface FetchResponseLike {
@@ -79,6 +85,9 @@ export function parsePlanetSpec(raw: unknown): PlanetSpec {
   const frequencies = ensureNumberArray(record.frequencies, 'frequencies')
   const amplitudes = ensureNumberArray(record.amplitudes, 'amplitudes')
   const lodThresholds = ensureNumberArray(record.lodThresholds, 'lodThresholds')
+  const seaLevel = ensureNumber(record.seaLevel, 'seaLevel')
+  const surfaceClearance = ensureNumber(record.surfaceClearance, 'surfaceClearance')
+  const atmosphereHeight = ensureNumber(record.atmosphereHeight, 'atmosphereHeight')
   //2.- Guarantee that noise parameters remain paired by length to avoid runtime mismatches during FBM evaluation.
   if (frequencies.length !== amplitudes.length) {
     throw new PlanetSpecValidationError('frequencies and amplitudes must have matching lengths')
@@ -89,6 +98,9 @@ export function parsePlanetSpec(raw: unknown): PlanetSpec {
     frequencies: Object.freeze([...frequencies]),
     amplitudes: Object.freeze([...amplitudes]),
     lodThresholds: Object.freeze([...lodThresholds]),
+    seaLevel,
+    surfaceClearance,
+    atmosphereHeight,
   }
 }
 
@@ -106,6 +118,9 @@ export function createPlanetConfiguration(spec: PlanetSpec): PlanetConfiguration
     radii: spec.radii,
     noiseLayers: Object.freeze(noiseLayers),
     lodThresholds: spec.lodThresholds,
+    seaLevel: spec.seaLevel,
+    surfaceClearance: spec.surfaceClearance,
+    atmosphereHeight: spec.atmosphereHeight,
   }
 }
 

--- a/tunnelcave_sandbox_web/app/gameplay/planet/radialSdfCollision.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/radialSdfCollision.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { generateCubedSphereMesh } from './cubedSphereMesh'
+import type { RadialDisplacementField } from './noiseDisplacement'
+import type { PlanetConfiguration } from './planetSpecLoader'
+import { clampVehicleAltitude, sampleGroundDistance } from './radialSdfCollision'
+import { classifySurfaceBySeaLevel } from './seaLevelMask'
+
+function createCollisionFixture(): {
+  mesh: ReturnType<typeof generateCubedSphereMesh>
+  field: RadialDisplacementField
+  configuration: PlanetConfiguration
+  classificationReturn: ReturnType<typeof classifySurfaceBySeaLevel>
+} {
+  //1.- Start from a unit cube sphere and inflate vertices to a uniform planetary radius.
+  const mesh = generateCubedSphereMesh(2)
+  const vertexCount = mesh.vertices.length / 3
+  const baseRadius = 100
+  const radii = new Float32Array(vertexCount)
+  const displacements = new Float32Array(vertexCount)
+  const positions = new Float32Array(mesh.vertices.length)
+  for (let index = 0; index < vertexCount; index += 1) {
+    radii[index] = baseRadius
+    displacements[index] = 0
+    const x = mesh.vertices[index * 3]
+    const y = mesh.vertices[index * 3 + 1]
+    const z = mesh.vertices[index * 3 + 2]
+    positions[index * 3] = x * baseRadius
+    positions[index * 3 + 1] = y * baseRadius
+    positions[index * 3 + 2] = z * baseRadius
+  }
+  const field: RadialDisplacementField = Object.freeze({
+    baseRadius,
+    radii,
+    displacements,
+    positions,
+  })
+  const configuration: PlanetConfiguration = {
+    seed: 0,
+    radii: Object.freeze([baseRadius]),
+    noiseLayers: Object.freeze([]),
+    lodThresholds: Object.freeze([0.1]),
+    seaLevel: 90,
+    surfaceClearance: 5,
+    atmosphereHeight: 40,
+  }
+  const classificationReturn = classifySurfaceBySeaLevel(field, configuration)
+  return { mesh, field, configuration, classificationReturn }
+}
+
+describe('sampleGroundDistance', () => {
+  it('returns radial distance and gradient aligned with the query direction', () => {
+    //1.- Measure a point offset from the ground surface along the positive X axis.
+    const { mesh, field, classificationReturn } = createCollisionFixture()
+    const position = { x: 120, y: 0, z: 0 }
+    const sample = sampleGroundDistance(position, mesh, field, classificationReturn)
+    //2.- Confirm the distance matches the analytic difference and the gradient remains normalised.
+    expect(sample.surfaceRadius).toBe(100)
+    expect(sample.distance).toBeCloseTo(20, 6)
+    expect(Math.hypot(sample.gradient.x, sample.gradient.y, sample.gradient.z)).toBeCloseTo(1, 6)
+    expect(Math.hypot(sample.groundPoint.x, sample.groundPoint.y, sample.groundPoint.z)).toBeCloseTo(100, 6)
+  })
+})
+
+describe('clampVehicleAltitude', () => {
+  it('enforces the configured clearance above the surface', () => {
+    //1.- Position the vehicle within the forbidden clearance band and clamp it outward.
+    const { mesh, field, classificationReturn, configuration } = createCollisionFixture()
+    const position = { x: 102, y: 0, z: 0 }
+    const result = clampVehicleAltitude(position, mesh, field, classificationReturn, configuration)
+    //2.- Ensure the new radius honours the clearance while reporting updated SDF distance.
+    expect(Math.hypot(result.position.x, result.position.y, result.position.z)).toBeCloseTo(105, 6)
+    expect(result.distance).toBeCloseTo(5, 6)
+    expect(result.minRadius).toBeCloseTo(105, 6)
+    expect(result.maxRadius).toBeCloseTo(140, 6)
+  })
+
+  it('caps altitude at the atmospheric ceiling', () => {
+    //1.- Push the sample beyond the permitted orbit and check the clamp uses the ceiling radius.
+    const { mesh, field, classificationReturn, configuration } = createCollisionFixture()
+    const position = { x: 0, y: 0, z: 180 }
+    const result = clampVehicleAltitude(position, mesh, field, classificationReturn, configuration)
+    //2.- Validate the radius equals the base radius plus atmosphere height and preserves heading.
+    expect(Math.hypot(result.position.x, result.position.y, result.position.z)).toBeCloseTo(140, 6)
+    expect(result.distance).toBeCloseTo(40, 6)
+    expect(result.gradient.x).toBeCloseTo(0, 6)
+    expect(result.gradient.z).toBeGreaterThan(0)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/radialSdfCollision.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/radialSdfCollision.ts
@@ -1,0 +1,122 @@
+import type { CubedSphereMesh } from './cubedSphereMesh'
+import type { RadialDisplacementField } from './noiseDisplacement'
+import type { PlanetConfiguration } from './planetSpecLoader'
+import type { SurfaceClassification } from './seaLevelMask'
+
+export interface Vector3Like {
+  readonly x: number
+  readonly y: number
+  readonly z: number
+}
+
+function createVector(x: number, y: number, z: number): Vector3Like {
+  //1.- Materialise lightweight vector records that are serialisable across worker boundaries.
+  return Object.freeze({ x, y, z })
+}
+
+function vectorLength(vector: Vector3Like): number {
+  //1.- Compute the Euclidean magnitude without relying on Three.js helpers that may be mocked in tests.
+  return Math.hypot(vector.x, vector.y, vector.z)
+}
+
+function normaliseVector(vector: Vector3Like): Vector3Like {
+  //1.- Re-scale the vector into a unit direction to reuse across gradient and ground projections.
+  const length = vectorLength(vector)
+  if (length === 0) {
+    throw new Error('Cannot normalise a zero-length vector')
+  }
+  return createVector(vector.x / length, vector.y / length, vector.z / length)
+}
+
+export interface GroundSample {
+  readonly surfaceRadius: number
+  readonly distance: number
+  readonly gradient: Vector3Like
+  readonly groundPoint: Vector3Like
+  readonly vertexIndex: number
+}
+
+function selectNearestVertexIndex(mesh: CubedSphereMesh, direction: Vector3Like): number {
+  //1.- Walk the shared vertex list and pick the direction that maximises alignment with the query.
+  let bestIndex = 0
+  let bestDot = -Infinity
+  for (let index = 0; index < mesh.vertices.length / 3; index += 1) {
+    const vx = mesh.vertices[index * 3]
+    const vy = mesh.vertices[index * 3 + 1]
+    const vz = mesh.vertices[index * 3 + 2]
+    const dot = vx * direction.x + vy * direction.y + vz * direction.z
+    if (dot > bestDot) {
+      bestDot = dot
+      bestIndex = index
+    }
+  }
+  return bestIndex
+}
+
+export function sampleGroundDistance(
+  position: Vector3Like,
+  mesh: CubedSphereMesh,
+  field: RadialDisplacementField,
+  classification: SurfaceClassification
+): GroundSample {
+  //1.- Normalise the position into a unit direction and locate the nearest precomputed vertex.
+  const radius = vectorLength(position)
+  if (radius === 0) {
+    throw new Error('Cannot sample ground distance from the origin')
+  }
+  const direction = normaliseVector(position)
+  const vertexIndex = selectNearestVertexIndex(mesh, direction)
+  //2.- Fetch the corresponding surface radius and derive the signed distance along the radial axis.
+  const surfaceRadius = classification.surfaceRadii[vertexIndex]
+  const distance = radius - surfaceRadius
+  const gradient = direction
+  const groundPoint = createVector(
+    direction.x * surfaceRadius,
+    direction.y * surfaceRadius,
+    direction.z * surfaceRadius,
+  )
+  return {
+    surfaceRadius,
+    distance,
+    gradient,
+    groundPoint,
+    vertexIndex,
+  }
+}
+
+export interface AltitudeClampResult extends GroundSample {
+  readonly position: Vector3Like
+  readonly minRadius: number
+  readonly maxRadius: number
+}
+
+export function clampVehicleAltitude(
+  position: Vector3Like,
+  mesh: CubedSphereMesh,
+  field: RadialDisplacementField,
+  classification: SurfaceClassification,
+  configuration: PlanetConfiguration
+): AltitudeClampResult {
+  //1.- Measure the raw distance to the ground before enforcing vehicle altitude limits.
+  const sample = sampleGroundDistance(position, mesh, field, classification)
+  const { gradient, surfaceRadius } = sample
+  const currentRadius = vectorLength(position)
+  //2.- Clamp the vehicle between the ground clearance and atmospheric ceiling while preserving heading.
+  const minRadius = surfaceRadius + configuration.surfaceClearance
+  const maxRadius = field.baseRadius + configuration.atmosphereHeight
+  const clampedRadius = Math.min(Math.max(currentRadius, minRadius), maxRadius)
+  const clampedPosition = createVector(
+    gradient.x * clampedRadius,
+    gradient.y * clampedRadius,
+    gradient.z * clampedRadius,
+  )
+  const distance = clampedRadius - surfaceRadius
+  return {
+    ...sample,
+    position: clampedPosition,
+    distance,
+    minRadius,
+    maxRadius,
+  }
+}
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/seaLevelMask.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/seaLevelMask.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { generateCubedSphereMesh } from './cubedSphereMesh'
+import type { RadialDisplacementField } from './noiseDisplacement'
+import type { PlanetConfiguration } from './planetSpecLoader'
+import { classifySurfaceBySeaLevel } from './seaLevelMask'
+
+function createTestField(): { field: RadialDisplacementField; configuration: PlanetConfiguration } {
+  //1.- Build a compact cubed-sphere mesh to derive deterministic vertex positions.
+  const mesh = generateCubedSphereMesh(1)
+  const vertexCount = mesh.vertices.length / 3
+  const radii = new Float32Array(vertexCount)
+  const displacements = new Float32Array(vertexCount)
+  const positions = new Float32Array(mesh.vertices.length)
+  const baseRadius = 110
+  for (let index = 0; index < vertexCount; index += 1) {
+    const baseX = mesh.vertices[index * 3]
+    const baseY = mesh.vertices[index * 3 + 1]
+    const baseZ = mesh.vertices[index * 3 + 2]
+    const radius = index % 2 === 0 ? 95 : 120
+    radii[index] = radius
+    displacements[index] = radius - baseRadius
+    positions[index * 3] = baseX * radius
+    positions[index * 3 + 1] = baseY * radius
+    positions[index * 3 + 2] = baseZ * radius
+  }
+  const field: RadialDisplacementField = Object.freeze({
+    baseRadius,
+    radii,
+    displacements,
+    positions,
+  })
+  const configuration: PlanetConfiguration = {
+    seed: 1,
+    radii: Object.freeze([80, baseRadius]),
+    noiseLayers: Object.freeze([]),
+    lodThresholds: Object.freeze([0.1]),
+    seaLevel: 100,
+    surfaceClearance: 2,
+    atmosphereHeight: 50,
+  }
+  return { field, configuration }
+}
+
+describe('classifySurfaceBySeaLevel', () => {
+  it('produces ocean masks for vertices below the configured sea level', () => {
+    //1.- Prepare a radial field with alternating above/below sea level radii.
+    const { field, configuration } = createTestField()
+    const classification = classifySurfaceBySeaLevel(field, configuration)
+    //2.- Validate mask counts and confirm sea-level clamping for ocean vertices.
+    expect(classification.seaLevel).toBe(100)
+    expect(classification.oceanVertexCount).toBeGreaterThan(0)
+    expect(classification.oceanVertexCount + classification.landVertexCount).toBe(
+      field.radii.length
+    )
+    for (let index = 0; index < field.radii.length; index += 1) {
+      if (field.radii[index] <= 100) {
+        expect(classification.oceanMask[index]).toBe(1)
+        expect(classification.surfaceRadii[index]).toBe(100)
+      } else {
+        expect(classification.oceanMask[index]).toBe(0)
+        expect(classification.surfaceRadii[index]).toBe(field.radii[index])
+      }
+    }
+  })
+
+  it('returns immutable buffers sized to the radial field', () => {
+    //1.- Reuse the shared fixture and ensure the returned structure is frozen for thread safety.
+    const { field, configuration } = createTestField()
+    const classification = classifySurfaceBySeaLevel(field, configuration)
+    expect(classification.surfaceRadii.length).toBe(field.radii.length)
+    expect(classification.oceanMask.length).toBe(field.radii.length)
+    expect(Object.isFrozen(classification)).toBe(true)
+  })
+})
+

--- a/tunnelcave_sandbox_web/app/gameplay/planet/seaLevelMask.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/seaLevelMask.ts
@@ -1,0 +1,43 @@
+import type { PlanetConfiguration } from './planetSpecLoader'
+import type { RadialDisplacementField } from './noiseDisplacement'
+
+export interface SurfaceClassification {
+  readonly seaLevel: number
+  readonly surfaceRadii: Float32Array
+  readonly oceanMask: Uint8Array
+  readonly oceanVertexCount: number
+  readonly landVertexCount: number
+}
+
+export function classifySurfaceBySeaLevel(
+  field: RadialDisplacementField,
+  configuration: PlanetConfiguration
+): SurfaceClassification {
+  //1.- Allocate typed buffers mirroring the vertex count so shaders can branch on ocean membership.
+  const vertexCount = field.radii.length
+  const surfaceRadii = new Float32Array(vertexCount)
+  const oceanMask = new Uint8Array(vertexCount)
+  let oceanCount = 0
+  //2.- Clamp each vertex radius against the sea level and flag the classification mask.
+  for (let index = 0; index < vertexCount; index += 1) {
+    const radius = field.radii[index]
+    if (radius <= configuration.seaLevel) {
+      surfaceRadii[index] = configuration.seaLevel
+      oceanMask[index] = 1
+      oceanCount += 1
+    } else {
+      surfaceRadii[index] = radius
+      oceanMask[index] = 0
+    }
+  }
+  const landCount = vertexCount - oceanCount
+  const classification: SurfaceClassification = {
+    seaLevel: configuration.seaLevel,
+    surfaceRadii,
+    oceanMask,
+    oceanVertexCount: oceanCount,
+    landVertexCount: landCount,
+  }
+  return Object.freeze(classification)
+}
+


### PR DESCRIPTION
## Summary
- extend the planet specification loader to validate sea level, surface clearance, and atmosphere height parameters
- add a sea-level surface classification helper with tests to flag ocean vertices and clamp surface radii
- provide radial SDF sampling and vehicle altitude clamping utilities with accompanying coverage

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e357eecfec8329a401d464352a0797