### PR TITLE
Ensure rocky planet texture data exposes ArrayBuffer backing

### DIFF
--- a/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.test.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.test.ts
@@ -25,4 +25,13 @@ describe('generateRockyPlanetTexture', () => {
     //3.- Verify the average luminance lifts above deep blues so the rocky shell contrasts the surrounding atmosphere.
     expect(sum / count).toBeGreaterThan(110)
   })
+
+  it('returns texture data backed by a transferable ArrayBuffer', () => {
+    const bundle = generateRockyPlanetTexture({ size: 16, seed: 19 })
+    //1.- Confirm the buffer advertises ArrayBuffer so strict DOM typings accept the data as a WebGL upload source.
+    expect(bundle.data.buffer).toBeInstanceOf(ArrayBuffer)
+    //2.- Ensure the view references the full allocated buffer so no byte offsets are introduced unexpectedly.
+    expect(bundle.data.byteOffset).toBe(0)
+    expect(bundle.data.byteLength).toBe(bundle.size * bundle.size * 4)
+  })
 })

--- a/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.ts
+++ b/tunnelcave_sandbox_web/app/gameplay/planet/rockyPlanetTexture.ts
@@ -3,12 +3,20 @@ export interface RockyTextureOptions {
   seed?: number
 }
 
+export type RockyTextureData = Uint8Array & { buffer: ArrayBuffer }
+
 export interface RockyTextureBundle {
   size: number
-  data: Uint8Array
+  data: RockyTextureData
 }
 
 const DEFAULT_SIZE = 256
+
+function createArrayBackedUint8Array(length: number): RockyTextureData {
+  //1.- Allocate an ArrayBuffer explicitly so the resulting view advertises the ArrayBuffer type to strict DOM lib typings.
+  const buffer = new ArrayBuffer(length)
+  return new Uint8Array(buffer) as RockyTextureData
+}
 
 function smoothStep(value: number): number {
   //1.- Ease interpolation edges so the layered noise transitions softly between grid samples.
@@ -67,7 +75,7 @@ export function generateRockyPlanetTexture(options: RockyTextureOptions = {}): R
   //7.- Resolve configuration values with safe defaults so the generator can run without explicit input.
   const size = Math.max(16, options.size ?? DEFAULT_SIZE)
   const seed = options.seed ?? 42
-  const data = new Uint8Array(size * size * 4)
+  const data = createArrayBackedUint8Array(size * size * 4)
   let offset = 0
 
   for (let y = 0; y < size; y += 1) {


### PR DESCRIPTION
## Summary
- add an ArrayBuffer-backed Uint8Array helper used by the rocky planet texture generator
- update rocky planet texture tests to verify ArrayBuffer compatibility with WebGL uploads

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e3ff4cb9e483298cf6d6d424f915a1