### PR TITLE
feat: add procedural planet generation framework

### DIFF
--- a/typescript-client/src/world/planet/biome.test.ts
+++ b/typescript-client/src/world/planet/biome.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { PlanetBiomes } from "./biome";
+import { parsePlanetSpec } from "./planetSpec";
+
+const spec = parsePlanetSpec({
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 990,
+  seed: 77,
+  displacementLayers: [{ frequency: 2, amplitude: 30 }],
+  temperatureFrequency: 0.4,
+  moistureFrequency: 0.6,
+  lodScreenError: [30, 15, 7.5],
+  scatterBudgetPerLod: [1, 2, 4],
+});
+
+describe("PlanetBiomes", () => {
+  it("returns ocean below sea level", () => {
+    const biomes = new PlanetBiomes(spec);
+    const sample = biomes.sample({ x: 0, y: 0, z: 1 }, spec.seaLevel - 20);
+    expect(sample.biome).toBe("ocean");
+  });
+
+  it("returns varied land biome", () => {
+    const biomes = new PlanetBiomes(spec);
+    const sample = biomes.sample({ x: 1, y: 0.5, z: 0.2 }, spec.radius + 50);
+    expect(["forest", "savanna", "desert", "tundra", "glacier"].includes(sample.biome)).toBe(true);
+  });
+});

--- a/typescript-client/src/world/planet/biome.ts
+++ b/typescript-client/src/world/planet/biome.ts
@@ -1,0 +1,78 @@
+import { DeterministicFbm } from "./noise";
+import type { PlanetSpec } from "./planetSpec";
+
+export type Biome =
+  | "ocean"
+  | "desert"
+  | "savanna"
+  | "forest"
+  | "tundra"
+  | "glacier";
+
+export interface BiomeSample {
+  //1.- Biome string identifier controlling material selection.
+  biome: Biome;
+  //2.- Derived low frequency temperature metric.
+  temperature: number;
+  //3.- Derived low frequency moisture metric.
+  moisture: number;
+}
+
+export class PlanetBiomes {
+  private readonly spec: PlanetSpec;
+  private readonly temperatureNoise: DeterministicFbm;
+  private readonly moistureNoise: DeterministicFbm;
+
+  constructor(spec: PlanetSpec) {
+    //1.- Reuse the deterministic FBM but offset seeds so fields remain decorrelated.
+    this.spec = spec;
+    const temperatureSpec = {
+      ...spec,
+      displacementLayers: spec.displacementLayers.map((layer, index) => ({
+        frequency: layer.frequency * spec.temperatureFrequency,
+        amplitude: layer.amplitude,
+      })),
+      seed: spec.seed + 7,
+    };
+    const moistureSpec = {
+      ...spec,
+      displacementLayers: spec.displacementLayers.map((layer, index) => ({
+        frequency: layer.frequency * spec.moistureFrequency,
+        amplitude: layer.amplitude,
+      })),
+      seed: spec.seed + 13,
+    };
+    this.temperatureNoise = new DeterministicFbm(temperatureSpec);
+    this.moistureNoise = new DeterministicFbm(moistureSpec);
+  }
+
+  sample(direction: { x: number; y: number; z: number }, elevation: number): BiomeSample {
+    //1.- Evaluate climate fields and remap them into [-1, 1].
+    const temperature = this.temperatureNoise.sample(direction);
+    const moisture = this.moistureNoise.sample(direction);
+    //2.- Adjust for elevation so high mountains become colder and drier.
+    const lapseRate = Math.max(0, 1 - elevation / (this.spec.atmosphereHeight + this.spec.radius));
+    const adjustedTemperature = temperature * lapseRate;
+    const adjustedMoisture = moisture * (0.7 + 0.3 * lapseRate);
+    //3.- Map the combination to a discrete biome label.
+    const biome = resolveBiome(adjustedTemperature, adjustedMoisture, elevation < this.spec.seaLevel);
+    return { biome, temperature: adjustedTemperature, moisture: adjustedMoisture };
+  }
+}
+
+function resolveBiome(temperature: number, moisture: number, isUnderSea: boolean): Biome {
+  //1.- Oceans override all land biomes regardless of moisture/temperature ratios.
+  if (isUnderSea) {
+    return "ocean";
+  }
+  if (temperature < -0.4) {
+    return moisture > 0 ? "glacier" : "tundra";
+  }
+  if (temperature < 0.2) {
+    return moisture > 0.3 ? "forest" : "savanna";
+  }
+  if (temperature < 0.6) {
+    return moisture < -0.2 ? "savanna" : "forest";
+  }
+  return moisture < 0 ? "desert" : "savanna";
+}

