### PR TITLE
Add infinite flight field generator and War Thunder controls

### DIFF
--- a/tunnelcave_sandbox_web/src/input/flightControls.test.ts
+++ b/tunnelcave_sandbox_web/src/input/flightControls.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_FLIGHT_BINDINGS,
+  FlightKeybindingConfiguration,
+  createFlightKeybindingConfiguration,
+} from './flightControls'
+
+//1.- Validate the War Thunder inspired defaults map actions to the expected keys and axes.
+describe('FlightKeybindingConfiguration defaults', () => {
+  it('exposes the full default control layout', () => {
+    const config = createFlightKeybindingConfiguration()
+    const bindings = config.describe()
+    for (const definition of DEFAULT_FLIGHT_BINDINGS) {
+      const binding = bindings.find((entry) => entry.action === definition.action)
+      expect(binding?.axis).toBe(definition.axis)
+      expect(binding?.mode).toBe(definition.mode)
+      expect(binding?.key).toBe(definition.defaultKey)
+      expect(binding?.step).toBe(definition.step)
+    }
+  })
+})
+
+//2.- Confirm overrides flow through accessibility helpers without mutating the defaults.
+describe('FlightKeybindingConfiguration overrides', () => {
+  it('allows throttle adjustments to use alternate keys', () => {
+    const config = FlightKeybindingConfiguration.withDefaults({
+      'Throttle Increase': { key: 'KeyR' },
+      'Throttle Decrease': { key: 'KeyF' },
+    })
+    const increase = config.describe().find((entry) => entry.action === 'Throttle Increase')
+    const defaults = config.listDefaults().find((entry) => entry.action === 'Throttle Increase')
+    expect(increase?.key).toBe('KeyR')
+    expect(defaults?.key).toBe('ShiftLeft')
+  })
+
+  it('surfaces accessibility summaries pairing current and default bindings', () => {
+    const config = FlightKeybindingConfiguration.withDefaults({ 'Toggle Freelook': { key: 'Mouse3' } })
+    const summary = config.accessibilitySummaries().find((entry) => entry.action === 'Toggle Freelook')
+    expect(summary).toEqual({ action: 'Toggle Freelook', key: 'Mouse3', defaultKey: 'KeyC' })
+  })
+})

