### PR TITLE
Add orbital clearance and PageUp throttle boost

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.test.ts
@@ -38,6 +38,7 @@ describe('createVehicleController', () => {
       bounds: 1000,
     })
     const craft = new THREE.Object3D()
+    //1.- Accelerate using the standard throttle so we can measure the unboosted terminal speed.
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
     for (let index = 0; index < 60; index += 1) {
       controller.step(0.1, craft)
@@ -128,8 +129,42 @@ describe('createVehicleController', () => {
     for (let index = 0; index < 60; index += 1) {
       controller.step(0.1, craft)
     }
-    expect(controller.getSpeed()).toBeCloseTo(90, 0)
+    expect(controller.getSpeed()).toBeCloseTo(180, 0)
     controller.dispose()
+  })
+
+  it('applies a 200 percent velocity boost when PageUp engages overdrive', () => {
+    //1.- Accelerate using the standard throttle so we can capture the reference terminal velocity.
+    const baseline = createVehicleController({
+      baseAcceleration: 40,
+      maxForwardSpeed: 90,
+      dragFactor: 1,
+      bounds: 1000,
+    })
+    const baselineCraft = new THREE.Object3D()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
+    for (let index = 0; index < 60; index += 1) {
+      baseline.step(0.1, baselineCraft)
+    }
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp' }))
+    const standardSpeed = baseline.getSpeed()
+    baseline.dispose()
+
+    const boosted = createVehicleController({
+      baseAcceleration: 40,
+      maxForwardSpeed: 90,
+      dragFactor: 1,
+      bounds: 1000,
+    })
+    const boostedCraft = new THREE.Object3D()
+    //2.- Engage PageUp overdrive and confirm the vehicle climbs to double the baseline velocity.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp' }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'PageUp' }))
+    for (let index = 0; index < 60; index += 1) {
+      boosted.step(0.1, boostedCraft)
+    }
+    expect(boosted.getSpeed()).toBeCloseTo(standardSpeed * 2, 0)
+    boosted.dispose()
   })
 
   it('ratchets the latched throttle downward when PageDown is pressed', () => {

--- a/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/vehicleController.ts
@@ -194,9 +194,10 @@ export function createVehicleController(options: VehicleControllerOptions = {}):
     forwardVector.z = -1
     applyQuaternionToVector(forwardVector, object.quaternion)
 
-    //3.- Integrate throttle, brake, and drag influences into the velocity so the craft responds smoothly.
+    //3.- Integrate throttle, brake, and drag influences into the velocity so the craft responds smoothly while PageUp overdrive doubles thrust.
+    const throttleBoost = latchedThrottle > 0 ? 2 : 1
     if (forwardIntent > 0) {
-      const accel = baseAcceleration * (boosting ? boostAccelerationMultiplier : 1)
+      const accel = baseAcceleration * throttleBoost * (boosting ? boostAccelerationMultiplier : 1)
       addScaled(velocity, forwardVector, accel * dt)
     } else if (forwardIntent < 0) {
       const reverseAccel = baseAcceleration * reverseAccelerationMultiplier
@@ -216,7 +217,7 @@ export function createVehicleController(options: VehicleControllerOptions = {}):
     velocity.z *= dragExponent
 
     const forwardComponent = dot(velocity, forwardVector)
-    const forwardCap = maxForwardSpeed * (boosting ? boostSpeedMultiplier : 1)
+    const forwardCap = maxForwardSpeed * throttleBoost * (boosting ? boostSpeedMultiplier : 1)
     if (forwardComponent > forwardCap) {
       addScaled(velocity, forwardVector, forwardCap - forwardComponent)
     } else if (forwardComponent < -maxReverseSpeed) {


### PR DESCRIPTION
## Summary
- enforce orbital clearance for sandbox vehicles and clamp fleet snapshots above the planet surface
- update map panels to spawn craft with the shared clearance helper and add unit coverage
- double the PageUp throttle effect and cover the overdrive behaviour with vitest

## Testing
- npm test (planet_sandbox_web)
- npm test (tunnelcave_sandbox_web)

------
https://chatgpt.com/codex/tasks/task_e_68e3ea6d75b88329bab74bdeda460e10