--- a/typescript-client/src/world/planet/cubedSphere.test.ts
+++ b/typescript-client/src/world/planet/cubedSphere.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildCubeTileMesh, enumerateCircumnavigation } from "./cubedSphere";
+import { parsePlanetSpec } from "./planetSpec";
+
+const spec = parsePlanetSpec({
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 1005,
+  seed: 12345,
+  displacementLayers: [{ frequency: 2, amplitude: 50 }],
+  temperatureFrequency: 0.5,
+  moistureFrequency: 0.4,
+  lodScreenError: [30, 15, 7.5],
+  scatterBudgetPerLod: [2, 4, 8],
+});
+
+describe("buildCubeTileMesh", () => {
+  it("creates edge consistent mesh", () => {
+    const mesh = buildCubeTileMesh(spec, { face: 0, i: 0, j: 0, lod: 2 });
+    expect(mesh.vertices).toHaveLength(((1 << 2) + 1) ** 2);
+    expect(mesh.indices.length % 3).toBe(0);
+  });
+});
+
+describe("enumerateCircumnavigation", () => {
+  it("produces reasonable arc length", () => {
+    const length = enumerateCircumnavigation(spec, 64);
+    const expectedCircumference = 2 * Math.PI * spec.radius;
+    expect(Math.abs(length - expectedCircumference)).toBeLessThan(expectedCircumference * 0.05);
+  });
+});

--- a/typescript-client/src/world/planet/cubedSphere.ts
+++ b/typescript-client/src/world/planet/cubedSphere.ts
@@ -1,0 +1,138 @@
+import type { PlanetSpec } from "./planetSpec";
+
+export type CubeFace = 0 | 1 | 2 | 3 | 4 | 5;
+
+export interface CubeTileKey {
+  //1.- Identify the quadtree location for streaming and scatter keys.
+  face: CubeFace;
+  //2.- Horizontal tile coordinate inside the quadtree level.
+  i: number;
+  //3.- Vertical tile coordinate inside the quadtree level.
+  j: number;
+  //4.- Level-of-detail depth where 0 represents the root face.
+  lod: number;
+}
+
+export interface CubeTileMesh {
+  //1.- Unique key referencing the tile for caching and streaming.
+  key: CubeTileKey;
+  //2.- Ordered list of vertex positions in planet-fixed coordinates.
+  vertices: Array<{ x: number; y: number; z: number }>;
+  //3.- Triangle indices forming an edge-aligned tessellation.
+  indices: number[];
+}
+
+function projectToSphere(u: number, v: number, face: CubeFace, radius: number): {
+  x: number;
+  y: number;
+  z: number;
+} {
+  //1.- Convert a face-local coordinate into 3D space using the cubed-sphere projection.
+  const a = 2 * u - 1;
+  const b = 2 * v - 1;
+  let x = 0;
+  let y = 0;
+  let z = 0;
+  switch (face) {
+    case 0:
+      x = 1;
+      y = a;
+      z = b;
+      break;
+    case 1:
+      x = -1;
+      y = -a;
+      z = b;
+      break;
+    case 2:
+      x = -a;
+      y = 1;
+      z = b;
+      break;
+    case 3:
+      x = a;
+      y = -1;
+      z = b;
+      break;
+    case 4:
+      x = a;
+      y = b;
+      z = 1;
+      break;
+    case 5:
+    default:
+      x = a;
+      y = -b;
+      z = -1;
+      break;
+  }
+  const normalised = 1 / Math.hypot(x, y, z);
+  return { x: x * normalised * radius, y: y * normalised * radius, z: z * normalised * radius };
+}
+
+function tileResolution(lod: number): number {
+  //1.- Each successive level doubles resolution ensuring shared vertices along edges.
+  return (1 << lod) + 1;
+}
+
+function generateIndices(resolution: number): number[] {
+  //1.- Build triangle strips aligned across edges for consistent tessellation between tiles.
+  const indices: number[] = [];
+  for (let y = 0; y < resolution - 1; y += 1) {
+    for (let x = 0; x < resolution - 1; x += 1) {
+      const topLeft = y * resolution + x;
+      const topRight = topLeft + 1;
+      const bottomLeft = topLeft + resolution;
+      const bottomRight = bottomLeft + 1;
+      indices.push(topLeft, bottomLeft, topRight);
+      indices.push(topRight, bottomLeft, bottomRight);
+    }
+  }
+  return indices;
+}
+
+export function buildCubeTileMesh(spec: PlanetSpec, key: CubeTileKey): CubeTileMesh {
+  //1.- Determine the resolution for this level of detail.
+  const resolution = tileResolution(key.lod);
+  const step = 1 / (resolution - 1);
+  const vertices: Array<{ x: number; y: number; z: number }> = [];
+  for (let y = 0; y < resolution; y += 1) {
+    for (let x = 0; x < resolution; x += 1) {
+      const u = (key.i + x * step) / (1 << key.lod);
+      const v = (key.j + y * step) / (1 << key.lod);
+      const projected = projectToSphere(u, v, key.face, spec.radius);
+      vertices.push(projected);
+    }
+  }
+  //2.- Calculate triangle indices ensuring edge consistency.
+  const indices = generateIndices(resolution);
+  return { key, vertices, indices };
+}
+
+export function enumerateCircumnavigation(spec: PlanetSpec, samples: number): number {
+  //1.- Trace a ring along the equator across the four lateral cube faces.
+  const segmentsPerFace = Math.max(1, samples);
+  const points: Array<{ x: number; y: number; z: number }> = [];
+  const faceOrder: CubeTileKey["face"][] = [0, 2, 1, 3];
+  for (const face of faceOrder) {
+    for (let stepIndex = 0; stepIndex <= segmentsPerFace; stepIndex += 1) {
+      if (points.length > 0 && stepIndex === 0) {
+        continue;
+      }
+      const u = stepIndex / segmentsPerFace;
+      const v = 0.5;
+      points.push(projectToSphere(u, v, face, spec.radius));
+    }
+  }
+  if (points.length === 0) {
+    return 0;
+  }
+  points.push(points[0]);
+  let total = 0;
+  for (let i = 1; i < points.length; i += 1) {
+    const a = points[i - 1];
+    const b = points[i];
+    total += Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+  }
+  return total;
+}

