### PR TITLE
feat: show vehicles on fullscreen sandbox

### DIFF
--- a/planet_sandbox_web/src/App.tsx
+++ b/planet_sandbox_web/src/App.tsx
@@ -4,10 +4,6 @@ import './style.css';
 const App = () => {
   return (
     <main className="app-container">
-      <header>
-        <h1>Planet Sandbox</h1>
-        <p>Navigate a spherical world and stay within the atmosphere.</p>
-      </header>
       <PlanetSandbox />
     </main>
   );

--- a/planet_sandbox_web/src/lib/vehicleFleet.test.ts
+++ b/planet_sandbox_web/src/lib/vehicleFleet.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { blueprintToSnapshot, VehicleBlueprint } from './vehicleFleet';
+
+describe('blueprintToSnapshot', () => {
+  it('converts a vehicle blueprint into a neutral telemetry snapshot', () => {
+    const blueprint: VehicleBlueprint = {
+      id: 'observer',
+      start: { latitudeDeg: 12.5, longitudeDeg: -42.75, altitude: 1_500 },
+      command: { headingDeg: 90, distance: 1_000, climb: 10 }
+    };
+
+    const snapshot = blueprintToSnapshot(blueprint);
+
+    expect(snapshot).toEqual({
+      id: 'observer',
+      position: { latitudeDeg: 12.5, longitudeDeg: -42.75, altitude: 1_500 },
+      laps: 0,
+      touchingSurface: false,
+      hittingCeiling: false
+    });
+  });
+
+  it('returns a defensive copy of the vehicle position', () => {
+    const blueprint: VehicleBlueprint = {
+      id: 'spectator',
+      start: { latitudeDeg: 0, longitudeDeg: 0, altitude: 1_200 },
+      command: { headingDeg: 45, distance: 2_000, climb: 5 }
+    };
+
+    const snapshot = blueprintToSnapshot(blueprint);
+    snapshot.position.latitudeDeg = 90;
+
+    expect(blueprint.start.latitudeDeg).toBe(0);
+  });
+});

--- a/planet_sandbox_web/src/lib/vehicleFleet.ts
+++ b/planet_sandbox_web/src/lib/vehicleFleet.ts
@@ -46,3 +46,14 @@ export class VehicleFleet {
     return snapshots;
   }
 }
+
+export const blueprintToSnapshot = (blueprint: VehicleBlueprint): VehicleSnapshot => {
+  //1.- Mirror the blueprint starting state into telemetry friendly structures.
+  return {
+    id: blueprint.id,
+    position: { ...blueprint.start },
+    laps: 0,
+    touchingSurface: false,
+    hittingCeiling: false
+  };
+};

--- a/planet_sandbox_web/src/style.css
+++ b/planet_sandbox_web/src/style.css
@@ -5,21 +5,21 @@
   color: #f0f5ff;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+}
+
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: 100%;
+  overflow: hidden;
 }
 
 .app-container {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  align-items: center;
-  padding: 2rem;
-}
-
-header {
-  text-align: center;
+  height: 100%;
+  width: 100%;
 }
 
 canvas {
@@ -28,13 +28,17 @@ canvas {
 }
 
 .info-panel {
+  position: absolute;
+  right: clamp(1rem, 4vw, 2.5rem);
+  bottom: clamp(1rem, 4vw, 2.5rem);
   background: rgba(14, 24, 52, 0.8);
   border-radius: 12px;
   padding: 1rem 1.5rem;
   display: grid;
   gap: 0.5rem;
-  width: min(480px, 90vw);
+  width: min(360px, 90vw);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
 }
 
 .info-panel span {
@@ -58,8 +62,10 @@ canvas {
 }
 
 .vehicle-status li {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+  align-items: center;
   font-size: 0.9rem;
   background: rgba(18, 38, 74, 0.6);
   padding: 0.35rem 0.5rem;
@@ -71,14 +77,54 @@ canvas {
 }
 
 .sandbox-wrapper {
-  display: grid;
-  gap: 1.5rem;
-  place-items: center;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.sandbox-wrapper > div {
-  background: radial-gradient(circle, rgba(80, 180, 255, 0.2), rgba(6, 18, 40, 0.9));
+.canvas-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  background: radial-gradient(circle, rgba(80, 180, 255, 0.12), rgba(6, 18, 40, 0.9));
   border: 1px solid rgba(78, 198, 255, 0.35);
   border-radius: 20px;
   overflow: hidden;
+}
+
+.canvas-container canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.sandbox-header {
+  position: absolute;
+  left: clamp(1rem, 4vw, 2.5rem);
+  top: clamp(1rem, 4vw, 2.5rem);
+  background: rgba(3, 16, 33, 0.8);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  max-width: min(420px, 90vw);
+  border: 1px solid rgba(78, 198, 255, 0.2);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.45);
+}
+
+.sandbox-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.sandbox-header p {
+  margin: 0;
+  line-height: 1.4;
+  font-size: clamp(0.95rem, 2vw, 1.1rem);
+}
+
+.vehicle-status ul {
+  grid-template-columns: 1fr;
 }


### PR DESCRIPTION
## Summary
- expand the planet sandbox viewport to occupy the full screen with overlay panels
- seed vehicle telemetry so companion meshes render immediately on load
- add a reusable helper and tests for converting vehicle blueprints into snapshots

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e3ac4851e08329a4661f8518031fb0