--- a/tunnelcave_sandbox_web/src/input/flightControls.ts
+++ b/tunnelcave_sandbox_web/src/input/flightControls.ts
@@ -1,0 +1,143 @@
+export type FlightControlAxis =
+  | 'pitch'
+  | 'roll'
+  | 'yaw'
+  | 'throttle'
+  | 'flaps'
+  | 'gear'
+  | 'engine'
+  | 'camera'
+  | 'airbrake'
+
+export type FlightBindingMode = 'positive' | 'negative' | 'toggle' | 'increment'
+
+export interface FlightKeybindingDefinition {
+  action: FlightControlAction
+  defaultKey: string
+  axis: FlightControlAxis
+  mode: FlightBindingMode
+  step?: number
+}
+
+export type FlightControlAction =
+  | 'Pitch Down'
+  | 'Pitch Up'
+  | 'Roll Left'
+  | 'Roll Right'
+  | 'Yaw Left'
+  | 'Yaw Right'
+  | 'Throttle Increase'
+  | 'Throttle Decrease'
+  | 'Throttle Fine Increase'
+  | 'Throttle Fine Decrease'
+  | 'Toggle Flaps'
+  | 'Toggle Landing Gear'
+  | 'Toggle Engine'
+  | 'Toggle Freelook'
+  | 'Toggle Alternate Camera'
+  | 'Hold Wheel Brakes / Airbrake'
+
+export interface FlightKeybinding {
+  action: FlightControlAction
+  key: string
+  axis: FlightControlAxis
+  mode: FlightBindingMode
+  defaultKey: string
+  step?: number
+}
+
+export type FlightKeybindingOverrides = Partial<Record<FlightControlAction, { key: string }>>
+
+export const DEFAULT_FLIGHT_BINDINGS: FlightKeybindingDefinition[] = [
+  { action: 'Pitch Down', defaultKey: 'KeyW', axis: 'pitch', mode: 'positive' },
+  { action: 'Pitch Up', defaultKey: 'KeyS', axis: 'pitch', mode: 'negative' },
+  { action: 'Roll Left', defaultKey: 'KeyA', axis: 'roll', mode: 'negative' },
+  { action: 'Roll Right', defaultKey: 'KeyD', axis: 'roll', mode: 'positive' },
+  { action: 'Yaw Left', defaultKey: 'KeyQ', axis: 'yaw', mode: 'negative' },
+  { action: 'Yaw Right', defaultKey: 'KeyE', axis: 'yaw', mode: 'positive' },
+  { action: 'Throttle Increase', defaultKey: 'ShiftLeft', axis: 'throttle', mode: 'increment', step: 0.08 },
+  { action: 'Throttle Decrease', defaultKey: 'ControlLeft', axis: 'throttle', mode: 'increment', step: -0.08 },
+  { action: 'Throttle Fine Increase', defaultKey: 'WheelUp', axis: 'throttle', mode: 'increment', step: 0.02 },
+  { action: 'Throttle Fine Decrease', defaultKey: 'WheelDown', axis: 'throttle', mode: 'increment', step: -0.02 },
+  { action: 'Toggle Flaps', defaultKey: 'KeyF', axis: 'flaps', mode: 'toggle' },
+  { action: 'Toggle Landing Gear', defaultKey: 'KeyG', axis: 'gear', mode: 'toggle' },
+  { action: 'Toggle Engine', defaultKey: 'KeyI', axis: 'engine', mode: 'toggle' },
+  { action: 'Toggle Freelook', defaultKey: 'KeyC', axis: 'camera', mode: 'toggle' },
+  { action: 'Toggle Alternate Camera', defaultKey: 'KeyV', axis: 'camera', mode: 'toggle' },
+  { action: 'Hold Wheel Brakes / Airbrake', defaultKey: 'KeyB', axis: 'airbrake', mode: 'toggle' },
+]
+
+export class FlightKeybindingConfiguration {
+  private readonly bindings: Map<FlightControlAction, FlightKeybinding>
+
+  private constructor(bindings: Map<FlightControlAction, FlightKeybinding>) {
+    //1.- Preserve the merged flight bindings to drive runtime control lookups.
+    this.bindings = bindings
+  }
+
+  static withDefaults(overrides: FlightKeybindingOverrides = {}): FlightKeybindingConfiguration {
+    //1.- Merge overrides against the baked-in War Thunder inspired control scheme.
+    const merged = new Map<FlightControlAction, FlightKeybinding>()
+    for (const definition of DEFAULT_FLIGHT_BINDINGS) {
+      const override = overrides[definition.action]
+      const key = override?.key ?? definition.defaultKey
+      merged.set(definition.action, {
+        action: definition.action,
+        key,
+        axis: definition.axis,
+        mode: definition.mode,
+        defaultKey: definition.defaultKey,
+        step: definition.step,
+      })
+    }
+    return new FlightKeybindingConfiguration(merged)
+  }
+
+  describe(): FlightKeybinding[] {
+    //1.- Emit a predictable binding list for UI renderers and tests.
+    return [...this.bindings.values()].sort((a, b) => a.action.localeCompare(b.action))
+  }
+
+  withOverrides(overrides: FlightKeybindingOverrides = {}): FlightKeybindingConfiguration {
+    //1.- Produce a new configuration that applies additional overrides without mutating the current map.
+    const next = new Map<FlightControlAction, FlightKeybinding>()
+    for (const binding of this.bindings.values()) {
+      const override = overrides[binding.action]
+      const key = override?.key ?? binding.key
+      next.set(binding.action, { ...binding, key })
+    }
+    return new FlightKeybindingConfiguration(next)
+  }
+
+  findByKey(key: string): FlightKeybinding | undefined {
+    //1.- Locate bindings by hardware key code so gameplay systems can react to input events.
+    for (const binding of this.bindings.values()) {
+      if (binding.key === key) {
+        return binding
+      }
+    }
+    return undefined
+  }
+
+  listDefaults(): FlightKeybinding[] {
+    //1.- Surface the original defaults while retaining per-action metadata for accessibility menus.
+    return this.describe().map((binding) => ({
+      ...binding,
+      key: binding.defaultKey,
+    }))
+  }
+
+  accessibilitySummaries(): Array<{ action: FlightControlAction; key: string; defaultKey: string }> {
+    //1.- Pair the active key with its default counterpart for quick UI summaries.
+    return this.describe().map((binding) => ({
+      action: binding.action,
+      key: binding.key,
+      defaultKey: binding.defaultKey,
+    }))
+  }
+}
+
+export const createFlightKeybindingConfiguration = (overrides: FlightKeybindingOverrides = {}): FlightKeybindingConfiguration => {
+  //1.- Convenience helper that mirrors the standard constructor signature.
+  return FlightKeybindingConfiguration.withDefaults(overrides)
+}