--- a/typescript-client/src/world/planet/noise.ts
+++ b/typescript-client/src/world/planet/noise.ts
@@ -1,0 +1,114 @@
+import type { NoiseLayerSpec, PlanetSpec } from "./planetSpec";
+
+const TAU = Math.PI * 2;
+
+function hash3(x: number, y: number, z: number, seed: number): number {
+  //1.- Generate a reproducible pseudo random value by mixing integer coordinates with the seed.
+  const prime1 = 0x9e3779b1;
+  const prime2 = 0x85ebca77;
+  const prime3 = 0xc2b2ae3d;
+  let h = Math.imul(Math.floor(x * 73856093) ^ Math.floor(y * 19349663) ^ Math.floor(z * 83492791), prime1);
+  h = Math.imul(h ^ (h >>> 16) ^ seed, prime2);
+  h ^= h >>> 13;
+  h = Math.imul(h, prime3);
+  h ^= h >>> 16;
+  return (h >>> 0) / 0xffffffff;
+}
+
+function smoothstep(t: number): number {
+  //1.- Ease the interpolation parameter to avoid visible grid artifacts in value noise.
+  return t * t * (3 - 2 * t);
+}
+
+function valueNoise3(x: number, y: number, z: number, seed: number): number {
+  //1.- Compute lattice coordinates and fractional offsets.
+  const xi = Math.floor(x);
+  const yi = Math.floor(y);
+  const zi = Math.floor(z);
+  const xf = x - xi;
+  const yf = y - yi;
+  const zf = z - zi;
+  //2.- Blend hashed corner values with trilinear interpolation.
+  const xfSmooth = smoothstep(xf);
+  const yfSmooth = smoothstep(yf);
+  const zfSmooth = smoothstep(zf);
+  const corner = (dx: number, dy: number, dz: number) =>
+    hash3(xi + dx, yi + dy, zi + dz, seed);
+  const c000 = corner(0, 0, 0);
+  const c100 = corner(1, 0, 0);
+  const c010 = corner(0, 1, 0);
+  const c110 = corner(1, 1, 0);
+  const c001 = corner(0, 0, 1);
+  const c101 = corner(1, 0, 1);
+  const c011 = corner(0, 1, 1);
+  const c111 = corner(1, 1, 1);
+  const x00 = c000 * (1 - xfSmooth) + c100 * xfSmooth;
+  const x10 = c010 * (1 - xfSmooth) + c110 * xfSmooth;
+  const x01 = c001 * (1 - xfSmooth) + c101 * xfSmooth;
+  const x11 = c011 * (1 - xfSmooth) + c111 * xfSmooth;
+  const y0 = x00 * (1 - yfSmooth) + x10 * yfSmooth;
+  const y1 = x01 * (1 - yfSmooth) + x11 * yfSmooth;
+  return y0 * (1 - zfSmooth) + y1 * zfSmooth;
+}
+
+export class DeterministicFbm {
+  private readonly layers: NoiseLayerSpec[];
+  private readonly seed: number;
+
+  constructor(spec: PlanetSpec) {
+    //1.- Copy only the parameters required for FBM evaluation to keep the instance self-contained.
+    this.layers = [...spec.displacementLayers];
+    this.seed = spec.seed;
+  }
+
+  sample(direction: { x: number; y: number; z: number }): number {
+    //1.- Normalise the vector to guarantee seam-free evaluation regardless of input length.
+    const length = Math.hypot(direction.x, direction.y, direction.z);
+    if (length === 0) {
+      return 0;
+    }
+    const nx = direction.x / length;
+    const ny = direction.y / length;
+    const nz = direction.z / length;
+    let value = 0;
+    let amplitudeSum = 0;
+    //2.- Accumulate octave contributions evaluated on the unit vector.
+    for (let i = 0; i < this.layers.length; i += 1) {
+      const layer = this.layers[i];
+      const scale = layer.frequency;
+      const noise = valueNoise3(nx * scale, ny * scale, nz * scale, this.seed + i * 1013);
+      value += (noise * 2 - 1) * layer.amplitude;
+      amplitudeSum += Math.abs(layer.amplitude);
+    }
+    //3.- Normalise by total amplitude to keep the displacement stable across specifications.
+    if (amplitudeSum === 0) {
+      return 0;
+    }
+    return value / amplitudeSum;
+  }
+
+  gradient(direction: { x: number; y: number; z: number }, epsilon = 1e-3): {
+    x: number;
+    y: number;
+    z: number;
+  } {
+    //1.- Approximate partial derivatives using central differences to feed collision normals.
+    const sampleAt = (dx: number, dy: number, dz: number) =>
+      this.sample({ x: direction.x + dx, y: direction.y + dy, z: direction.z + dz });
+    const gx = (sampleAt(epsilon, 0, 0) - sampleAt(-epsilon, 0, 0)) / (2 * epsilon);
+    const gy = (sampleAt(0, epsilon, 0) - sampleAt(0, -epsilon, 0)) / (2 * epsilon);
+    const gz = (sampleAt(0, 0, epsilon) - sampleAt(0, 0, -epsilon)) / (2 * epsilon);
+    return { x: gx, y: gy, z: gz };
+  }
+}
+
+export function wrapAngle(angle: number): number {
+  //1.- Clamp longitudes into [-pi, pi] so cubed-sphere seams remain stable.
+  let wrapped = angle % TAU;
+  if (wrapped <= -Math.PI) {
+    wrapped += TAU;
+  } else if (wrapped > Math.PI) {
+    wrapped -= TAU;
+  }
+  return wrapped;
+}

