### PR TITLE
Brighten gameplay planet texture sampling

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/createPlanetShell.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/createPlanetShell.test.ts
@@ -15,8 +15,10 @@ describe('createPlanetShell', () => {
     }
     class StubMeshStandardMaterial {
       side: unknown
-      constructor(options: { side: unknown }) {
+      map?: unknown
+      constructor(options: { side: unknown; map?: unknown }) {
         this.side = options.side
+        this.map = options.map
       }
       dispose = materialDispose
     }
@@ -27,14 +29,41 @@ describe('createPlanetShell', () => {
     class StubColor {
       constructor(public value: unknown) {}
     }
+    const textureDispose = vi.fn()
+    const repeatSet = vi.fn()
+    class StubDataTexture {
+      wrapS: unknown
+      wrapT: unknown
+      colorSpace: unknown
+      format: unknown
+      anisotropy = 0
+      repeat = { set: repeatSet }
+      generateMipmaps = false
+      minFilter: unknown
+      magFilter: unknown
+      needsUpdate = false
+      constructor(public data: Uint8Array, public width: number, public height: number, format: unknown) {
+        this.format = format
+      }
+      dispose = textureDispose
+    }
     const stub = {
       SphereGeometry: StubSphereGeometry,
       MeshStandardMaterial: StubMeshStandardMaterial,
       Mesh: StubMesh,
       Color: StubColor,
       BackSide: 'back-face',
+      DataTexture: StubDataTexture,
+      RepeatWrapping: 'repeat-wrap',
+      RGBAFormat: 'rgba-format',
+      SRGBColorSpace: 'srgb-space',
+      LinearFilter: 'linear-filter',
+      LinearMipMapLinearFilter: 'linear-mipmap-linear',
     }
     vi.doMock('three', () => stub)
+    vi.doMock('./rockyPlanetTexture', () => ({
+      generateRockyPlanetTexture: () => ({ size: 2, data: new Uint8Array(16) }),
+    }))
     const { createPlanetShell } = await import('./createPlanetShell')
     const { mesh, dispose } = createPlanetShell({
       radius: 180,
@@ -45,10 +74,23 @@ describe('createPlanetShell', () => {
     //1.- Ensure the geometry uses the spherical primitive requested for the planetary enclosure.
     expect((mesh.geometry as StubSphereGeometry).parameters.radius).toBe(180)
     //2.- Confirm the material renders the interior faces to keep the shell from hiding gameplay elements.
-    expect((mesh.material as StubMeshStandardMaterial).side).toBe('back-face')
+    const material = mesh.material as StubMeshStandardMaterial
+    expect(material.side).toBe('back-face')
+    const map = material.map as StubDataTexture
+    expect(map).toBeInstanceOf(StubDataTexture)
+    expect(map.wrapS).toBe('repeat-wrap')
+    expect(map.wrapT).toBe('repeat-wrap')
+    expect(map.colorSpace).toBe('srgb-space')
+    //3.- Ensure the rocky albedo uses mipmapped linear filtering and repeats around the sphere for detail clarity.
+    expect(map.generateMipmaps).toBe(true)
+    expect(map.minFilter).toBe('linear-mipmap-linear')
+    expect(map.magFilter).toBe('linear-filter')
+    expect(repeatSet).toHaveBeenCalledWith(3, 1.5)
+    //4.- Confirm the factory provides a disposal hook that clears underlying WebGL resources.
     dispose()
     expect(geometryDispose).toHaveBeenCalled()
     expect(materialDispose).toHaveBeenCalled()
+    expect(textureDispose).toHaveBeenCalled()
   })
 })
 

--- a/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateRockyPlanetTexture } from './rockyPlanetTexture'
+
+describe('generateRockyPlanetTexture', () => {
+  it('produces packed RGBA data with visible tonal variation', () => {
+    const bundle = generateRockyPlanetTexture({ size: 32, seed: 7 })
+    //1.- Ensure the generator honours the requested resolution and returns a packed RGBA buffer.
+    expect(bundle.size).toBe(32)
+    expect(bundle.data).toBeInstanceOf(Uint8Array)
+    expect(bundle.data).toHaveLength(32 * 32 * 4)
+    //2.- Ensure the packed pixels span a range of brightness values to read as rocky relief instead of a flat tone.
+    let min = 255
+    let max = 0
+    let sum = 0
+    let count = 0
+    for (let i = 0; i < bundle.data.length; i += 4) {
+      const brightness = (bundle.data[i] + bundle.data[i + 1] + bundle.data[i + 2]) / 3
+      min = Math.min(min, brightness)
+      max = Math.max(max, brightness)
+      sum += brightness
+      count += 1
+    }
+    expect(max - min).toBeGreaterThan(20)
+    //3.- Verify the average luminance lifts above deep blues so the rocky shell contrasts the surrounding atmosphere.
+    expect(sum / count).toBeGreaterThan(110)
+  })
+})

--- a/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.ts
@@ -1,0 +1,102 @@
+export interface RockyTextureOptions {
+  size?: number
+  seed?: number
+}
+
+export interface RockyTextureBundle {
+  size: number
+  data: Uint8Array
+}
+
+const DEFAULT_SIZE = 256
+
+function smoothStep(value: number): number {
+  //1.- Ease interpolation edges so the layered noise transitions softly between grid samples.
+  return value * value * (3 - 2 * value)
+}
+
+function interpolate(a: number, b: number, t: number): number {
+  //2.- Blend two values using the smoothed interpolation factor for coherent noise synthesis.
+  return a + (b - a) * t
+}
+
+function pseudoRandom(x: number, y: number, seed: number): number {
+  //3.- Produce a deterministic pseudo-random value in the range [0, 1) using a hashed sine pattern.
+  const s = Math.sin(x * 127.1 + y * 311.7 + seed * 19.19) * 43758.5453
+  return s - Math.floor(s)
+}
+
+function clamp(value: number, min: number, max: number): number {
+  //4.- Bound a value between the provided limits without pulling in Three.js helpers that are undefined during tests.
+  return Math.min(max, Math.max(min, value))
+}
+
+function valueNoise(x: number, y: number, seed: number): number {
+  //5.- Sample value noise by interpolating pseudo-random corner values across a grid cell.
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = x0 + 1
+  const y1 = y0 + 1
+  const tx = smoothStep(x - x0)
+  const ty = smoothStep(y - y0)
+  const n00 = pseudoRandom(x0, y0, seed)
+  const n10 = pseudoRandom(x1, y0, seed)
+  const n01 = pseudoRandom(x0, y1, seed)
+  const n11 = pseudoRandom(x1, y1, seed)
+  const ix0 = interpolate(n00, n10, tx)
+  const ix1 = interpolate(n01, n11, tx)
+  return interpolate(ix0, ix1, ty)
+}
+
+function fractalBrownianMotion(x: number, y: number, seed: number, octaves: number): number {
+  //6.- Layer multiple octaves of value noise to create rich surface detail reminiscent of cratered stone.
+  let amplitude = 1
+  let frequency = 1
+  let sum = 0
+  let weight = 0
+  for (let i = 0; i < octaves; i += 1) {
+    sum += valueNoise(x * frequency, y * frequency, seed + i * 37.17) * amplitude
+    weight += amplitude
+    amplitude *= 0.5
+    frequency *= 2
+  }
+  return weight > 0 ? sum / weight : 0
+}
+
+export function generateRockyPlanetTexture(options: RockyTextureOptions = {}): RockyTextureBundle {
+  //7.- Resolve configuration values with safe defaults so the generator can run without explicit input.
+  const size = Math.max(16, options.size ?? DEFAULT_SIZE)
+  const seed = options.seed ?? 42
+  const data = new Uint8Array(size * size * 4)
+  let offset = 0
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      //8.- Normalise coordinates into [0, 1] to keep the procedural pattern resolution independent.
+      const u = x / size
+      const v = y / size
+      const base = fractalBrownianMotion(u * 8, v * 8, seed, 4)
+      const craters = fractalBrownianMotion(u * 24 + 17.3, v * 24 + 9.1, seed + 91.7, 3)
+      const ridge = fractalBrownianMotion(u * 16 - 5.4, v * 16 + 12.6, seed + 13.5, 2)
+      const frost = fractalBrownianMotion(u * 48 + 3.2, v * 48 - 11.7, seed + 211.4, 2)
+      //9.- Sculpt a crater mask by emphasising deviations from the midpoint and blending in ridge detail.
+      const craterMask = Math.pow(Math.abs(craters - 0.5) * 2, 1.6)
+      const ridgeMask = ridge * 0.45 + 0.35
+      const frostMask = clamp(Math.pow(frost, 1.8) * 0.6, 0, 0.6)
+      //10.- Assemble the final intensity and bias the palette toward moonlit basalt tones with bright frosted rims.
+      const height = clamp(base * 0.5 + craterMask * 0.45 + ridgeMask * 0.2, 0, 1)
+      const highlight = clamp(0.2 + height * 0.6 + frostMask, 0, 1)
+      const r = clamp(92 + highlight * 128 - craterMask * 36, 0, 255)
+      const g = clamp(100 + highlight * 120 - craterMask * 28, 0, 255)
+      const b = clamp(108 + highlight * 116 - craterMask * 18, 0, 255)
+      data[offset] = r
+      data[offset + 1] = g
+      data[offset + 2] = b
+      data[offset + 3] = 255
+      offset += 4
+    }
+  }
+
+  //11.- Return the packed texture data so the runtime can upload it using the active Three.js context.
+  return { size, data }
+}


### PR DESCRIPTION
## Summary
- boost the procedural rocky texture with frosted highlights so the surface reads brighter against the atmosphere
- enable mipmapped linear filtering and tiling on the planet shell material for sharper detail coverage
- extend texture and shell unit tests to cover the new luminance targets and sampler configuration

## Testing
- npm test -- --run


------
https://chatgpt.com/codex/tasks/task_e_68e3f7c37c708329b49b4e8005ebcbfa