### PR TITLE
Move battlefield terrain rendering into planet map preview

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/page.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.test.tsx
@@ -24,7 +24,9 @@ vi.mock('./BattlefieldCanvas', () => ({
 
 vi.mock('./planetSandbox/PlanetaryMapPanel', () => ({
   __esModule: true,
-  default: () => <div data-testid="mock-planet-panel">planet-panel</div>,
+  default: ({ battlefield }: { battlefield: unknown }) => (
+    <div data-testid="mock-planet-panel">planet-panel-{Boolean(battlefield)}</div>
+  ),
 }))
 
 describe('GameplayPage', () => {

--- a/tunnelcave_sandbox_web/app/gameplay/page.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/page.tsx
@@ -100,7 +100,7 @@ export default function GameplayPage() {
             <div className="battle-stage-canvas" data-testid="battle-stage-canvas">
               <BattlefieldCanvas config={battlefield} playerName={playerName} sessionId={sessionId} vehicleId={vehicleId} />
             </div>
-            <PlanetaryMapPanel />
+            <PlanetaryMapPanel battlefield={battlefield} />
           </div>
         </section>
       )}

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/PlanetaryMapPanel.test.tsx
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/PlanetaryMapPanel.test.tsx
@@ -1,6 +1,45 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+
+import type { BattlefieldConfig } from '../generateBattlefield'
+import { assetRegistry } from '../assets/assetCatalog'
+
+const createStubBattlefield = (): BattlefieldConfig => {
+  //1.- Provide a minimal battlefield snapshot so the planet panel receives terrain data even in mocked WebGL environments.
+  return {
+    seed: 1,
+    fieldSize: 120,
+    spawnPoint: new THREE.Vector3(0, 0, 0),
+    terrain: {
+      sampler: {
+        sampleGround: () => ({ height: 0, normal: new THREE.Vector3(0, 1, 0), slopeRadians: 0 }),
+        sampleCeiling: () => 50,
+        sampleWater: () => Number.NEGATIVE_INFINITY,
+        flatSpawnRadius: 12,
+        registerWaterOverride: () => {},
+      },
+      spawnRadius: 12,
+    },
+    environment: {
+      boundsRadius: 200,
+      vehicleRadius: 2,
+      slopeLimitRadians: 1,
+      bounceDamping: 0.2,
+      groundSnapStrength: 0,
+      waterDrag: 0.5,
+      waterBuoyancy: 0.4,
+      waterMinDepth: 0.5,
+      maxWaterSpeedScale: 0.8,
+      wrapSize: 300,
+    },
+    rocks: [],
+    trees: [],
+    waters: [],
+    assets: assetRegistry,
+  }
+}
 
 describe('PlanetaryMapPanel', () => {
   const originalWebGl = globalThis.window?.WebGLRenderingContext
@@ -24,7 +63,7 @@ describe('PlanetaryMapPanel', () => {
 
   it('renders telemetry using the initial blueprint snapshots', async () => {
     const { default: PlanetaryMapPanel } = await import('./PlanetaryMapPanel')
-    render(<PlanetaryMapPanel />)
+    render(<PlanetaryMapPanel battlefield={createStubBattlefield()} />)
 
     expect(screen.queryByTestId('planet-map-panel')).not.toBeNull()
     expect(screen.queryByText('Planet Sandbox')).not.toBeNull()

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/createBattlefieldTerrain.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/createBattlefieldTerrain.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as THREE from 'three'
+
+import { createBattlefieldTerrainPreview } from './createBattlefieldTerrain'
+import { assetRegistry } from '../assets/assetCatalog'
+import type { BattlefieldConfig } from '../generateBattlefield'
+
+describe('createBattlefieldTerrainPreview', () => {
+  const createConfig = (): BattlefieldConfig => {
+    //1.- Craft a representative battlefield snapshot that includes water, rocks, and foliage.
+    const terrainSampler = {
+      sampleGround: (x: number, z: number) => ({
+        height: Math.sin(x * 0.02) * 2 + Math.cos(z * 0.02) * 1.5,
+        normal: new THREE.Vector3(0, 1, 0),
+        slopeRadians: 0.2,
+      }),
+      sampleCeiling: () => 48,
+      sampleWater: (x: number, z: number) => (Math.hypot(x, z) < 10 ? 2 : Number.NEGATIVE_INFINITY),
+      flatSpawnRadius: 6,
+      registerWaterOverride: () => {},
+    }
+    return {
+      seed: 7,
+      fieldSize: 60,
+      spawnPoint: new THREE.Vector3(0, 0, 0),
+      terrain: { sampler: terrainSampler, spawnRadius: 6 },
+      environment: {
+        boundsRadius: 120,
+        vehicleRadius: 2,
+        slopeLimitRadians: 1,
+        bounceDamping: 0.2,
+        groundSnapStrength: 0,
+        waterDrag: 0.5,
+        waterBuoyancy: 0.3,
+        waterMinDepth: 0.4,
+        maxWaterSpeedScale: 0.9,
+        wrapSize: 180,
+      },
+      rocks: [
+        {
+          archetypeIndex: 0,
+          position: new THREE.Vector3(8, 1, -6),
+          rotation: 0.4,
+          scale: new THREE.Vector3(1.1, 0.9, 1.2),
+        },
+      ],
+      trees: [
+        {
+          position: new THREE.Vector3(-5, 0, 4),
+          trunkHeight: 6,
+          canopyRadius: 4,
+          branchCount: 3,
+          variation: 1,
+        },
+      ],
+      waters: [
+        {
+          position: new THREE.Vector3(0, 0, 0),
+          level: 2,
+        },
+      ],
+      assets: assetRegistry,
+    }
+  }
+
+  it('builds meshes for each terrain layer and disposes them on request', () => {
+    const config = createConfig()
+    const preview = createBattlefieldTerrainPreview(config)
+    const groundMesh = preview.group.getObjectByName('battlefield-ground') as THREE.Mesh
+    const ceilingMesh = preview.group.getObjectByName('battlefield-ceiling') as THREE.Mesh
+    const waterMesh = preview.group.getObjectByName('battlefield-water') as THREE.InstancedMesh | null
+    const rockMesh = preview.group.getObjectByName('battlefield-rocks-0') as THREE.InstancedMesh | null
+    const trunkMesh = preview.group.getObjectByName('battlefield-tree-trunks') as THREE.InstancedMesh | null
+    const canopyMesh = preview.group.getObjectByName('battlefield-tree-canopies') as THREE.InstancedMesh | null
+
+    expect(groundMesh).toBeTruthy()
+    expect(ceilingMesh).toBeTruthy()
+    expect(waterMesh).toBeTruthy()
+    expect(rockMesh).toBeTruthy()
+    expect(trunkMesh).toBeTruthy()
+    expect(canopyMesh).toBeTruthy()
+
+    const groundGeometryDispose = vi.spyOn(groundMesh.geometry, 'dispose')
+    const groundMaterialDispose = vi.spyOn(groundMesh.material as THREE.Material, 'dispose')
+    const ceilingGeometryDispose = vi.spyOn(ceilingMesh.geometry, 'dispose')
+    const ceilingMaterialDispose = vi.spyOn(ceilingMesh.material as THREE.Material, 'dispose')
+
+    const waterGeometryDispose = waterMesh ? vi.spyOn(waterMesh.geometry, 'dispose') : null
+    const waterMaterialDispose = waterMesh
+      ? vi.spyOn((waterMesh.material as THREE.Material), 'dispose')
+      : null
+    const waterMeshDispose = waterMesh ? vi.spyOn(waterMesh, 'dispose') : null
+
+    const rockGeometryDispose = rockMesh ? vi.spyOn(rockMesh.geometry, 'dispose') : null
+    const rockMaterialDispose = rockMesh
+      ? vi.spyOn(rockMesh.material as THREE.Material, 'dispose')
+      : null
+    const rockMeshDispose = rockMesh ? vi.spyOn(rockMesh, 'dispose') : null
+
+    const trunkGeometryDispose = trunkMesh ? vi.spyOn(trunkMesh.geometry, 'dispose') : null
+    const trunkMaterialDispose = trunkMesh
+      ? vi.spyOn(trunkMesh.material as THREE.Material, 'dispose')
+      : null
+    const trunkMeshDispose = trunkMesh ? vi.spyOn(trunkMesh, 'dispose') : null
+
+    const canopyGeometryDispose = canopyMesh ? vi.spyOn(canopyMesh.geometry, 'dispose') : null
+    const canopyMaterialDispose = canopyMesh
+      ? vi.spyOn(canopyMesh.material as THREE.Material, 'dispose')
+      : null
+    const canopyMeshDispose = canopyMesh ? vi.spyOn(canopyMesh, 'dispose') : null
+
+    preview.dispose()
+
+    expect(groundGeometryDispose).toHaveBeenCalled()
+    expect(groundMaterialDispose).toHaveBeenCalled()
+    expect(ceilingGeometryDispose).toHaveBeenCalled()
+    expect(ceilingMaterialDispose).toHaveBeenCalled()
+    if (waterMesh) {
+      expect(waterGeometryDispose).not.toBeNull()
+      expect(waterMaterialDispose).not.toBeNull()
+      expect(waterMeshDispose).not.toBeNull()
+      expect(waterGeometryDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(waterMaterialDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(waterMeshDispose?.mock.calls.length).toBeGreaterThan(0)
+    }
+    if (rockMesh) {
+      expect(rockGeometryDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(rockMaterialDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(rockMeshDispose?.mock.calls.length).toBeGreaterThan(0)
+    }
+    if (trunkMesh) {
+      expect(trunkGeometryDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(trunkMaterialDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(trunkMeshDispose?.mock.calls.length).toBeGreaterThan(0)
+    }
+    if (canopyMesh) {
+      expect(canopyGeometryDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(canopyMaterialDispose?.mock.calls.length).toBeGreaterThan(0)
+      expect(canopyMeshDispose?.mock.calls.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planetSandbox/createBattlefieldTerrain.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planetSandbox/createBattlefieldTerrain.ts
@@ -1,0 +1,217 @@
+import {
+  BackSide,
+  BufferAttribute,
+  CylinderGeometry,
+  DynamicDrawUsage,
+  Group,
+  IcosahedronGeometry,
+  InstancedMesh,
+  Matrix4,
+  Mesh,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  Quaternion,
+  Vector3,
+} from 'three'
+
+import type { BattlefieldConfig } from '../generateBattlefield'
+import { createRockGeometry } from '../rocks/createRockGeometry'
+
+export interface BattlefieldTerrainPreview {
+  group: Group
+  dispose: () => void
+}
+
+export const createBattlefieldTerrainPreview = (config: BattlefieldConfig): BattlefieldTerrainPreview => {
+  //1.- Build a root group that holds all battlefield terrain primitives for reuse within the planet map.
+  const group = new Group()
+  group.name = 'battlefield-terrain-preview'
+
+  const disposables: Array<() => void> = []
+
+  const terrainSampler = config.terrain.sampler
+
+  //2.- Generate a displaced plane that mirrors the ground height samples from the procedural battlefield.
+  const groundSegments = 160
+  const groundGeometry = new PlaneGeometry(config.fieldSize, config.fieldSize, groundSegments, groundSegments)
+  groundGeometry.rotateX(-Math.PI / 2)
+  const groundPositions = groundGeometry.getAttribute('position') as BufferAttribute
+  for (let index = 0; index < groundPositions.count; index += 1) {
+    const x = groundPositions.getX(index)
+    const z = groundPositions.getZ(index)
+    const sample = terrainSampler.sampleGround(x, z)
+    groundPositions.setY(index, sample.height)
+  }
+  groundPositions.needsUpdate = true
+  groundGeometry.computeVertexNormals()
+  const groundMaterial = new MeshStandardMaterial({ color: 0x2e4f30, roughness: 0.88, metalness: 0.08 })
+  const groundMesh = new Mesh(groundGeometry, groundMaterial)
+  groundMesh.name = 'battlefield-ground'
+  groundMesh.receiveShadow = true
+  group.add(groundMesh)
+  disposables.push(() => {
+    groundGeometry.dispose()
+    groundMaterial.dispose()
+  })
+
+  //3.- Raise a translucent ceiling slab so the cavern silhouette remains recognizable on the planet panel.
+  const ceilingGeometry = new PlaneGeometry(config.fieldSize, config.fieldSize, 16, 16)
+  ceilingGeometry.rotateX(Math.PI / 2)
+  const ceilingPositions = ceilingGeometry.getAttribute('position') as BufferAttribute
+  for (let index = 0; index < ceilingPositions.count; index += 1) {
+    const x = ceilingPositions.getX(index)
+    const z = ceilingPositions.getZ(index)
+    const ceilingHeight = terrainSampler.sampleCeiling(x, z)
+    ceilingPositions.setY(index, ceilingHeight)
+  }
+  ceilingPositions.needsUpdate = true
+  const ceilingMaterial = new MeshStandardMaterial({
+    color: 0x1b1b2f,
+    side: BackSide,
+    roughness: 0.35,
+    metalness: 0.08,
+    transparent: true,
+    opacity: 0.65,
+  })
+  const ceilingMesh = new Mesh(ceilingGeometry, ceilingMaterial)
+  ceilingMesh.name = 'battlefield-ceiling'
+  group.add(ceilingMesh)
+  disposables.push(() => {
+    ceilingGeometry.dispose()
+    ceilingMaterial.dispose()
+  })
+
+  //4.- Project any water samples into instanced quads so lakes and rivers remain visible in the miniature.
+  if (config.waters.length > 0) {
+    const waterCellSize = config.fieldSize / 32
+    const waterGeometry = new PlaneGeometry(1, 1)
+    waterGeometry.rotateX(-Math.PI / 2)
+    const waterMaterial = new MeshStandardMaterial({
+      color: 0x335c81,
+      transparent: true,
+      opacity: 0.6,
+      roughness: 0.35,
+      metalness: 0.1,
+    })
+    const waterMesh = new InstancedMesh(waterGeometry, waterMaterial, config.waters.length)
+    waterMesh.name = 'battlefield-water'
+    waterMesh.instanceMatrix.setUsage(DynamicDrawUsage)
+    const waterMatrix = new Matrix4()
+    const waterQuaternion = new Quaternion()
+    config.waters.forEach((sample, index) => {
+      waterMatrix.compose(
+        new Vector3(sample.position.x, sample.level + 0.01, sample.position.z),
+        waterQuaternion,
+        new Vector3(waterCellSize, 1, waterCellSize),
+      )
+      waterMesh.setMatrixAt(index, waterMatrix)
+    })
+    waterMesh.instanceMatrix.needsUpdate = true
+    group.add(waterMesh)
+    disposables.push(() => {
+      waterGeometry.dispose()
+      waterMaterial.dispose()
+      waterMesh.dispose()
+    })
+  }
+
+  //5.- Combine the procedural rock instances into instanced meshes for each archetype to keep draw calls manageable.
+  const rockGeometries = config.assets.rocks.map((_, index) =>
+    createRockGeometry(index, config.seed + index * 13, config.assets),
+  )
+  const rockCounts = config.assets.rocks.map(() => 0)
+  config.rocks.forEach((rock) => {
+    rockCounts[rock.archetypeIndex] += 1
+  })
+  const rockMeshes: InstancedMesh[] = []
+  const rockMatrix = new Matrix4()
+  const rockQuaternion = new Quaternion()
+  const rockScale = new Vector3()
+  const rockOffsets = config.assets.rocks.map(() => 0)
+  config.assets.rocks.forEach((archetype, index) => {
+    const count = Math.max(1, rockCounts[index])
+    const material = new MeshStandardMaterial({ color: 0x5a615c, roughness: 0.92, metalness: 0.18 })
+    const mesh = new InstancedMesh(rockGeometries[index], material, count)
+    mesh.name = `battlefield-rocks-${index}`
+    mesh.instanceMatrix.setUsage(DynamicDrawUsage)
+    group.add(mesh)
+    rockMeshes.push(mesh)
+    disposables.push(() => {
+      rockGeometries[index].dispose()
+      material.dispose()
+      mesh.dispose()
+    })
+  })
+  config.rocks.forEach((rock) => {
+    const archetype = config.assets.rocks[rock.archetypeIndex]
+    const mesh = rockMeshes[rock.archetypeIndex]
+    const instanceIndex = rockOffsets[rock.archetypeIndex]
+    rockOffsets[rock.archetypeIndex] += 1
+    rockQuaternion.setFromAxisAngle(new Vector3(0, 1, 0), rock.rotation)
+    rockScale.set(archetype.radius * rock.scale.x, archetype.height * rock.scale.y, archetype.radius * rock.scale.z)
+    rockMatrix.compose(rock.position, rockQuaternion, rockScale)
+    mesh.setMatrixAt(instanceIndex, rockMatrix)
+  })
+  rockMeshes.forEach((mesh) => {
+    mesh.instanceMatrix.needsUpdate = true
+  })
+
+  //6.- Populate tree trunks and canopies with instanced meshes so forests appear around the miniature battlefield.
+  const treeCount = config.trees.length
+  if (treeCount > 0) {
+    const species = config.assets.trees[0]
+    const trunkGeometry = new CylinderGeometry(1, 1, 2, species.lods[0].trunkSides)
+    trunkGeometry.translate(0, 1, 0)
+    const canopyGeometry = new IcosahedronGeometry(1, species.lods[0].leafDetail)
+    const trunkMaterial = new MeshStandardMaterial({ color: 0x4d2c1c, roughness: 0.85, metalness: 0.1 })
+    const canopyMaterial = new MeshStandardMaterial({ color: 0x4a7c59, roughness: 0.65, metalness: 0.1 })
+
+    const trunkMesh = new InstancedMesh(trunkGeometry, trunkMaterial, treeCount)
+    trunkMesh.name = 'battlefield-tree-trunks'
+    const canopyMesh = new InstancedMesh(canopyGeometry, canopyMaterial, treeCount)
+    canopyMesh.name = 'battlefield-tree-canopies'
+
+    const trunkMatrix = new Matrix4()
+    const canopyMatrix = new Matrix4()
+
+    config.trees.forEach((tree, index) => {
+      trunkMatrix.compose(
+        new Vector3(tree.position.x, tree.position.y + tree.trunkHeight * 0.5, tree.position.z),
+        new Quaternion(),
+        new Vector3(tree.variation * 0.8, tree.trunkHeight, tree.variation * 0.8),
+      )
+      canopyMatrix.compose(
+        new Vector3(tree.position.x, tree.position.y + tree.trunkHeight, tree.position.z),
+        new Quaternion(),
+        new Vector3(tree.canopyRadius, tree.canopyRadius, tree.canopyRadius),
+      )
+      trunkMesh.setMatrixAt(index, trunkMatrix)
+      canopyMesh.setMatrixAt(index, canopyMatrix)
+    })
+
+    trunkMesh.instanceMatrix.needsUpdate = true
+    canopyMesh.instanceMatrix.needsUpdate = true
+
+    group.add(trunkMesh)
+    group.add(canopyMesh)
+
+    disposables.push(() => {
+      trunkGeometry.dispose()
+      canopyGeometry.dispose()
+      trunkMaterial.dispose()
+      canopyMaterial.dispose()
+      trunkMesh.dispose()
+      canopyMesh.dispose()
+    })
+  }
+
+  //7.- Return the assembled group with a disposer so callers can clean GPU resources when the preview unmounts.
+  return {
+    group,
+    dispose: () => {
+      disposables.forEach((dispose) => {
+        dispose()
+      })
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- stop instantiating battlefield terrain meshes inside `BattlefieldCanvas` so the combat scene only manages the vehicle, HUD, and peers
- add a reusable `createBattlefieldTerrainPreview` helper (with tests) and have `PlanetaryMapPanel` render the miniature terrain when it receives the battlefield config
- expand the Vitest Three.js mock and related unit tests to exercise the new terrain preview wiring and updated props

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3e3a8f2208329b2c1c9c400aca5d0