--- a/typescript-client/src/world/planet/planetSpec.test.ts
+++ b/typescript-client/src/world/planet/planetSpec.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parsePlanetSpec } from "./planetSpec";
+
+const validSpec = {
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 1005,
+  seed: 12345,
+  displacementLayers: [
+    { frequency: 2, amplitude: 50 },
+    { frequency: 4, amplitude: 20 },
+  ],
+  temperatureFrequency: 0.5,
+  moistureFrequency: 0.4,
+  lodScreenError: [30, 15, 7.5],
+  scatterBudgetPerLod: [2, 4, 8],
+};
+
+describe("parsePlanetSpec", () => {
+  it("parses valid configuration", () => {
+    const spec = parsePlanetSpec(validSpec);
+    expect(spec.radius).toBe(1000);
+    expect(spec.lodScreenError).toHaveLength(3);
+  });
+
+  it("throws for missing displacement", () => {
+    expect(() => parsePlanetSpec({ ...validSpec, displacementLayers: [] })).toThrow();
+  });
+});

--- a/typescript-client/src/world/planet/planetSpec.ts
+++ b/typescript-client/src/world/planet/planetSpec.ts
@@ -1,0 +1,113 @@
+export interface NoiseLayerSpec {
+  //1.- Describe the spectral characteristics for a single fractal octave.
+  frequency: number;
+  //2.- Amplitude scales the contribution of this octave to the displacement field.
+  amplitude: number;
+}
+
+export interface PlanetSpec {
+  //1.- Core planet radius forming the base sphere before displacements.
+  radius: number;
+  //2.- Height of the atmosphere shell above the reference radius.
+  atmosphereHeight: number;
+  //3.- Elevation below which points are flooded and rendered as ocean.
+  seaLevel: number;
+  //4.- Seed ensures reproducible noise sampling and streaming layout.
+  seed: number;
+  //5.- Fractal noise layers used to compute the radial displacement.
+  displacementLayers: NoiseLayerSpec[];
+  //6.- Low frequency temperature field controls biome selection.
+  temperatureFrequency: number;
+  //7.- Low frequency moisture field controls biome selection.
+  moistureFrequency: number;
+  //8.- Screen space error thresholds for quadtree refinement per LOD.
+  lodScreenError: number[];
+  //9.- Desired number of blue-noise instances per tile at each LOD.
+  scatterBudgetPerLod: number[];
+}
+
+export function parsePlanetSpec(json: unknown): PlanetSpec {
+  //1.- Validate the runtime structure to guard against malformed configuration blobs.
+  if (typeof json !== "object" || json === null) {
+    throw new Error("Planet spec must be an object");
+  }
+  const spec = json as Record<string, unknown>;
+  const radius = Number(spec.radius);
+  const atmosphereHeight = Number(spec.atmosphereHeight);
+  const seaLevel = Number(spec.seaLevel);
+  const seed = Number(spec.seed);
+  if (!Number.isFinite(radius) || radius <= 0) {
+    throw new Error("Planet radius must be a positive number");
+  }
+  if (!Number.isFinite(atmosphereHeight) || atmosphereHeight <= 0) {
+    throw new Error("Atmosphere height must be a positive number");
+  }
+  if (!Number.isFinite(seaLevel)) {
+    throw new Error("Sea level must be a finite number");
+  }
+  if (!Number.isFinite(seed)) {
+    throw new Error("Seed must be a finite number");
+  }
+  const displacementLayers = Array.isArray(spec.displacementLayers)
+    ? spec.displacementLayers.map((layer) => {
+        if (typeof layer !== "object" || layer === null) {
+          throw new Error("Displacement layer must be an object");
+        }
+        const frequency = Number((layer as Record<string, unknown>).frequency);
+        const amplitude = Number((layer as Record<string, unknown>).amplitude);
+        if (!Number.isFinite(frequency) || frequency <= 0) {
+          throw new Error("Displacement frequency must be a positive number");
+        }
+        if (!Number.isFinite(amplitude)) {
+          throw new Error("Displacement amplitude must be finite");
+        }
+        return { frequency, amplitude } satisfies NoiseLayerSpec;
+      })
+    : [];
+  if (displacementLayers.length === 0) {
+    throw new Error("At least one displacement layer is required");
+  }
+  const temperatureFrequency = Number(spec.temperatureFrequency);
+  const moistureFrequency = Number(spec.moistureFrequency);
+  if (!Number.isFinite(temperatureFrequency) || temperatureFrequency <= 0) {
+    throw new Error("Temperature frequency must be positive");
+  }
+  if (!Number.isFinite(moistureFrequency) || moistureFrequency <= 0) {
+    throw new Error("Moisture frequency must be positive");
+  }
+  const lodScreenError = Array.isArray(spec.lodScreenError)
+    ? spec.lodScreenError.map((value) => {
+        const num = Number(value);
+        if (!Number.isFinite(num) || num <= 0) {
+          throw new Error("LOD screen error values must be positive numbers");
+        }
+        return num;
+      })
+    : [];
+  if (lodScreenError.length === 0) {
+    throw new Error("At least one LOD screen error threshold is required");
+  }
+  const scatterBudgetPerLod = Array.isArray(spec.scatterBudgetPerLod)
+    ? spec.scatterBudgetPerLod.map((value) => {
+        const num = Number(value);
+        if (!Number.isFinite(num) || num < 0) {
+          throw new Error("Scatter budget values must be non-negative numbers");
+        }
+        return num;
+      })
+    : [];
+  if (scatterBudgetPerLod.length !== lodScreenError.length) {
+    throw new Error("Scatter budget entries must match LOD thresholds");
+  }
+  return {
+    radius,
+    atmosphereHeight,
+    seaLevel,
+    seed,
+    displacementLayers,
+    temperatureFrequency,
+    moistureFrequency,
+    lodScreenError,
+    scatterBudgetPerLod,
+  } satisfies PlanetSpec;
+}