--- a/tunnelcave_sandbox_web/src/world/procedural/infiniteFlightField.test.ts
+++ b/tunnelcave_sandbox_web/src/world/procedural/infiniteFlightField.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+
+import { createInfiniteFlightField, debugGenerateFlightTile } from './infiniteFlightField'
+
+//1.- Confirm deterministic tile generation so infinite map streaming stays stable across sessions.
+describe('debugGenerateFlightTile', () => {
+  it('generates reproducible terrain metrics per tile index', () => {
+    const first = debugGenerateFlightTile(1337, { x: 0, z: 0 }, 160, 17)
+    const second = debugGenerateFlightTile(1337, { x: 0, z: 0 }, 160, 17)
+    expect(first.tile.metrics).toEqual(second.tile.metrics)
+    expect(Array.from(first.tile.heights)).toEqual(Array.from(second.tile.heights))
+  })
+
+  it('varies heights between neighbouring tiles so repetition is avoided', () => {
+    const base = debugGenerateFlightTile(2001, { x: 0, z: 0 }, 200, 17)
+    const neighbour = debugGenerateFlightTile(2001, { x: 1, z: 0 }, 200, 17)
+    expect(base.tile.metrics.maxHeight).not.toBeCloseTo(neighbour.tile.metrics.maxHeight)
+  })
+})
+
+//2.- Validate the streaming loader loads and unloads tiles relative to the viewer position.
+describe('createInfiniteFlightField', () => {
+  it('loads tiles around the observer and clears stale tiles when moving', () => {
+    const loaded: string[] = []
+    const unloaded: string[] = []
+    const field = createInfiniteFlightField({
+      seed: 99,
+      tileSize: 100,
+      resolution: 17,
+      viewDistance: 1,
+      onTileLoaded: (tile) => loaded.push(tile.id),
+      onTileUnloaded: (tile) => unloaded.push(tile.id),
+    })
+
+    field.update(new THREE.Vector3(10, 0, 10))
+    expect(field.tiles.size).toBe(9)
+    expect(loaded).toHaveLength(9)
+
+    loaded.length = 0
+
+    field.update(new THREE.Vector3(210, 0, 10))
+    expect(field.tiles.size).toBe(9)
+    expect(loaded).toContain('2:0')
+    expect(unloaded).toContain('-1:-1')
+
+    field.dispose()
+  })
+
+  it('normalises resolution to odd values to preserve a central vertex', () => {
+    const field = createInfiniteFlightField({ resolution: 12 })
+    field.update(new THREE.Vector3(0, 0, 0))
+    const [tile] = [...field.tiles.values()]
+    expect(tile?.resolution % 2).toBe(1)
+    field.dispose()
+  })
+})

