### PR TITLE
Add planetary sandbox panel to gameplay route

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/page.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.test.tsx
@@ -22,6 +22,11 @@ vi.mock('./BattlefieldCanvas', () => ({
   ),
 }))
 
+vi.mock('./planetSandbox/PlanetaryMapPanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-planet-panel">planet-panel</div>,
+}))
+
 describe('GameplayPage', () => {
   beforeEach(() => {
     //1.- Reset the DOM between scenarios to avoid leaking rendered components or validation states.
@@ -53,7 +58,7 @@ describe('GameplayPage', () => {
     expect(screen.queryByTestId('battle-stage')).toBeNull()
   })
 
-  it('mounts the battlefield when launch conditions are satisfied', async () => {
+  it('mounts the battlefield and planet panel when launch conditions are satisfied', async () => {
     const { default: GameplayPage } = await import('./page')
     render(<GameplayPage />)
     fireEvent.click(screen.getByTestId('join-button'))
@@ -63,6 +68,8 @@ describe('GameplayPage', () => {
     fireEvent.click(screen.getByTestId('launch-button'))
     expect(screen.queryByTestId('battle-stage')).not.toBeNull()
     expect(screen.getByTestId('mock-canvas').textContent).toContain('Nova-aurora-pilot')
+    //2.- The sandbox panel should render alongside the battlefield layout.
+    expect(screen.queryByTestId('mock-planet-panel')).not.toBeNull()
   })
 
   it('generates the shared battlefield using the global world seed', async () => {
@@ -72,4 +79,3 @@ describe('GameplayPage', () => {
     expect(generateBattlefieldMock).toHaveBeenCalledWith(SHARED_WORLD_SEED)
   })
 })
-

--- a/tunnelcave_sandbox_web/app/gameplay/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { useMemo, useState } from 'react'
 
 import BattlefieldCanvas from './BattlefieldCanvas'
+import PlanetaryMapPanel from './planetSandbox/PlanetaryMapPanel'
 import { generateBattlefield } from './generateBattlefield'
 import { createPlayerSessionId } from './playerSession'
 import { VEHICLE_IDS, type VehicleId } from './vehicles'
@@ -95,10 +96,14 @@ export default function GameplayPage() {
       )}
       {stage === 'battle' && (
         <section className="battle-stage" data-testid="battle-stage">
-          <BattlefieldCanvas config={battlefield} playerName={playerName} sessionId={sessionId} vehicleId={vehicleId} />
+          <div className="battle-stage-content">
+            <div className="battle-stage-canvas" data-testid="battle-stage-canvas">
+              <BattlefieldCanvas config={battlefield} playerName={playerName} sessionId={sessionId} vehicleId={vehicleId} />
+            </div>
+            <PlanetaryMapPanel />
+          </div>
         </section>
       )}
     </main>
   )
 }
-

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/PlanetaryMapPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/PlanetaryMapPanel.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+describe('PlanetaryMapPanel', () => {
+  const originalWebGl = globalThis.window?.WebGLRenderingContext
+
+  beforeEach(() => {
+    //1.- Force the component to skip WebGL setup within the test environment.
+    Object.defineProperty(window, 'WebGLRenderingContext', {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'WebGLRenderingContext', {
+      configurable: true,
+      value: originalWebGl,
+      writable: true,
+    })
+  })
+
+  it('renders telemetry using the initial blueprint snapshots', async () => {
+    const { default: PlanetaryMapPanel } = await import('./PlanetaryMapPanel')
+    render(<PlanetaryMapPanel />)
+
+    expect(screen.queryByTestId('planet-map-panel')).not.toBeNull()
+    expect(screen.queryByText('Planet Sandbox')).not.toBeNull()
+    //2.- The initial telemetry should list the seeded vehicles immediately.
+    expect(screen.getByTestId('planet-map-fleet').textContent).toMatch(/scout/)
+    expect(screen.getByTestId('planet-map-fleet').textContent).toMatch(/freighter/)
+    expect(screen.getByTestId('planet-map-fleet').textContent).toMatch(/racer/)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/PlanetaryMapPanel.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/PlanetaryMapPanel.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import React from 'react'
+import { useEffect, useRef, useState } from 'react'
+import * as THREE from 'three'
+
+import {
+  describeAtmosphere,
+  defaultPlanetaryShell,
+  PlanetTraveler,
+  VehicleFleet,
+  blueprintToSnapshot,
+  type MovementCommand,
+  type SphericalPosition,
+  type VehicleBlueprint,
+  type VehicleSnapshot,
+} from './lib'
+
+interface TelemetrySnapshot {
+  position: SphericalPosition
+  laps: number
+  collidedWithSurface: boolean
+  hitAtmosphereCeiling: boolean
+  vehicles: VehicleSnapshot[]
+}
+
+const initialPosition: SphericalPosition = {
+  latitudeDeg: 5,
+  longitudeDeg: 45,
+  altitude: defaultPlanetaryShell.surfaceRadius + 150,
+}
+
+const travelCommand: MovementCommand = {
+  headingDeg: 92,
+  distance: 4_000,
+  climb: 5,
+}
+
+const vehicleBlueprints: VehicleBlueprint[] = [
+  {
+    id: 'scout',
+    start: { latitudeDeg: 15, longitudeDeg: 120, altitude: defaultPlanetaryShell.surfaceRadius + 300 },
+    command: { headingDeg: 80, distance: 3_000, climb: 3 },
+  },
+  {
+    id: 'freighter',
+    start: { latitudeDeg: -10, longitudeDeg: -40, altitude: defaultPlanetaryShell.surfaceRadius + 120 },
+    command: { headingDeg: 115, distance: 2_500, climb: -1 },
+  },
+  {
+    id: 'racer',
+    start: { latitudeDeg: 25, longitudeDeg: -150, altitude: defaultPlanetaryShell.surfaceRadius + 600 },
+    command: { headingDeg: 65, distance: 4_500, climb: 4 },
+  },
+]
+
+const initialVehicleTelemetry = vehicleBlueprints.map((blueprint) => {
+  //1.- Seed the telemetry with blueprint defaults so the sidebar lists craft immediately.
+  return blueprintToSnapshot(blueprint)
+})
+
+const hasWebGlSupport = (): boolean => {
+  //1.- Detect WebGL support defensively so SSR and tests skip renderer setup.
+  if (typeof window === 'undefined') {
+    return false
+  }
+  const glConstructor = (window as typeof window & { WebGLRenderingContext?: unknown }).WebGLRenderingContext
+  return typeof glConstructor === 'function'
+}
+
+const PlanetaryMapPanel = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [telemetry, setTelemetry] = useState<TelemetrySnapshot>(() => ({
+    position: initialPosition,
+    laps: 0,
+    collidedWithSurface: false,
+    hitAtmosphereCeiling: false,
+    vehicles: initialVehicleTelemetry.map((snapshot) => ({
+      //2.- Clone snapshot data to keep React state immutable between renders.
+      ...snapshot,
+      position: { ...snapshot.position },
+    })),
+  }))
+
+  useEffect(() => {
+    const mount = containerRef.current
+    if (!mount || !hasWebGlSupport()) {
+      return undefined
+    }
+
+    //1.- Build the Three.js renderer and mount a canvas that fills the container.
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    renderer.setSize(mount.clientWidth, mount.clientHeight)
+    renderer.setPixelRatio(window.devicePixelRatio)
+    mount.appendChild(renderer.domElement)
+
+    //2.- Position a perspective camera with a gentle orbital angle showcasing the horizon.
+    const camera = new THREE.PerspectiveCamera(38, mount.clientWidth / mount.clientHeight, 1, 10_000_000)
+    camera.position.set(0, 900, 1550)
+    camera.lookAt(0, 0, 0)
+
+    //3.- Compose the scene with gradient lighting to hint at atmosphere scattering.
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color('#031021')
+    const hemisphereLight = new THREE.HemisphereLight('#89b4ff', '#021726', 0.9)
+    const directionalLight = new THREE.DirectionalLight('#ffddaa', 1.2)
+    directionalLight.position.set(3000, 2000, 1000)
+    scene.add(hemisphereLight)
+    scene.add(directionalLight)
+
+    //4.- Construct the planetary shell meshes to visualise surface and atmosphere limits.
+    const planetRadius = 1_400
+    const planetGeometry = new THREE.SphereGeometry(planetRadius, 128, 128)
+    const planetMaterial = new THREE.MeshStandardMaterial({
+      color: '#1b5f5f',
+      emissive: '#042326',
+      metalness: 0.1,
+      roughness: 0.8,
+    })
+    const planetMesh = new THREE.Mesh(planetGeometry, planetMaterial)
+    scene.add(planetMesh)
+
+    const shellScale = planetRadius / defaultPlanetaryShell.surfaceRadius
+    const atmosphereGeometry = new THREE.SphereGeometry(defaultPlanetaryShell.atmosphereRadius * shellScale, 128, 128)
+    const atmosphereMaterial = new THREE.MeshPhongMaterial({
+      color: '#4ec6ff',
+      transparent: true,
+      opacity: 0.15,
+      side: THREE.DoubleSide,
+    })
+    const atmosphereMesh = new THREE.Mesh(atmosphereGeometry, atmosphereMaterial)
+    scene.add(atmosphereMesh)
+
+    //5.- Prepare helpers to convert spherical telemetry into cartesian coordinates.
+    const traveler = new PlanetTraveler(defaultPlanetaryShell, initialPosition)
+    const fleet = new VehicleFleet(defaultPlanetaryShell, vehicleBlueprints)
+    const vehicleMeshes = new Map<string, THREE.Object3D>()
+
+    const toCartesian = (position: SphericalPosition) => {
+      const latRad = THREE.MathUtils.degToRad(position.latitudeDeg)
+      const lonRad = THREE.MathUtils.degToRad(position.longitudeDeg)
+      const radius = position.altitude * shellScale
+      const cosLat = Math.cos(latRad)
+      return new THREE.Vector3(
+        radius * cosLat * Math.cos(lonRad),
+        radius * Math.sin(latRad),
+        radius * cosLat * Math.sin(lonRad),
+      )
+    }
+
+    //6.- Spawn simple vehicle meshes that trail the player around the shell.
+    const vehicleColors: Record<string, string> = {
+      scout: '#ffd166',
+      freighter: '#00f5d4',
+      racer: '#ff6392',
+    }
+
+    for (const blueprint of vehicleBlueprints) {
+      const vehicleGeometry = new THREE.ConeGeometry(24, 68, 12)
+      const vehicleMaterial = new THREE.MeshStandardMaterial({
+        color: vehicleColors[blueprint.id] ?? '#ffffff',
+        emissive: '#1a2b3c',
+        metalness: 0.3,
+        roughness: 0.5,
+      })
+      const mesh = new THREE.Mesh(vehicleGeometry, vehicleMaterial)
+      mesh.rotation.x = Math.PI / 2
+      scene.add(mesh)
+      const startingPosition = toCartesian(blueprint.start)
+      mesh.position.copy(startingPosition)
+      vehicleMeshes.set(blueprint.id, mesh)
+    }
+
+    let animationFrame = 0
+    let disposed = false
+
+    const animate = () => {
+      if (disposed) {
+        return
+      }
+
+      //7.- Step the traveler and companion fleet before rendering the latest frame.
+      const result = traveler.move(travelCommand)
+      const atmosphere = describeAtmosphere(defaultPlanetaryShell, result.position)
+      const vehicleSnapshots = fleet.advance()
+      for (const snapshot of vehicleSnapshots) {
+        const mesh = vehicleMeshes.get(snapshot.id)
+        if (!mesh) {
+          continue
+        }
+        const cartesian = toCartesian(snapshot.position)
+        mesh.position.copy(cartesian)
+      }
+      setTelemetry({
+        position: result.position,
+        laps: result.laps,
+        collidedWithSurface: result.collidedWithSurface,
+        hitAtmosphereCeiling: result.hitAtmosphereCeiling || atmosphere.distanceToCeiling === 0,
+        vehicles: vehicleSnapshots,
+      })
+
+      //8.- Rotate the planet and atmosphere for a gentle sense of drift.
+      planetMesh.rotation.y += 0.001
+      atmosphereMesh.rotation.y += 0.001
+
+      renderer.render(scene, camera)
+      animationFrame = requestAnimationFrame(animate)
+    }
+
+    //9.- React to viewport changes so the camera aspect and renderer stay in sync.
+    const handleResize = () => {
+      if (!containerRef.current) {
+        return
+      }
+      const { clientWidth, clientHeight } = containerRef.current
+      camera.aspect = clientWidth / Math.max(clientHeight, 1)
+      camera.updateProjectionMatrix()
+      renderer.setSize(clientWidth, clientHeight)
+    }
+
+    window.addEventListener('resize', handleResize)
+    animate()
+
+    return () => {
+      //10.- Dispose resources and detach DOM nodes once the panel unmounts.
+      disposed = true
+      cancelAnimationFrame(animationFrame)
+      window.removeEventListener('resize', handleResize)
+      renderer.dispose()
+      mount.removeChild(renderer.domElement)
+      scene.clear()
+      planetGeometry.dispose()
+      planetMaterial.dispose()
+      atmosphereGeometry.dispose()
+      atmosphereMaterial.dispose()
+      vehicleMeshes.forEach((mesh) => {
+        scene.remove(mesh)
+        const geometry = mesh.geometry as THREE.BufferGeometry
+        const material = mesh.material as THREE.Material
+        geometry.dispose()
+        material.dispose()
+      })
+    }
+  }, [])
+
+  const atmosphere = describeAtmosphere(defaultPlanetaryShell, telemetry.position)
+
+  return (
+    <aside className="planet-map-panel" data-testid="planet-map-panel">
+      <div className="planet-map-canvas" ref={containerRef} />
+      <header className="planet-map-header">
+        <h2>Planet Sandbox</h2>
+        <p>Navigate the orbital shell and monitor atmosphere limits.</p>
+      </header>
+      <dl className="planet-map-telemetry" data-testid="planet-map-telemetry">
+        <div>
+          <dt>Latitude</dt>
+          <dd>{telemetry.position.latitudeDeg.toFixed(2)}°</dd>
+        </div>
+        <div>
+          <dt>Longitude</dt>
+          <dd>{telemetry.position.longitudeDeg.toFixed(2)}°</dd>
+        </div>
+        <div>
+          <dt>Altitude</dt>
+          <dd>{(telemetry.position.altitude - defaultPlanetaryShell.surfaceRadius).toFixed(1)} m</dd>
+        </div>
+        <div>
+          <dt>Laps</dt>
+          <dd>{telemetry.laps}</dd>
+        </div>
+        <div>
+          <dt>Surface Contact</dt>
+          <dd>{telemetry.collidedWithSurface ? 'Yes' : 'No'}</dd>
+        </div>
+        <div>
+          <dt>Ceiling Contact</dt>
+          <dd>{telemetry.hitAtmosphereCeiling ? 'Yes' : 'No'}</dd>
+        </div>
+        <div>
+          <dt>Distance to ceiling</dt>
+          <dd>{atmosphere.distanceToCeiling.toFixed(1)} m</dd>
+        </div>
+        <div>
+          <dt>Outside breathable band</dt>
+          <dd>{atmosphere.outsideBreathableBand ? 'Yes' : 'No'}</dd>
+        </div>
+      </dl>
+      <section className="planet-map-fleet" data-testid="planet-map-fleet">
+        <h3>Companion telemetry</h3>
+        <ul>
+          {telemetry.vehicles.map((vehicle) => (
+            <li key={vehicle.id}>
+              <span>{vehicle.id}</span>
+              <span>
+                {vehicle.position.latitudeDeg.toFixed(1)}° / {vehicle.position.longitudeDeg.toFixed(1)}°
+              </span>
+              <span>{(vehicle.position.altitude - defaultPlanetaryShell.surfaceRadius).toFixed(0)} m</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  )
+}
+
+export default PlanetaryMapPanel

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/atmosphere.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/atmosphere.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeAtmosphere, defaultPlanetaryShell, type SphericalPosition } from './index'
+
+describe('describeAtmosphere', () => {
+  it('reports breathable band metrics', () => {
+    const position: SphericalPosition = {
+      latitudeDeg: 12,
+      longitudeDeg: 5,
+      altitude: defaultPlanetaryShell.surfaceRadius + 100,
+    }
+
+    //1.- Sample a position well inside the breathable layer to verify computed distances.
+    const snapshot = describeAtmosphere(defaultPlanetaryShell, position)
+
+    expect(snapshot.altitudeToSurface).toBe(100)
+    expect(snapshot.breathableBandHeight).toBe(defaultPlanetaryShell.atmosphereRadius - defaultPlanetaryShell.surfaceRadius)
+    expect(snapshot.distanceToCeiling).toBe(defaultPlanetaryShell.exosphereRadius - position.altitude)
+    expect(snapshot.outsideBreathableBand).toBe(false)
+  })
+
+  it('flags when leaving the breathable atmosphere layer', () => {
+    const highFlight: SphericalPosition = {
+      latitudeDeg: 0,
+      longitudeDeg: 0,
+      altitude: defaultPlanetaryShell.atmosphereRadius + 10,
+    }
+
+    const lowFlight: SphericalPosition = {
+      latitudeDeg: 0,
+      longitudeDeg: 0,
+      altitude: defaultPlanetaryShell.surfaceRadius - 10,
+    }
+
+    //1.- Crossing either boundary should mark the traveler as outside the breathable band.
+    expect(describeAtmosphere(defaultPlanetaryShell, highFlight).outsideBreathableBand).toBe(true)
+    expect(describeAtmosphere(defaultPlanetaryShell, lowFlight).outsideBreathableBand).toBe(true)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/atmosphere.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/atmosphere.ts
@@ -1,0 +1,26 @@
+import type { PlanetaryShell, SphericalPosition } from './planetConfig'
+
+export interface AtmosphereState {
+  altitudeToSurface: number
+  distanceToCeiling: number
+  breathableBandHeight: number
+  outsideBreathableBand: boolean
+}
+
+export const describeAtmosphere = (shell: PlanetaryShell, position: SphericalPosition): AtmosphereState => {
+  //1.- Measure the vertical clearance from the surface so the HUD can show impact risk.
+  const altitudeToSurface = Math.max(0, position.altitude - shell.surfaceRadius)
+  //2.- Compute the remaining headroom until the exosphere to gauge ceiling collisions.
+  const distanceToCeiling = Math.max(0, shell.exosphereRadius - position.altitude)
+  //3.- Track the habitable band depth to highlight breathable range within the UI copy.
+  const breathableBandHeight = shell.atmosphereRadius - shell.surfaceRadius
+  //4.- Flag when the craft leaves the breathable band even if it remains within shell bounds.
+  const outsideBreathableBand = position.altitude > shell.atmosphereRadius || position.altitude < shell.surfaceRadius
+
+  return {
+    altitudeToSurface,
+    distanceToCeiling,
+    breathableBandHeight,
+    outsideBreathableBand,
+  }
+}

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/index.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './planetConfig'
+export * from './atmosphere'
+export * from './sphericalNavigator'
+export * from './vehicleFleet'

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/planetConfig.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/planetConfig.ts
@@ -1,0 +1,31 @@
+export interface PlanetaryShell {
+  readonly surfaceRadius: number
+  readonly atmosphereRadius: number
+  readonly exosphereRadius: number
+}
+
+export const defaultPlanetaryShell: PlanetaryShell = {
+  //1.- Establish an Earth-like shell with generous altitude bands for the sandbox visualisation.
+  surfaceRadius: 6_000_000,
+  atmosphereRadius: 6_050_000,
+  exosphereRadius: 6_120_000,
+}
+
+export interface SphericalPosition {
+  latitudeDeg: number
+  longitudeDeg: number
+  altitude: number
+}
+
+export interface MovementCommand {
+  headingDeg: number
+  distance: number
+  climb: number
+}
+
+export interface MovementResult {
+  position: SphericalPosition
+  laps: number
+  collidedWithSurface: boolean
+  hitAtmosphereCeiling: boolean
+}

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/sphericalNavigator.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/sphericalNavigator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { PlanetTraveler, defaultPlanetaryShell, type MovementCommand, type SphericalPosition } from './index'
+
+describe('PlanetTraveler', () => {
+  it('advances along great circles and respects climb limits', () => {
+    const start: SphericalPosition = { latitudeDeg: 0, longitudeDeg: 0, altitude: defaultPlanetaryShell.surfaceRadius + 50 }
+    const traveler = new PlanetTraveler(defaultPlanetaryShell, start)
+
+    const command: MovementCommand = { headingDeg: 90, distance: 500, climb: 20 }
+
+    //1.- Move eastward and climb slightly to capture updated telemetry.
+    const result = traveler.move(command)
+
+    expect(result.position.latitudeDeg).toBeCloseTo(0, 3)
+    expect(result.position.longitudeDeg).toBeGreaterThan(0)
+    expect(result.position.altitude).toBe(start.altitude + command.climb)
+    expect(result.collidedWithSurface).toBe(false)
+    expect(result.hitAtmosphereCeiling).toBe(false)
+  })
+
+  it('counts laps when crossing the longitudinal seam', () => {
+    const start: SphericalPosition = { latitudeDeg: 0, longitudeDeg: 179, altitude: defaultPlanetaryShell.surfaceRadius + 50 }
+    const traveler = new PlanetTraveler(defaultPlanetaryShell, start)
+
+    const command: MovementCommand = { headingDeg: 90, distance: 200_000, climb: 0 }
+
+    //1.- Crossing the anti-meridian should increment the lap counter once.
+    traveler.move(command)
+
+    expect(traveler.lapsCompleted).toBe(1)
+  })
+
+  it('clamps altitude against the surface and exosphere', () => {
+    const start: SphericalPosition = { latitudeDeg: 0, longitudeDeg: 0, altitude: defaultPlanetaryShell.surfaceRadius + 5 }
+    const traveler = new PlanetTraveler(defaultPlanetaryShell, start)
+
+    //1.- Dive into the surface and then sprint upward beyond the exosphere.
+    const descentResult = traveler.move({ headingDeg: 0, distance: 0, climb: -10 })
+    const ascentResult = traveler.move({ headingDeg: 0, distance: 0, climb: 1_000_000 })
+
+    expect(descentResult.collidedWithSurface).toBe(true)
+    expect(ascentResult.hitAtmosphereCeiling).toBe(true)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/sphericalNavigator.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/sphericalNavigator.ts
@@ -1,0 +1,122 @@
+import type { MovementCommand, MovementResult, PlanetaryShell, SphericalPosition } from './planetConfig'
+
+const DEG_TO_RAD = Math.PI / 180
+const RAD_TO_DEG = 180 / Math.PI
+const TWO_PI = Math.PI * 2
+
+const normalizeLongitude = (valueRad: number): number => {
+  //1.- Wrap longitudes into [-π, π] so render coordinates remain numerically stable.
+  let wrapped = valueRad % TWO_PI
+  if (wrapped <= -Math.PI) {
+    wrapped += TWO_PI
+  }
+  if (wrapped > Math.PI) {
+    wrapped -= TWO_PI
+  }
+  return wrapped
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  //1.- Restrict values within the supplied interval to avoid escaping the shell bounds.
+  return Math.min(Math.max(value, min), max)
+}
+
+export interface NavigatorOptions {
+  surfacePadding?: number
+}
+
+export class PlanetTraveler {
+  private current: SphericalPosition
+  private readonly shell: PlanetaryShell
+  private unboundedLongitudeRad: number
+  private completedLaps = 0
+  private readonly surfacePadding: number
+
+  constructor(shell: PlanetaryShell, initialPosition: SphericalPosition, options: NavigatorOptions = {}) {
+    //1.- Cache the planetary shell radii so each move uses consistent bounds.
+    this.shell = shell
+    //2.- Clone the starting position to preserve immutability of external callers.
+    this.current = { ...initialPosition }
+    //3.- Track longitude without wrapping to count circumnavigation laps precisely.
+    this.unboundedLongitudeRad = initialPosition.longitudeDeg * DEG_TO_RAD
+    //4.- Permit a tweakable buffer above the surface to reduce collision chatter.
+    this.surfacePadding = options.surfacePadding ?? 0.5
+  }
+
+  get position(): SphericalPosition {
+    //1.- Return a defensive copy so UI code cannot mutate the internal navigator state.
+    return { ...this.current }
+  }
+
+  get lapsCompleted(): number {
+    //1.- Expose the total laps for HUD displays while keeping the field read-only.
+    return this.completedLaps
+  }
+
+  move(command: MovementCommand): MovementResult {
+    //1.- Convert current coordinates into radians so spherical trig is straightforward.
+    const latitudeRad = this.current.latitudeDeg * DEG_TO_RAD
+    const longitudeRad = this.unboundedLongitudeRad
+    //2.- Translate the movement into angular displacements on the sphere surface.
+    const angularDistance = command.distance / this.shell.surfaceRadius
+    const headingRad = command.headingDeg * DEG_TO_RAD
+
+    //3.- Resolve the new latitude using the great-circle navigation formula.
+    const sinLat = Math.sin(latitudeRad)
+    const cosLat = Math.cos(latitudeRad)
+    const sinAngular = Math.sin(angularDistance)
+    const cosAngular = Math.cos(angularDistance)
+    const sinHeading = Math.sin(headingRad)
+    const cosHeading = Math.cos(headingRad)
+
+    const newLatitudeRad = Math.asin(
+      sinLat * cosAngular +
+        cosLat * sinAngular * cosHeading,
+    )
+
+    //4.- Compute the longitude change prior to wrapping to keep lap tracking continuous.
+    const deltaLongitude = Math.atan2(
+      sinHeading * sinAngular * cosLat,
+      cosAngular - sinLat * Math.sin(newLatitudeRad),
+    )
+    const newUnboundedLongitude = longitudeRad + deltaLongitude
+
+    //5.- Count seam crossings by comparing unbounded longitude intervals before and after.
+    const previousSeamIndex = Math.floor((longitudeRad + Math.PI) / TWO_PI)
+    const nextSeamIndex = Math.floor((newUnboundedLongitude + Math.PI) / TWO_PI)
+    this.completedLaps += nextSeamIndex - previousSeamIndex
+
+    //6.- Wrap longitude back into renderable bounds for the public snapshot.
+    const newLongitudeRad = normalizeLongitude(newUnboundedLongitude)
+    this.unboundedLongitudeRad = newUnboundedLongitude
+
+    //7.- Apply climb input while clamping between surface padding and exosphere ceiling.
+    const newAltitude = clamp(
+      this.current.altitude + command.climb,
+      this.shell.surfaceRadius + this.surfacePadding,
+      this.shell.exosphereRadius,
+    )
+
+    //8.- Detect contact with the terrain whenever the altitude clamp hits the lower bound.
+    const collidedWithSurface = newAltitude <= this.shell.surfaceRadius + this.surfacePadding + Number.EPSILON
+    //9.- Detect ceiling saturation whenever altitude touches the exosphere radius.
+    const hitAtmosphereCeiling = newAltitude >= this.shell.exosphereRadius - Number.EPSILON
+
+    //10.- Convert the computed radians back into degrees for UI friendly telemetry.
+    const updatedPosition: SphericalPosition = {
+      latitudeDeg: newLatitudeRad * RAD_TO_DEG,
+      longitudeDeg: newLongitudeRad * RAD_TO_DEG,
+      altitude: newAltitude,
+    }
+
+    //11.- Persist the result for the following integration step.
+    this.current = updatedPosition
+
+    return {
+      position: this.position,
+      laps: this.completedLaps,
+      collidedWithSurface,
+      hitAtmosphereCeiling,
+    }
+  }
+}

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/vehicleFleet.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/vehicleFleet.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { VehicleFleet, blueprintToSnapshot, defaultPlanetaryShell, type VehicleBlueprint } from './index'
+
+describe('VehicleFleet', () => {
+  it('advances each vehicle using its blueprint command', () => {
+    const blueprints: VehicleBlueprint[] = [
+      {
+        id: 'alpha',
+        start: { latitudeDeg: 0, longitudeDeg: 0, altitude: defaultPlanetaryShell.surfaceRadius + 50 },
+        command: { headingDeg: 45, distance: 300, climb: 10 },
+      },
+      {
+        id: 'beta',
+        start: { latitudeDeg: 10, longitudeDeg: 20, altitude: defaultPlanetaryShell.surfaceRadius + 80 },
+        command: { headingDeg: 180, distance: 150, climb: -5 },
+      },
+    ]
+
+    const fleet = new VehicleFleet(defaultPlanetaryShell, blueprints)
+
+    //1.- Each call should emit telemetry for every configured blueprint.
+    const snapshots = fleet.advance()
+
+    expect(snapshots).toHaveLength(2)
+    expect(snapshots.map((snapshot) => snapshot.id)).toEqual(['alpha', 'beta'])
+  })
+
+  it('mirrors blueprint starting positions into initial telemetry', () => {
+    const blueprint: VehicleBlueprint = {
+      id: 'gamma',
+      start: { latitudeDeg: -5, longitudeDeg: 42, altitude: defaultPlanetaryShell.surfaceRadius + 120 },
+      command: { headingDeg: 5, distance: 0, climb: 0 },
+    }
+
+    //1.- A snapshot derived from the blueprint should match the starting coordinates exactly.
+    const snapshot = blueprintToSnapshot(blueprint)
+
+    expect(snapshot.position).toEqual(blueprint.start)
+    expect(snapshot.laps).toBe(0)
+    expect(snapshot.touchingSurface).toBe(false)
+    expect(snapshot.hittingCeiling).toBe(false)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/vehicleFleet.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/lib/vehicleFleet.ts
@@ -1,0 +1,61 @@
+import type { MovementCommand, PlanetaryShell, SphericalPosition } from './planetConfig'
+import { PlanetTraveler } from './sphericalNavigator'
+
+export interface VehicleBlueprint {
+  readonly id: string
+  readonly start: SphericalPosition
+  readonly command: MovementCommand
+}
+
+export interface VehicleSnapshot {
+  readonly id: string
+  readonly position: SphericalPosition
+  readonly laps: number
+  readonly touchingSurface: boolean
+  readonly hittingCeiling: boolean
+}
+
+export class VehicleFleet {
+  private readonly travelers: Map<string, PlanetTraveler> = new Map()
+  private readonly commands: Map<string, MovementCommand> = new Map()
+
+  constructor(shell: PlanetaryShell, blueprints: VehicleBlueprint[]) {
+    //1.- Spin up a traveler per blueprint so formations can animate independently.
+    for (const blueprint of blueprints) {
+      const traveler = new PlanetTraveler(shell, blueprint.start)
+      this.travelers.set(blueprint.id, traveler)
+      this.commands.set(blueprint.id, blueprint.command)
+    }
+  }
+
+  advance(): VehicleSnapshot[] {
+    //1.- Step every traveler with its recorded command and emit the telemetry snapshot.
+    const snapshots: VehicleSnapshot[] = []
+    for (const [id, traveler] of this.travelers.entries()) {
+      const command = this.commands.get(id)
+      if (!command) {
+        continue
+      }
+      const result = traveler.move(command)
+      snapshots.push({
+        id,
+        position: result.position,
+        laps: result.laps,
+        touchingSurface: result.collidedWithSurface,
+        hittingCeiling: result.hitAtmosphereCeiling,
+      })
+    }
+    return snapshots
+  }
+}
+
+export const blueprintToSnapshot = (blueprint: VehicleBlueprint): VehicleSnapshot => {
+  //1.- Convert starting blueprints into telemetry entries so UI renders without waiting for the first tick.
+  return {
+    id: blueprint.id,
+    position: { ...blueprint.start },
+    laps: 0,
+    touchingSurface: false,
+    hittingCeiling: false,
+  }
+}

--- a/tunnelcave_sandbox_web/app/globals.css
+++ b/tunnelcave_sandbox_web/app/globals.css
@@ -278,3 +278,145 @@ body {
   color: #e2e8f0;
   font-size: 0.8rem;
 }
+
+.battle-stage {
+  /* 2.- Pad the viewport so the battlefield and planet map can breathe side-by-side. */
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.battle-stage-content {
+  /* 1.- Arrange the interactive battlefield next to the orbital sandbox preview. */
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(320px, 1fr);
+  gap: 1.5rem;
+  width: 100%;
+  height: 100%;
+}
+
+.battle-stage-canvas {
+  /* 1.- Allow the battlefield renderer to stretch vertically within the grid cell. */
+  min-height: 0;
+  display: flex;
+}
+
+.battle-stage-canvas > .battlefield-wrapper {
+  /* 1.- Ensure the underlying canvas continues filling the available height. */
+  flex: 1 1 auto;
+}
+
+.planet-map-panel {
+  /* 1.- Style the sandbox panel as a complementary glassmorphism card. */
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  color: #e2e8f0;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 25px 60px rgba(8, 47, 73, 0.45);
+}
+
+.planet-map-canvas {
+  /* 1.- Reserve vertical space for the Three.js renderer even when WebGL is unavailable. */
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: radial-gradient(circle at 30% 30%, rgba(59, 130, 246, 0.35), rgba(15, 23, 42, 0.6));
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.planet-map-header h2 {
+  /* 1.- Harmonise the heading with the primary gameplay typography. */
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.planet-map-header p {
+  /* 1.- Provide supportive copy encouraging pilots to monitor their orbit. */
+  margin: 0.25rem 0 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.planet-map-telemetry {
+  /* 1.- Present telemetry as a compact definition list for quick scanning. */
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+  margin: 0;
+}
+
+.planet-map-telemetry div {
+  /* 1.- Group label-value pairs vertically for clarity. */
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.planet-map-telemetry dt {
+  /* 1.- Tone down labels so the numeric values take focus. */
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.planet-map-telemetry dd {
+  /* 1.- Highlight numeric telemetry with bolder typography. */
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.planet-map-fleet {
+  /* 1.- Showcase the companion vehicles and their orbital stats. */
+  display: grid;
+  gap: 0.5rem;
+}
+
+.planet-map-fleet h3 {
+  /* 1.- Align the fleet heading with other sidebar headings. */
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a5b4fc;
+}
+
+.planet-map-fleet ul {
+  /* 1.- Provide a subtle backdrop for the telemetry rows. */
+  list-style: none;
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.planet-map-fleet li {
+  /* 1.- Lay out each vehicle telemetry row with evenly spaced fields. */
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) minmax(0, 0.9fr);
+  font-size: 0.85rem;
+  gap: 0.5rem;
+}
+
+.planet-map-fleet li span:first-child {
+  /* 1.- Emphasise vehicle identifiers to support quick recognition. */
+  font-weight: 600;
+  color: #facc15;
+}
+
+@media (max-width: 1200px) {
+  .battle-stage-content {
+    /* 1.- Stack panels vertically on narrower screens while preserving breathing room. */
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .battle-stage {
+    /* 1.- Reduce padding when stacking to maximise viewport usage. */
+    padding: 1.25rem;
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- embed the PlanetaryMapPanel beside the battle canvas on the /gameplay route
- port the planetary sandbox navigation and telemetry helpers into the gameplay app
- add vitest coverage for the new planetary map and supporting library utilities

## Testing
- npm test --prefix tunnelcave_sandbox_web

------
https://chatgpt.com/codex/tasks/task_e_68e3dbd993c883298d2b6099b7e73453