--- a/typescript-client/src/world/planet/quadtree.test.ts
+++ b/typescript-client/src/world/planet/quadtree.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { CubeQuadtreeLod } from "./quadtree";
+import { parsePlanetSpec } from "./planetSpec";
+
+const spec = parsePlanetSpec({
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 1005,
+  seed: 42,
+  displacementLayers: [{ frequency: 2, amplitude: 10 }],
+  temperatureFrequency: 0.5,
+  moistureFrequency: 0.4,
+  lodScreenError: [60, 30, 15, 7.5],
+  scatterBudgetPerLod: [1, 2, 4, 8],
+});
+
+describe("CubeQuadtreeLod", () => {
+  it("refines near camera", () => {
+    const lod = new CubeQuadtreeLod(spec);
+    const selection = lod.select({ position: { x: 0, y: 0, z: spec.radius + 10 }, fov: Math.PI / 3, viewportHeight: 1080 });
+    expect(selection.selected.length).toBeGreaterThan(6);
+  });
+});

--- a/typescript-client/src/world/planet/quadtree.ts
+++ b/typescript-client/src/world/planet/quadtree.ts
@@ -1,0 +1,89 @@
+import type { CubeTileKey } from "./cubedSphere";
+import type { PlanetSpec } from "./planetSpec";
+
+export interface LodSelection {
+  //1.- List of tiles to render at the evaluated viewpoint.
+  selected: CubeTileKey[];
+  //2.- Tiles that should be evicted from caches due to over-refinement.
+  dropped: CubeTileKey[];
+}
+
+export interface CameraState {
+  //1.- Position of the camera in planet-fixed coordinates.
+  position: { x: number; y: number; z: number };
+  //2.- Horizontal field of view in radians used to estimate screen error.
+  fov: number;
+  //3.- Pixel height of the viewport.
+  viewportHeight: number;
+}
+
+interface Node {
+  key: CubeTileKey;
+  error: number;
+  children?: Node[];
+}
+
+function screenSpaceError(
+  spec: PlanetSpec,
+  key: CubeTileKey,
+  camera: CameraState,
+  cameraDistance: number,
+): number {
+  //1.- Derive geometric error based on tile size and distance to viewpoint.
+  const worldSize = (spec.radius * Math.PI) / (1 << key.lod);
+  const projected = (worldSize / cameraDistance) * camera.viewportHeight * (2 / camera.fov);
+  return projected;
+}
+
+export class CubeQuadtreeLod {
+  private readonly spec: PlanetSpec;
+
+  constructor(spec: PlanetSpec) {
+    //1.- Keep the specification handy so LOD thresholds remain reproducible.
+    this.spec = spec;
+  }
+
+  select(camera: CameraState): LodSelection {
+    //1.- Evaluate each cube face independently and merge the resulting tile keys.
+    const selected: CubeTileKey[] = [];
+    const dropped: CubeTileKey[] = [];
+    const cameraDistance = Math.max(
+      Math.hypot(camera.position.x, camera.position.y, camera.position.z) - this.spec.radius,
+      1e-3,
+    );
+    for (let face = 0; face < 6; face += 1) {
+      this.traverse({ face: face as CubeTileKey["face"], i: 0, j: 0, lod: 0 }, camera, cameraDistance, selected, dropped);
+    }
+    return { selected, dropped };
+  }
+
+  private traverse(
+    key: CubeTileKey,
+    camera: CameraState,
+    cameraDistance: number,
+    selected: CubeTileKey[],
+    dropped: CubeTileKey[],
+  ): void {
+    //1.- Determine the threshold for the current level and whether we must refine the node.
+    const threshold = this.spec.lodScreenError[Math.min(key.lod, this.spec.lodScreenError.length - 1)];
+    const error = screenSpaceError(this.spec, key, camera, cameraDistance);
+    if (error <= threshold || key.lod + 1 >= this.spec.lodScreenError.length) {
+      selected.push(key);
+      return;
+    }
+    //2.- Split into four children maintaining edge consistency across neighbouring tiles.
+    const nextLod = key.lod + 1;
+    const childI = key.i * 2;
+    const childJ = key.j * 2;
+    const children: CubeTileKey[] = [
+      { face: key.face, i: childI, j: childJ, lod: nextLod },
+      { face: key.face, i: childI + 1, j: childJ, lod: nextLod },
+      { face: key.face, i: childI, j: childJ + 1, lod: nextLod },
+      { face: key.face, i: childI + 1, j: childJ + 1, lod: nextLod },
+    ];
+    for (const child of children) {
+      this.traverse(child, camera, cameraDistance, selected, dropped);
+    }
+    dropped.push(key);
+  }
+}