--- a/tunnelcave_sandbox_web/src/world/procedural/infiniteFlightField.ts
+++ b/tunnelcave_sandbox_web/src/world/procedural/infiniteFlightField.ts
@@ -1,0 +1,219 @@
+import * as THREE from 'three'
+
+export interface FlightTileIndex {
+  x: number
+  z: number
+}
+
+export interface FlightTileMetrics {
+  minHeight: number
+  maxHeight: number
+  averageHeight: number
+}
+
+export interface FlightTile {
+  id: string
+  index: FlightTileIndex
+  origin: { x: number; z: number }
+  size: number
+  resolution: number
+  heights: Float32Array
+  normals: Float32Array
+  metrics: FlightTileMetrics
+}
+
+export interface InfiniteFlightFieldOptions {
+  seed?: number
+  tileSize?: number
+  resolution?: number
+  viewDistance?: number
+  onTileLoaded?: (tile: FlightTile) => void
+  onTileUnloaded?: (tile: FlightTile) => void
+}
+
+interface GeneratedTile {
+  tile: FlightTile
+  heightGrid: number[][]
+}
+
+const DEFAULT_TILE_SIZE = 320
+const DEFAULT_RESOLUTION = 33
+const DEFAULT_VIEW_DISTANCE = 1
+const MIN_RESOLUTION = 5
+
+function tileKey(index: FlightTileIndex): string {
+  //1.- Compose a deterministic string key so tile storage stays map friendly.
+  return `${index.x}:${index.z}`
+}
+
+function sampleHeight(seed: number, worldX: number, worldZ: number): number {
+  //1.- Blend several trigonometric layers to provide deterministic pseudo-random terrain undulation.
+  const nx = worldX * 0.0031 + seed * 0.0002
+  const nz = worldZ * 0.0027 - seed * 0.00015
+  const ridge = Math.sin(nx * 1.4 + Math.cos(nz * 0.6)) * Math.cos(nz * 1.1 + seed * 0.0013)
+  const dunes = Math.sin(nx * 0.32 + nz * 0.28) * 12
+  const strata = Math.cos(nx * 0.12 - nz * 0.18 + seed * 0.0041) * 18
+  const valley = Math.sin((nx + nz) * 0.62) * 9
+  const plateau = Math.max(0, Math.sin(nx * 0.18 + seed * 0.02) + Math.cos(nz * 0.21 - seed * 0.018)) * 7
+  return ridge * 11 + dunes + strata * 0.6 + valley * 0.8 + plateau
+}
+
+function generateHeightGrid(seed: number, index: FlightTileIndex, tileSize: number, resolution: number): number[][] {
+  //1.- Fill a two-dimensional grid with deterministic height samples anchored to the tile indices.
+  const grid: number[][] = []
+  const step = tileSize / (resolution - 1)
+  for (let row = 0; row < resolution; row += 1) {
+    const worldZ = (index.z * tileSize) + row * step
+    const samples: number[] = []
+    for (let column = 0; column < resolution; column += 1) {
+      const worldX = (index.x * tileSize) + column * step
+      samples.push(sampleHeight(seed, worldX, worldZ))
+    }
+    grid.push(samples)
+  }
+  return grid
+}
+
+function buildNormals(grid: number[][], tileSize: number, resolution: number): Float32Array {
+  //1.- Approximate normals via central differences so lighting can react to slope changes.
+  const normals = new Float32Array(resolution * resolution * 3)
+  const step = tileSize / (resolution - 1)
+  for (let row = 0; row < resolution; row += 1) {
+    for (let column = 0; column < resolution; column += 1) {
+      const center = grid[row][column]
+      const left = column > 0 ? grid[row][column - 1] : center
+      const right = column < resolution - 1 ? grid[row][column + 1] : center
+      const top = row > 0 ? grid[row - 1][column] : center
+      const bottom = row < resolution - 1 ? grid[row + 1][column] : center
+      const dx = (right - left) / (2 * step)
+      const dz = (bottom - top) / (2 * step)
+      const normal = new THREE.Vector3(-dx, 1, -dz).normalize()
+      const baseIndex = (row * resolution + column) * 3
+      normals[baseIndex] = normal.x
+      normals[baseIndex + 1] = normal.y
+      normals[baseIndex + 2] = normal.z
+    }
+  }
+  return normals
+}
+
+function flattenGrid(grid: number[][]): Float32Array {
+  //1.- Convert the two-dimensional height table into a tightly packed Float32Array for GPU uploads.
+  const resolution = grid.length
+  const flat = new Float32Array(resolution * resolution)
+  for (let row = 0; row < resolution; row += 1) {
+    for (let column = 0; column < resolution; column += 1) {
+      flat[row * resolution + column] = grid[row][column]
+    }
+  }
+  return flat
+}
+
+function computeMetrics(grid: number[][]): FlightTileMetrics {
+  //1.- Track height extremes and the rolling average for quick telemetry overlays.
+  let minHeight = Number.POSITIVE_INFINITY
+  let maxHeight = Number.NEGATIVE_INFINITY
+  let sum = 0
+  let count = 0
+  for (const row of grid) {
+    for (const value of row) {
+      minHeight = Math.min(minHeight, value)
+      maxHeight = Math.max(maxHeight, value)
+      sum += value
+      count += 1
+    }
+  }
+  return {
+    minHeight,
+    maxHeight,
+    averageHeight: count > 0 ? sum / count : 0,
+  }
+}
+
+function generateTile(seed: number, index: FlightTileIndex, tileSize: number, resolution: number): GeneratedTile {
+  //1.- Assemble the height grid, derived metrics, and tangent-space normals for a single tile.
+  const heightGrid = generateHeightGrid(seed, index, tileSize, resolution)
+  const heights = flattenGrid(heightGrid)
+  const normals = buildNormals(heightGrid, tileSize, resolution)
+  const metrics = computeMetrics(heightGrid)
+  const origin = { x: index.x * tileSize, z: index.z * tileSize }
+  const tile: FlightTile = {
+    id: tileKey(index),
+    index,
+    origin,
+    size: tileSize,
+    resolution,
+    heights,
+    normals,
+    metrics,
+  }
+  return { tile, heightGrid }
+}
+
+export interface InfiniteFlightField {
+  update: (position: THREE.Vector3 | { x: number; z: number }) => void
+  tiles: Map<string, FlightTile>
+  dispose: () => void
+}
+
+export const createInfiniteFlightField = (options: InfiniteFlightFieldOptions = {}): InfiniteFlightField => {
+  //1.- Normalise configuration inputs ensuring tile dimensions and resolution stay within safe bounds.
+  const seed = options.seed ?? 1337
+  const tileSize = options.tileSize && options.tileSize > 0 ? options.tileSize : DEFAULT_TILE_SIZE
+  const viewDistance = options.viewDistance !== undefined && options.viewDistance >= 0 ? options.viewDistance : DEFAULT_VIEW_DISTANCE
+  const resolution = options.resolution && options.resolution >= MIN_RESOLUTION ? Math.floor(options.resolution) : DEFAULT_RESOLUTION
+  const clampedResolution = resolution % 2 === 1 ? resolution : resolution + 1
+
+  const activeTiles = new Map<string, FlightTile>()
+  const desiredSet = new Set<string>()
+
+  const ensureTile = (index: FlightTileIndex) => {
+    const key = tileKey(index)
+    if (!activeTiles.has(key)) {
+      const generated = generateTile(seed, index, tileSize, clampedResolution)
+      activeTiles.set(key, generated.tile)
+      options.onTileLoaded?.(generated.tile)
+    }
+    desiredSet.add(key)
+  }
+
+  const releaseMissingTiles = () => {
+    for (const [key, tile] of activeTiles.entries()) {
+      if (!desiredSet.has(key)) {
+        activeTiles.delete(key)
+        options.onTileUnloaded?.(tile)
+      }
+    }
+    desiredSet.clear()
+  }
+
+  const update = (position: THREE.Vector3 | { x: number; z: number }) => {
+    //1.- Resolve the observer position, derive the central tile, and queue surrounding tiles.
+    const x = position.x
+    const z = position.z
+    const center: FlightTileIndex = { x: Math.floor(x / tileSize), z: Math.floor(z / tileSize) }
+    for (let dz = -viewDistance; dz <= viewDistance; dz += 1) {
+      for (let dx = -viewDistance; dx <= viewDistance; dx += 1) {
+        ensureTile({ x: center.x + dx, z: center.z + dz })
+      }
+    }
+    releaseMissingTiles()
+  }
+
+  const dispose = () => {
+    //1.- Clear tile caches and emit unload callbacks for deterministic teardown.
+    for (const tile of activeTiles.values()) {
+      options.onTileUnloaded?.(tile)
+    }
+    activeTiles.clear()
+    desiredSet.clear()
+  }
+
+  return {
+    update,
+    tiles: activeTiles,
+    dispose,
+  }
+}
+
+export { generateTile as debugGenerateFlightTile }


### PR DESCRIPTION
## Summary
- add a War Thunder inspired flight keybinding configuration with defaults and overrides helpers
- implement a procedural infinite flight field generator that streams tiles around the observer and expose debugging helpers
- cover the new modules with Vitest suites validating deterministic generation and configuration overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e403d9156c8329b979e77096031022