--- a/typescript-client/src/world/planet/scatter.test.ts
+++ b/typescript-client/src/world/planet/scatter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { scatterInstances } from "./scatter";
+import { parsePlanetSpec } from "./planetSpec";
+
+const spec = parsePlanetSpec({
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 990,
+  seed: 99,
+  displacementLayers: [{ frequency: 2, amplitude: 15 }],
+  temperatureFrequency: 0.4,
+  moistureFrequency: 0.6,
+  lodScreenError: [30, 15, 7.5],
+  scatterBudgetPerLod: [1, 3, 5],
+});
+
+describe("scatterInstances", () => {
+  it("generates deterministic ids", () => {
+    const a = scatterInstances(spec, { face: 0, i: 0, j: 0, lod: 1 });
+    const b = scatterInstances(spec, { face: 0, i: 0, j: 0, lod: 1 });
+    expect(a.map((item) => item.id)).toEqual(b.map((item) => item.id));
+  });
+});

--- a/typescript-client/src/world/planet/scatter.ts
+++ b/typescript-client/src/world/planet/scatter.ts
@@ -1,0 +1,46 @@
+import type { CubeTileKey } from "./cubedSphere";
+import type { PlanetSpec } from "./planetSpec";
+
+export interface ScatterInstance {
+  //1.- Deterministically generated unique identifier per instance.
+  id: string;
+  //2.- Position relative to the tile in barycentric coordinates for later placement.
+  localPosition: { x: number; y: number; z: number };
+}
+
+function halton(index: number, base: number): number {
+  //1.- Generate low-discrepancy sequence value for blue-noise approximation.
+  let result = 0;
+  let f = 1;
+  let i = index;
+  while (i > 0) {
+    f /= base;
+    result += f * (i % base);
+    i = Math.floor(i / base);
+  }
+  return result;
+}
+
+function hashTile(key: CubeTileKey, seed: number): number {
+  //1.- Blend face, coordinates, lod, and external seed into a reproducible hash.
+  let h = key.face * 73856093 + key.i * 19349663 + key.j * 83492791 + key.lod * 2971215073;
+  h ^= seed + 0x9e3779b9 + (h << 6) + (h >> 2);
+  return h >>> 0;
+}
+
+export function scatterInstances(spec: PlanetSpec, key: CubeTileKey): ScatterInstance[] {
+  //1.- Determine how many instances this tile should host based on the configured budget.
+  const budget = spec.scatterBudgetPerLod[Math.min(key.lod, spec.scatterBudgetPerLod.length - 1)];
+  const instances: ScatterInstance[] = [];
+  const tileHash = hashTile(key, spec.seed);
+  for (let n = 1; n <= budget; n += 1) {
+    const hx = halton(n + tileHash, 2);
+    const hy = halton(n + tileHash, 3);
+    const hz = halton(n + tileHash, 5);
+    instances.push({
+      id: `${key.face}:${key.lod}:${key.i}:${key.j}:${n}`,
+      localPosition: { x: hx, y: hy, z: hz },
+    });
+  }
+  return instances;
+}

--- a/typescript-client/src/world/planet/sdf.test.ts
+++ b/typescript-client/src/world/planet/sdf.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { PlanetSdf } from "./sdf";
+import { parsePlanetSpec } from "./planetSpec";
+
+const spec = parsePlanetSpec({
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 1002,
+  seed: 987,
+  displacementLayers: [{ frequency: 2, amplitude: 10 }],
+  temperatureFrequency: 0.3,
+  moistureFrequency: 0.5,
+  lodScreenError: [30, 15, 7.5],
+  scatterBudgetPerLod: [1, 2, 4],
+});
+
+describe("PlanetSdf", () => {
+  it("samples distance and normal", () => {
+    const sdf = new PlanetSdf(spec);
+    const sample = sdf.sample({ x: 0, y: 0, z: spec.radius + 5 });
+    expect(sample.distance).toBeGreaterThan(-20);
+    expect(sample.normal.z).toBeGreaterThan(0.5);
+  });
+
+  it("clamps altitude within shell", () => {
+    const sdf = new PlanetSdf(spec);
+    const clamped = sdf.clampAltitude({ x: 0, y: 0, z: spec.radius * 2 }, 5);
+    const maxRadius = spec.radius + spec.atmosphereHeight;
+    expect(Math.hypot(clamped.clamped.x, clamped.clamped.y, clamped.clamped.z)).toBeLessThanOrEqual(maxRadius + 1e-3);
+  });
+});

--- a/typescript-client/src/world/planet/sdf.ts
+++ b/typescript-client/src/world/planet/sdf.ts
@@ -1,0 +1,89 @@
+import { DeterministicFbm } from "./noise";
+import type { PlanetSpec } from "./planetSpec";
+
+export interface SdfSample {
+  //1.- Signed distance from the query position to the displaced surface.
+  distance: number;
+  //2.- Normal vector derived from the gradient for collision responses.
+  normal: { x: number; y: number; z: number };
+  //3.- Scalar displacement applied to the base radius at this direction.
+  displacement: number;
+  //4.- Whether the sample lies below the defined sea level plane.
+  isOcean: boolean;
+}
+
+export class PlanetSdf {
+  private readonly spec: PlanetSpec;
+  private readonly fbm: DeterministicFbm;
+
+  constructor(spec: PlanetSpec) {
+    //1.- Store the specification and initialise the deterministic noise generator.
+    this.spec = spec;
+    this.fbm = new DeterministicFbm(spec);
+  }
+
+  displacementAt(direction: { x: number; y: number; z: number }): number {
+    //1.- Evaluate fractal noise on the unit direction to obtain radial offset.
+    return this.fbm.sample(direction);
+  }
+
+  groundRadius(direction: { x: number; y: number; z: number }): number {
+    //1.- Combine base radius with displacement to get the final ground radius.
+    return this.spec.radius + this.displacementAt(direction);
+  }
+
+  sample(position: { x: number; y: number; z: number }): SdfSample {
+    //1.- Compute radial distance and unit vector towards the query point.
+    const distanceToCenter = Math.hypot(position.x, position.y, position.z);
+    const direction =
+      distanceToCenter === 0
+        ? { x: 0, y: 1, z: 0 }
+        : { x: position.x / distanceToCenter, y: position.y / distanceToCenter, z: position.z / distanceToCenter };
+    //2.- Obtain the ground radius and signed distance relative to the surface.
+    const displacement = this.displacementAt(direction);
+    const surfaceRadius = this.spec.radius + displacement;
+    const signedDistance = distanceToCenter - surfaceRadius;
+    //3.- Approximate normal via gradient sampling.
+    const gradient = this.fbm.gradient(direction);
+    const normal = normalise({
+      x: direction.x - gradient.x,
+      y: direction.y - gradient.y,
+      z: direction.z - gradient.z,
+    });
+    //4.- Determine if the sample is flooded by comparing displacement to sea level.
+    const isOcean = surfaceRadius < this.spec.seaLevel;
+    return { distance: signedDistance, normal, displacement, isOcean };
+  }
+
+  clampAltitude(position: { x: number; y: number; z: number }, clearance: number): {
+    clamped: { x: number; y: number; z: number };
+    altitude: number;
+  } {
+    //1.- Ensure the point stays between ground+clearance and the atmosphere shell.
+    const distanceToCenter = Math.hypot(position.x, position.y, position.z);
+    const direction =
+      distanceToCenter === 0
+        ? { x: 0, y: 1, z: 0 }
+        : { x: position.x / distanceToCenter, y: position.y / distanceToCenter, z: position.z / distanceToCenter };
+    const ground = this.groundRadius(direction) + clearance;
+    const maxRadius = this.spec.radius + this.spec.atmosphereHeight;
+    const clampedRadius = Math.min(Math.max(distanceToCenter, ground), maxRadius);
+    return {
+      clamped: {
+        x: direction.x * clampedRadius,
+        y: direction.y * clampedRadius,
+        z: direction.z * clampedRadius,
+      },
+      altitude: clampedRadius - ground,
+    };
+  }
+}
+
+function normalise(vector: { x: number; y: number; z: number }): { x: number; y: number; z: number } {
+  //1.- Prevent zero-length normals while providing stable fallback direction.
+  const length = Math.hypot(vector.x, vector.y, vector.z);
+  if (length === 0) {
+    return { x: 0, y: 1, z: 0 };
+  }
+  return { x: vector.x / length, y: vector.y / length, z: vector.z / length };
+}

--- a/typescript-client/src/world/planet/vehicleIntegration.test.ts
+++ b/typescript-client/src/world/planet/vehicleIntegration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { PlanetVehicleIntegrator } from "./vehicleIntegration";
+import { parsePlanetSpec } from "./planetSpec";
+
+const spec = parsePlanetSpec({
+  radius: 1000,
+  atmosphereHeight: 200,
+  seaLevel: 990,
+  seed: 21,
+  displacementLayers: [{ frequency: 2, amplitude: 10 }],
+  temperatureFrequency: 0.4,
+  moistureFrequency: 0.6,
+  lodScreenError: [30, 15, 7.5],
+  scatterBudgetPerLod: [1, 2, 4],
+});
+
+describe("PlanetVehicleIntegrator", () => {
+  it("prevents vehicles tunnelling underground", () => {
+    const integrator = new PlanetVehicleIntegrator(spec, { clearance: 5, maxDt: 0.1 });
+    const result = integrator.integrate(
+      {
+        position: { x: 0, y: 0, z: spec.radius + 1 },
+        velocity: { x: 0, y: 0, z: -10 },
+      },
+      { x: 0, y: 0, z: -50 },
+      0.1,
+    );
+    const sampleRadius = Math.hypot(result.position.x, result.position.y, result.position.z);
+    expect(sampleRadius).toBeGreaterThanOrEqual(spec.radius - 1);
+  });
+});

--- a/typescript-client/src/world/planet/vehicleIntegration.ts
+++ b/typescript-client/src/world/planet/vehicleIntegration.ts
@@ -1,0 +1,76 @@
+import { PlanetSdf } from "./sdf";
+import type { PlanetSpec } from "./planetSpec";
+
+export interface VehicleState {
+  //1.- Current position of the vehicle in planet-fixed coordinates.
+  position: { x: number; y: number; z: number };
+  //2.- Velocity vector expressed in the same reference frame.
+  velocity: { x: number; y: number; z: number };
+}
+
+export interface VehicleIntegrationOptions {
+  //1.- Clearance distance that vehicles must keep above the terrain.
+  clearance: number;
+  //2.- Maximum integration time step to preserve stability.
+  maxDt: number;
+}
+
+export class PlanetVehicleIntegrator {
+  private readonly sdf: PlanetSdf;
+  private readonly options: VehicleIntegrationOptions;
+
+  constructor(spec: PlanetSpec, options: VehicleIntegrationOptions) {
+    //1.- Compose the integrator with an SDF evaluator for collision handling.
+    this.sdf = new PlanetSdf(spec);
+    this.options = options;
+  }
+
+  integrate(state: VehicleState, acceleration: { x: number; y: number; z: number }, dt: number): VehicleState {
+    //1.- Clamp the time step to avoid overshooting during sub-stepping.
+    const step = Math.min(Math.max(dt, 0), this.options.maxDt);
+    const velocity = {
+      x: state.velocity.x + acceleration.x * step,
+      y: state.velocity.y + acceleration.y * step,
+      z: state.velocity.z + acceleration.z * step,
+    };
+    const position = {
+      x: state.position.x + velocity.x * step,
+      y: state.position.y + velocity.y * step,
+      z: state.position.z + velocity.z * step,
+    };
+    //2.- Query the signed distance to enforce the clearance constraint.
+    const sample = this.sdf.sample(position);
+    const clearance = sample.distance - this.options.clearance;
+    let resolvedPosition = position;
+    let resolvedVelocity = velocity;
+    if (clearance < 0) {
+      const correction = -clearance;
+      resolvedPosition = {
+        x: position.x + sample.normal.x * correction,
+        y: position.y + sample.normal.y * correction,
+        z: position.z + sample.normal.z * correction,
+      };
+      const dot =
+        velocity.x * sample.normal.x +
+        velocity.y * sample.normal.y +
+        velocity.z * sample.normal.z;
+      resolvedVelocity = {
+        x: velocity.x - sample.normal.x * dot,
+        y: velocity.y - sample.normal.y * dot,
+        z: velocity.z - sample.normal.z * dot,
+      };
+    }
+    //3.- Clamp against the upper atmosphere boundary.
+    const clamped = this.sdf.clampAltitude(resolvedPosition, this.options.clearance);
+    const speed = Math.hypot(resolvedVelocity.x, resolvedVelocity.y, resolvedVelocity.z);
+    const direction = speed === 0 ? { x: 0, y: 0, z: 0 } : {
+      x: resolvedVelocity.x / speed,
+      y: resolvedVelocity.y / speed,
+      z: resolvedVelocity.z / speed,
+    };
+    return {
+      position: clamped.clamped,
+      velocity: { x: direction.x * speed, y: direction.y * speed, z: direction.z * speed },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add deterministic planet specification parsing, noise sampling, and cubed-sphere mesh generation utilities
- implement SDF-based terrain queries, biome selection, scatter placement, and vehicle integration helpers
- cover the new functionality with focused Vitest suites for spec parsing, geometry, LOD streaming, biomes, scattering, SDF, and vehicle constraints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e35be3620483298a556097b0e91cf8