### PR TITLE
Switch frontend to planet sandbox with live service wiring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,17 +35,16 @@ services:
   web-client:
     build:
       context: .
-      dockerfile: tunnelcave_sandbox_web/Dockerfile
+      dockerfile: planet_sandbox_web/Dockerfile
     image: driftpursuit/web-client:latest
     depends_on:
       - broker
     environment:
       NODE_ENV: production
-      NEXT_PUBLIC_BROKER_URL: ws://host.docker.internal:43127/ws
-      # Web client proxy reaches the bundled Python bridge via the Compose network.
-      SIM_BRIDGE_URL: http://bot-runner:8000
+      VITE_BROKER_URL: ws://host.docker.internal:43127/ws
+      VITE_SIM_BRIDGE_URL: http://localhost:8000
     ports:
-      - "3000:3000"
+      - "3000:80"
     networks:
       - battleground
     # Linux: map host.docker.internal to the Docker host gateway

--- a/docs/env_configuration/README.md
+++ b/docs/env_configuration/README.md
@@ -1,26 +1,25 @@
 # Environment Configuration
 
-The Drift Pursuit sandbox relies on a small `.env.local` file inside `tunnelcave_sandbox_web/` to surface runtime configuration to the Next.js frontend. The keys listed below are safe defaults for local development and align with the expectations baked into the onboarding UI.
+The Drift Pursuit sandbox relies on a small `.env.local` file inside `planet_sandbox_web/` to surface runtime configuration to the Vite frontend. The keys listed below are safe defaults for local development and align with the expectations baked into the onboarding UI.
 
 ## Required Keys
 
 | Key | Purpose | Local sample |
 | --- | --- | --- |
-| `NEXT_PUBLIC_BROKER_URL` | Websocket endpoint for exchanging HUD telemetry with the broker service. | `ws://localhost:43127/ws` |
-| `SIM_BRIDGE_URL` | Server-side override for the simulation bridge origin used by the API proxy. | `http://localhost:8000` |
-| `NEXT_PUBLIC_SIM_BRIDGE_URL` | Optional browser-visible origin for bypassing the proxy during cross-origin development. | `http://localhost:8000` |
+| `VITE_BROKER_URL` | Websocket endpoint for exchanging HUD telemetry with the broker service. | `ws://localhost:43127/ws` |
+| `VITE_SIM_BRIDGE_URL` | HTTP origin for the Python simulation bridge. | `http://localhost:8000` |
 
 > [!TIP]
-> Run `scripts/setup-env.sh` from the repository root to scaffold a `.env.local` file pre-populated with the values above, including inline comments that explain how to adjust them for non-local setups. When deploying the Next.js frontend separately from the bridge, set `SIM_BRIDGE_URL` on the server to avoid CORS preflight failures.
+> Run `scripts/setup-env.sh` from the repository root to scaffold a `.env.local` file pre-populated with the values above, including inline comments that explain how to adjust them for non-local setups. When deploying the frontend separately from the bridge, update `VITE_SIM_BRIDGE_URL` to point at the reachable origin.
 
 > [!IMPORTANT]
-> The simulation control panel automatically falls back to `/api/sim-bridge/*` when no direct base URL override is supplied. With that proxy in place, configuring `SIM_BRIDGE_URL` on the server is enough to reach the bridge; only add `NEXT_PUBLIC_SIM_BRIDGE_URL` when the browser must talk to the bridge origin directly.
+> The simulation control panel talks directly to the configured bridge origin. Update `VITE_SIM_BRIDGE_URL` whenever the Python service moves to a different host or port.
 
 > [!NOTE]
-> When the Next.js frontend runs inside Docker, `localhost` resolves to the container itself. Point `SIM_BRIDGE_URL` (and `NEXT_PUBLIC_SIM_BRIDGE_URL` when needed) at `http://host.docker.internal:8000` so the proxy can reach a bridge running on your host machine. The provided `docker-compose.yml` sets `SIM_BRIDGE_URL=http://bot-runner:8000` so the web client reaches the bundled Python bridge by default.
+> When the frontend runs inside Docker, the static assets are baked with production URLs at build time. The provided `docker-compose.yml` sets `VITE_BROKER_URL=ws://host.docker.internal:43127/ws` and `VITE_SIM_BRIDGE_URL=http://localhost:8000` so the browser can reach the bundled services.
 
 ## Manual Setup Checklist
 
-1. Create `tunnelcave_sandbox_web/.env.local` if it does not exist.
+1. Create `planet_sandbox_web/.env.local` if it does not exist.
 2. Populate the keys above, adjusting the host/port to match your running services.
-3. Restart `npm run dev` so the Next.js client reloads with the new environment variables.
+3. Restart `npm run dev` so the Vite client reloads with the new environment variables.

--- a/docs/integration_bridge/README.md
+++ b/docs/integration_bridge/README.md
@@ -3,7 +3,7 @@
 ## Audit Summary
 - `python-sim` exposes vehicle state via physics modules and now provides an HTTP bridge at `web_bridge.server` for handshake, state polling, and command dispatch.
 - `tunnelcave_sandbox` hosts legacy simulation scenes compatible with the Python runtime.
-- `tunnelcave_sandbox_web` renders the browser client using Next.js, with new components that connect to the HTTP bridge.
+- `planet_sandbox_web` renders the browser client using Vite + React, with components that connect directly to the HTTP bridge.
 
 ## Communication Layer Decisions
 - Initial integration keeps the authoritative simulation in Python and synchronises through an HTTP bridge to reduce browser-side porting.
@@ -14,7 +14,7 @@
 - Convert assets to `glTF` using Blender export presets to minimise file size before publishing to the web client.
 
 ## Front-End Rendering & Controls
-- Next.js client now includes `SimulationControlPanel`, enabling handshake verification and dispatch of throttle/brake commands.
+- The Vite client includes `SimulationBridgePanel`, enabling handshake verification and dispatch of throttle/brake commands.
 - Integration with the 3D renderer will map telemetry returned by `/state` into scene graph updates.
 
 ## Back-End API
@@ -29,7 +29,7 @@
 
 ## Deployment Notes
 - Start the server via `python -m web_bridge.server` with `PYTHONPATH=python-sim` during development.
-- Run `npm run dev` inside `tunnelcave_sandbox_web` and set `NEXT_PUBLIC_SIM_BRIDGE_URL` to the bridge origin (e.g. `http://localhost:8000`).
+- Run `npm run dev` inside `planet_sandbox_web` and set `VITE_SIM_BRIDGE_URL` to the bridge origin (e.g. `http://localhost:8000`).
 
 ## Next Steps
 - Wire real simulation telemetry into the `state_provider` callback.

--- a/docs/reviews/game-access/README.md
+++ b/docs/reviews/game-access/README.md
@@ -2,11 +2,11 @@
 
 ## Docker Availability
 - The repository ships a `docker-compose.yml` configuration that builds three services (`broker`, `bot-runner`, `web-client`).
-- The `web-client` service exposes port 3000, depends on the broker, and injects the `NEXT_PUBLIC_BROKER_URL` needed for the Next.js front-end to connect.
+- The `web-client` service exposes port 3000, depends on the broker, and embeds the `VITE_BROKER_URL` value needed for the Vite front-end to connect.
 
 ## Three.js Game Client
-- The Next.js client in `tunnelcave_sandbox_web` mounts the game shell inside `<div id="canvas-root">`, creating a deterministic canvas for rendering.
-- `ClientBootstrap` dynamically imports the runtime shell and mounts it once the broker URL is resolved, ensuring the HUD and 3D renderer initialize when the page loads.
+- The Vite client in `planet_sandbox_web` mounts the sandbox inside the main React tree, creating a deterministic canvas for rendering.
+- The `PlanetSandbox` component resolves broker telemetry and simulation bridge configuration before wiring up the renderer so the HUD and 3D scene initialize when the page loads.
 
 ## Procedural Vehicle Geometry
 - The shared TypeScript client (`typescript-client`) includes a `VehicleSceneManager` that generates vehicle meshes from procedural geometry, assembles wheels and spoilers, and keeps them synchronised with server telemetry.

--- a/docs/visualizer_ops/README.md
+++ b/docs/visualizer_ops/README.md
@@ -52,44 +52,30 @@ section in order to ensure the three services share credentials and network bind
    Expect a JSON payload similar to `{ "status": "ok", "message": "Simulation bridge online" }` as defined in
    `python-sim/web_bridge/server.py`.
 
-## 3. Configure and run the Next.js visualizer client
-1. Install dependencies with pnpm:
+## 3. Configure and run the Vite visualizer client
+1. Install dependencies:
    ```bash
-   cd tunnelcave_sandbox_web
-   corepack enable pnpm
-   pnpm install
+   cd planet_sandbox_web
+   npm install
    ```
 2. Scaffold `.env.local` with broker endpoints:
    ```bash
    ../scripts/setup-env.sh --force
    ```
-   The generated file defines `NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws`,
-   `SIM_BRIDGE_URL=http://localhost:8000`, and
-   `NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000` so both the proxy and the browser can reach the bridge.
+   The generated file defines `VITE_BROKER_URL=ws://localhost:43127/ws` and
+   `VITE_SIM_BRIDGE_URL=http://localhost:8000` so the browser can reach both services.
 3. Launch the development server:
    ```bash
-   pnpm dev
+   npm run dev
    ```
-4. Open `http://localhost:3000` in a browser. The client bootstrap (`app/components/ClientBootstrap.tsx`) will surface an
-   inline warning if either environment variable is missing.
+4. Open `http://localhost:3000` in a browser. The bridge panel surfaces handshake status and highlights missing configuration.
 
-## 4. Optional smoke-test screenshot
-Once the UI is reachable, the Playwright script at `tunnelcave_sandbox_web/test/smoke/visual-smoke.spec.ts` can capture a
-baseline screenshot for visual regression tracking:
-```bash
-cd tunnelcave_sandbox_web
-npx playwright install --with-deps
-pnpm exec playwright test test/smoke/visual-smoke.spec.ts
-```
-Set `VISUALIZER_BASE_URL` and `VISUALIZER_SMOKE_OUTPUT` to override the navigation target or screenshot path if needed.
-
-## 5. Test expectations before merge
+## 4. Test expectations before merge
 All automated suites must be green prior to merging changes:
 - Run the Go unit suite: `cd go-broker && go test ./...`.
 - Execute the Python bridge tests: `cd python-sim && pytest`.
-- From `tunnelcave_sandbox_web`, ensure `pnpm test` passes so the networking mocks, procedural geometry, and UI interaction
+- From `planet_sandbox_web`, ensure `npm test` passes so the networking mocks, procedural geometry, and UI interaction
   Vitest suites stay healthy.
-- If the Playwright smoke test is updated, run `pnpm exec playwright test` as part of the review checklist.
 
 Document successful runs (timestamps and commit hash) in your pull request description when promoting changes to the main
 branch.

--- a/docs/visualizer_setup/README.md
+++ b/docs/visualizer_setup/README.md
@@ -1,20 +1,19 @@
 # Visualizer Sandbox Setup
 
 ## Supported global tool versions
-- **Node.js**: Use a release that satisfies Next.js 15.5.4's engine constraint (`^18.18.0 || ^19.8.0 || >= 20.0.0`). Node 20.19.4 has been verified locally and comfortably meets this requirement while also covering Vitest's `^18.0.0 || >=20.0.0` range and TypeScript 5.9.3's `>=14.17` floor. 
+- **Node.js**: Use a release compatible with the Vite toolchain (`^18.0.0 || >=20.0.0`). Node 20.19.4 has been verified locally and comfortably meets this requirement while also covering Vitest's `^18.0.0 || >=20.0.0` range and TypeScript 5.9.3's `>=14.17` floor.
 - **pnpm**: Use pnpm 10.18.x as declared in `package.json`. Corepack can pin the version via `corepack use pnpm@10.18.0` before installing dependencies.
 
 ## Verification steps
 1. **Inspect versions**
-   - Confirm the dependency ranges in `tunnelcave_sandbox_web/package.json` to ensure they align with the Node.js and pnpm targets above.
+   - Confirm the dependency ranges in `planet_sandbox_web/package.json` to ensure they align with the Node.js and pnpm targets above.
    - Validate engine constraints directly from installed packages:
-     - Next.js 15.5.4 lists `node: ^18.18.0 || ^19.8.0 || >= 20.0.0`.
      - TypeScript 5.9.3 lists `node: >=14.17`.
      - Vitest 1.6.1 lists `node: ^18.0.0 || >=20.0.0`.
 2. **Install dependencies**
-   - From `tunnelcave_sandbox_web/`, run `pnpm install`. Approve any optional build scripts only if they are required for local workflows.
+   - From `planet_sandbox_web/`, run `pnpm install`. Approve any optional build scripts only if they are required for local workflows.
 3. **Validate the baseline**
-   - Run `pnpm test` to execute the Vitest suite (`vitest run`). The current baseline passes across 18 test files / 46 tests with React act warnings that do not fail the run.
+   - Run `pnpm test` to execute the Vitest suite (`vitest run`).
 
 ## Notes
 - The repository already contains an up-to-date `pnpm-lock.yaml`. Rerunning `pnpm install` with pnpm 10.18.0 confirms the lockfile without changes, so no additional snapshot is necessary under matching tool versions.

--- a/planet_sandbox_web/Dockerfile
+++ b/planet_sandbox_web/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+#1.- Install dependencies using the npm lockfile when available.
+COPY planet_sandbox_web/package.json planet_sandbox_web/package-lock.json* ./
+RUN npm ci
+
+#2.- Copy the application source and shared client library into the build context.
+COPY planet_sandbox_web/ ./
+COPY typescript-client ./typescript-client
+
+#3.- Produce the static Vite build artefacts.
+RUN npm run build
+
+FROM nginx:1.25-alpine AS runner
+WORKDIR /usr/share/nginx/html
+
+#1.- Copy the compiled assets into the nginx document root.
+COPY --from=builder /app/dist ./
+
+#2.- Expose the default HTTP port for the static site.
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/planet_sandbox_web/package-lock.json
+++ b/planet_sandbox_web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "planet_sandbox_web",
       "version": "0.1.0",
       "dependencies": {
+        "@bufbuild/protobuf": "^2.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "three": "^0.161.0"
@@ -15,6 +16,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@types/three": "^0.156.0",
@@ -323,6 +325,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
+      "integrity": "sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1174,6 +1182,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/planet_sandbox_web/package.json
+++ b/planet_sandbox_web/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "^2.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "three": "^0.161.0"
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.1",

--- a/planet_sandbox_web/src/components/SimulationBridgePanel.tsx
+++ b/planet_sandbox_web/src/components/SimulationBridgePanel.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { resolveSimulationBridgeConfig } from '../lib/backendConfig';
+
+type CommandName = 'throttle' | 'brake';
+
+const DEFAULT_STATUS = 'Simulation bridge offline.';
+const CONFIG_HINT = 'Set VITE_SIM_BRIDGE_URL (e.g. http://localhost:8000) to enable interactive control.';
+
+const SimulationBridgePanel = () => {
+  //1.- Capture the configured bridge endpoints once so the component can reuse them across renders.
+  const bridgeConfig = useMemo(() => resolveSimulationBridgeConfig(), []);
+  const [status, setStatus] = useState(DEFAULT_STATUS);
+  const [error, setError] = useState('');
+  const [lastCommand, setLastCommand] = useState('none');
+
+  useEffect(() => {
+    //1.- Abort any pending handshake when the component unmounts or the configuration changes.
+    const controller = new AbortController();
+    let cancelled = false;
+
+    if (!bridgeConfig) {
+      setStatus(DEFAULT_STATUS);
+      setError(CONFIG_HINT);
+      return () => controller.abort();
+    }
+
+    //2.- Initiate the handshake workflow to confirm the Python bridge is reachable.
+    setStatus('Negotiating with simulation bridge…');
+    setError('');
+    fetch(bridgeConfig.handshakeUrl, { cache: 'no-store', signal: controller.signal })
+      .then(async (response) => {
+        const payload = (await response.json().catch(() => ({}))) as { message?: string };
+        if (!response.ok) {
+          const message = typeof payload.message === 'string' ? payload.message : `Handshake failed with status ${response.status}`;
+          throw new Error(message);
+        }
+        if (!cancelled) {
+          setStatus(payload.message ?? 'Simulation bridge online');
+          setError('');
+        }
+      })
+      .catch((reason: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        const message = reason instanceof Error ? reason.message : 'Unknown handshake error';
+        setStatus(DEFAULT_STATUS);
+        setError(`Handshake error: ${message}`);
+      });
+
+    return () => {
+      //3.- Cancel the outstanding fetch so React strict mode remounts do not leak requests.
+      cancelled = true;
+      controller.abort();
+    };
+  }, [bridgeConfig]);
+
+  const handleCommand = useCallback(
+    async (command: CommandName) => {
+      //1.- Prevent command dispatches when the bridge has not been configured yet.
+      if (!bridgeConfig) {
+        setError(CONFIG_HINT);
+        return;
+      }
+      try {
+        setError('');
+        const response = await fetch(bridgeConfig.commandUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command, issuedAtMs: Date.now() })
+        });
+        const payload = (await response.json().catch(() => ({}))) as { command?: { command?: string } };
+        if (!response.ok) {
+          const message = typeof payload?.command?.command === 'string' ? payload.command.command : undefined;
+          throw new Error(message ?? `Command failed with status ${response.status}`);
+        }
+        setLastCommand(payload.command?.command ?? command);
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : 'Unknown command error';
+        setError(`Command error: ${message}`);
+      }
+    },
+    [bridgeConfig]
+  );
+
+  return (
+    <section className="bridge-panel" aria-live="polite">
+      <header>
+        <h2>Simulation Bridge</h2>
+        <p>{status}</p>
+      </header>
+      <div className="bridge-status">
+        {bridgeConfig ? (
+          <span className="bridge-target">Target: {bridgeConfig.baseUrl}</span>
+        ) : (
+          <span className="bridge-hint">{CONFIG_HINT}</span>
+        )}
+        {error && <span className="bridge-error">{error}</span>}
+      </div>
+      <div className="bridge-controls">
+        <button type="button" onClick={() => void handleCommand('throttle')}>
+          Throttle
+        </button>
+        <button type="button" onClick={() => void handleCommand('brake')}>
+          Brake
+        </button>
+      </div>
+      <p className="bridge-last-command">Last command: {lastCommand}</p>
+    </section>
+  );
+};
+
+export default SimulationBridgePanel;

--- a/planet_sandbox_web/src/components/__tests__/SimulationBridgePanel.test.tsx
+++ b/planet_sandbox_web/src/components/__tests__/SimulationBridgePanel.test.tsx
@@ -1,0 +1,89 @@
+import type { FC } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+declare const global: { fetch: typeof fetch };
+
+describe('SimulationBridgePanel', () => {
+  beforeEach(() => {
+    //1.- Provide a predictable fetch spy that individual tests can override.
+    global.fetch = vi.fn();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('displays configuration guidance when the bridge URL is missing', async () => {
+    vi.doMock('../../lib/backendConfig', () => ({
+      resolveSimulationBridgeConfig: () => null
+    }));
+    const { default: Panel } = (await import('../SimulationBridgePanel')) as { default: FC };
+
+    render(<Panel />);
+
+    expect(screen.getByText(/simulation bridge offline/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/VITE_SIM_BRIDGE_URL/i).length).toBeGreaterThan(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('negotiates the handshake and sends commands to the configured bridge', async () => {
+    const handshakeResponse = Promise.resolve(
+      new Response(JSON.stringify({ message: 'Simulation bridge online' }), { status: 200 })
+    );
+    const commandResponse = Promise.resolve(
+      new Response(JSON.stringify({ command: { command: 'throttle' } }), { status: 200 })
+    );
+
+    const fetchSpy = vi.fn().mockImplementation((url: RequestInfo | URL) => {
+      if (`${url}`.endsWith('/handshake')) {
+        return handshakeResponse;
+      }
+      return commandResponse;
+    });
+    global.fetch = fetchSpy;
+
+    vi.doMock('../../lib/backendConfig', () => ({
+      resolveSimulationBridgeConfig: () => ({
+        baseUrl: 'http://localhost:8000',
+        handshakeUrl: 'http://localhost:8000/handshake',
+        commandUrl: 'http://localhost:8000/command',
+        stateUrl: 'http://localhost:8000/state'
+      })
+    }));
+    const { default: Panel } = (await import('../SimulationBridgePanel')) as { default: FC };
+
+    render(<Panel />);
+
+    await waitFor(() => expect(screen.getByText(/Simulation bridge online/i)).toBeInTheDocument());
+    expect(fetchSpy).toHaveBeenCalledWith('http://localhost:8000/handshake', expect.any(Object));
+
+    await userEvent.click(screen.getByRole('button', { name: /Throttle/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith('http://localhost:8000/command', expect.any(Object)));
+    expect(screen.getByText(/Last command: throttle/i)).toBeInTheDocument();
+  });
+
+  it('surfaces handshake failures as actionable errors', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'not configured' }), { status: 500 })
+    );
+    global.fetch = fetchSpy;
+
+    vi.doMock('../../lib/backendConfig', () => ({
+      resolveSimulationBridgeConfig: () => ({
+        baseUrl: 'http://localhost:8000',
+        handshakeUrl: 'http://localhost:8000/handshake',
+        commandUrl: 'http://localhost:8000/command',
+        stateUrl: 'http://localhost:8000/state'
+      })
+    }));
+    const { default: Panel } = (await import('../SimulationBridgePanel')) as { default: FC };
+
+    render(<Panel />);
+
+    await waitFor(() => expect(screen.getByText(/Handshake error/i)).toBeInTheDocument());
+    expect(screen.getByText(/not configured/i)).toBeInTheDocument();
+  });
+});

--- a/planet_sandbox_web/src/hooks/__tests__/useSimulationBridgeState.test.tsx
+++ b/planet_sandbox_web/src/hooks/__tests__/useSimulationBridgeState.test.tsx
@@ -1,0 +1,107 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SimulationBridgeConfig } from '../../lib/backendConfig';
+import { useSimulationBridgeState } from '../useSimulationBridgeState';
+
+describe('useSimulationBridgeState', () => {
+  const bridgeConfig: SimulationBridgeConfig = {
+    baseUrl: 'http://localhost:8000',
+    handshakeUrl: 'http://localhost:8000/handshake',
+    commandUrl: 'http://localhost:8000/command',
+    stateUrl: 'http://localhost:8000/state'
+  };
+
+  afterEach(() => {
+    //1.- Restore the environment between tests so spies do not leak into other suites.
+    vi.clearAllMocks();
+  });
+
+  it('reports a disabled status when the bridge URL is missing', () => {
+    const { result } = renderHook(() =>
+      useSimulationBridgeState({
+        dependencies: {
+          resolveConfig: () => null
+        }
+      })
+    );
+
+    expect(result.current.status).toBe('disabled');
+    expect(result.current.snapshot).toBeNull();
+    expect(result.current.error).toMatch(/VITE_SIM_BRIDGE_URL/);
+  });
+
+  it('polls the state endpoint and normalises vehicle telemetry', async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          status: 'ok',
+          tickId: 24,
+          capturedAtMs: 1_234,
+          vehicles: {
+            alpha: { x: 1.5, y: '2', z: 3, speed: '450' },
+            beta: { x: -5, y: 0.5, z: 8 }
+          }
+        }),
+        { status: 200 }
+      )
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useSimulationBridgeState({
+        pollIntervalMs: 10_000,
+        dependencies: {
+          resolveConfig: () => bridgeConfig,
+          fetch: fetchSpy,
+          now: () => 9_999
+        }
+      })
+    );
+
+    await waitFor(() => {
+      //1.- Wait for the hook to transition into the ready state before reading the snapshot.
+      expect(result.current.status).toBe('ready');
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith('http://localhost:8000/state', expect.any(Object));
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.snapshot).not.toBeNull();
+    expect(result.current.snapshot?.tickId).toBe(24);
+    expect(result.current.snapshot?.capturedAtMs).toBe(1_234);
+    expect(result.current.snapshot?.receivedAtMs).toBe(9_999);
+    expect(result.current.snapshot?.vehicles).toEqual([
+      {
+        id: 'alpha',
+        position: { x: 1.5, y: 2, z: 3 },
+        speed: 450
+      },
+      {
+        id: 'beta',
+        position: { x: -5, y: 0.5, z: 8 }
+      }
+    ]);
+
+    unmount();
+  });
+
+  it('surfaces errors returned by the bridge', async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ message: 'bridge offline' }), { status: 503 })
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useSimulationBridgeState({
+        dependencies: {
+          resolveConfig: () => bridgeConfig,
+          fetch: fetchSpy
+        }
+      })
+    );
+
+    await waitFor(() => {
+      //1.- Confirm the hook surfaced the error before asserting on the message contents.
+      expect(result.current.status).toBe('error');
+    });
+    expect(result.current.error).toMatch(/bridge offline/);
+    unmount();
+  });
+});

--- a/planet_sandbox_web/src/hooks/__tests__/useWorldEntities.test.ts
+++ b/planet_sandbox_web/src/hooks/__tests__/useWorldEntities.test.ts
@@ -1,0 +1,176 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EntityTransform, WorldSessionHandle } from '@client/networking/worldSession';
+import { useWorldEntities } from '../useWorldEntities';
+
+describe('useWorldEntities', () => {
+  afterEach(() => {
+    //1.- Ensure mocks reset between tests so each scenario starts from a clean slate.
+    vi.clearAllMocks();
+  });
+
+  it('reports an error when the broker configuration is missing', () => {
+    const { result } = renderHook(() =>
+      useWorldEntities({
+        dependencies: {
+          resolveConfig: () => null
+        }
+      })
+    );
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toContain('Broker URL not configured');
+    expect(result.current.entities.size).toBe(0);
+  });
+
+  it('connects to the broker and publishes entity snapshots', async () => {
+    const storeSubscribers = new Set<(snapshot: ReadonlyMap<string, EntityTransform>) => void>();
+    const fakeEntity: EntityTransform = {
+      entityId: 'craft-1',
+      tickId: 42,
+      capturedAtMs: 1_000,
+      keyframe: true,
+      position: { x: 1, y: 2, z: 3 },
+      orientation: { yawDeg: 0, pitchDeg: 0, rollDeg: 0 }
+    };
+
+    let resolveConnect: (() => void) | undefined;
+    const connectPromise = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+
+    const createSession = vi.fn(() => {
+      const client = new EventTarget();
+      const handle: WorldSessionHandle = {
+        client,
+        store: {
+          subscribe: (subscriber) => {
+            storeSubscribers.add(subscriber);
+            subscriber(new Map([[fakeEntity.entityId, fakeEntity]]));
+            return () => {
+              storeSubscribers.delete(subscriber);
+            };
+          }
+        },
+        connect: () => connectPromise,
+        disconnect: vi.fn(),
+        dispose: vi.fn(),
+        trackEntity: () => () => undefined
+      };
+      return handle;
+    });
+
+    const { result } = renderHook(() =>
+      useWorldEntities({
+        dependencies: {
+          resolveConfig: () => ({
+            url: 'ws://broker.test/ws',
+            subject: 'pilot',
+            token: 'token'
+          }),
+          createSession
+        }
+      })
+    );
+
+    expect(result.current.status).toBe('connecting');
+    expect(result.current.entities.size).toBe(1);
+
+    await act(async () => {
+      resolveConnect?.();
+      await connectPromise;
+    });
+
+    expect(result.current.status).toBe('connected');
+    expect(result.current.entities.get('craft-1')).toEqual(fakeEntity);
+
+    await act(async () => {
+      for (const subscriber of storeSubscribers) {
+        subscriber(new Map());
+      }
+      await Promise.resolve();
+    });
+
+    expect(result.current.entities.size).toBe(0);
+  });
+
+  it('surfaces connection failures as errors', async () => {
+    const failure = new Error('dial failed');
+    const createSession = vi.fn(() => {
+      const client = new EventTarget();
+      const handle: WorldSessionHandle = {
+        client,
+        store: {
+          subscribe: () => () => undefined
+        },
+        connect: () => Promise.reject(failure),
+        disconnect: vi.fn(),
+        dispose: vi.fn(),
+        trackEntity: () => () => undefined
+      };
+      return handle;
+    });
+
+    const { result } = renderHook(() =>
+      useWorldEntities({
+        dependencies: {
+          resolveConfig: () => ({ url: 'ws://broker/ws', subject: 'pilot' }),
+          createSession
+        }
+      })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('dial failed');
+  });
+
+  it('emits an error when the session broadcasts a disconnected status', async () => {
+    let resolveConnect: (() => void) | undefined;
+    const connectPromise = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+
+    const client = new EventTarget();
+    const createSession = vi.fn(() => {
+      const handle: WorldSessionHandle = {
+        client,
+        store: {
+          subscribe: () => () => undefined
+        },
+        connect: () => connectPromise,
+        disconnect: vi.fn(),
+        dispose: vi.fn(),
+        trackEntity: () => () => undefined
+      };
+      return handle;
+    });
+
+    const { result } = renderHook(() =>
+      useWorldEntities({
+        dependencies: {
+          resolveConfig: () => ({ url: 'ws://broker/ws', subject: 'pilot', token: 'token' }),
+          createSession
+        }
+      })
+    );
+
+    await act(async () => {
+      resolveConnect?.();
+      await connectPromise;
+    });
+
+    expect(result.current.status).toBe('connected');
+
+    await act(async () => {
+      client.dispatchEvent(new CustomEvent('status', { detail: 'disconnected' }));
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('Disconnected from broker.');
+  });
+});

--- a/planet_sandbox_web/src/hooks/useSimulationBridgeState.ts
+++ b/planet_sandbox_web/src/hooks/useSimulationBridgeState.ts
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useState } from 'react';
+import { resolveSimulationBridgeConfig, type SimulationBridgeConfig } from '../lib/backendConfig';
+
+export type SimulationBridgeStatus = 'disabled' | 'idle' | 'loading' | 'ready' | 'error';
+
+export interface BridgeVehicleSnapshot {
+  id: string;
+  position: { x: number; y: number; z: number };
+  speed?: number;
+}
+
+export interface SimulationBridgeSnapshot {
+  tickId: number;
+  capturedAtMs: number;
+  receivedAtMs: number;
+  vehicles: BridgeVehicleSnapshot[];
+}
+
+type Dependencies = {
+  resolveConfig: () => SimulationBridgeConfig | null;
+  fetch: typeof fetch;
+  now: () => number;
+};
+
+const DEFAULT_DEPENDENCIES: Dependencies = {
+  //1.- Reuse the shared configuration resolver so the hook honours `.env.local` overrides.
+  resolveConfig: resolveSimulationBridgeConfig,
+  //2.- Delegate HTTP calls to the global fetch implementation for browser compatibility.
+  fetch: (input: RequestInfo | URL, init?: RequestInit) => fetch(input, init),
+  //3.- Capture the current timestamp via `Date.now` so timestamps stay consistent across environments.
+  now: () => Date.now()
+};
+
+export interface UseSimulationBridgeStateOptions {
+  pollIntervalMs?: number;
+  dependencies?: Partial<Dependencies>;
+}
+
+export interface UseSimulationBridgeStateResult {
+  status: SimulationBridgeStatus;
+  snapshot: SimulationBridgeSnapshot | null;
+  error?: string;
+}
+
+interface BridgeStatePayload {
+  status?: string;
+  message?: string;
+  tickId?: unknown;
+  capturedAtMs?: unknown;
+  vehicles?: unknown;
+}
+
+const DEFAULT_HINT = 'Set VITE_SIM_BRIDGE_URL (e.g. http://localhost:8000) to enable interactive control.';
+const DEFAULT_POLL_INTERVAL_MS = 3_000;
+
+function normaliseVehicles(source: unknown): BridgeVehicleSnapshot[] {
+  //1.- Treat non-object payloads as empty telemetry so the UI can degrade gracefully.
+  if (!source || typeof source !== 'object') {
+    return [];
+  }
+  const vehicles: BridgeVehicleSnapshot[] = [];
+  for (const [id, raw] of Object.entries(source as Record<string, unknown>)) {
+    if (!id || !raw || typeof raw !== 'object') {
+      continue;
+    }
+    const vector = raw as Record<string, unknown>;
+    const x = Number(vector.x);
+    const y = Number(vector.y);
+    const z = Number(vector.z);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      continue;
+    }
+    const speedValue = Number((vector as Record<string, unknown>).speed);
+    vehicles.push({
+      id,
+      position: { x, y, z },
+      speed: Number.isFinite(speedValue) ? speedValue : undefined
+    });
+  }
+  vehicles.sort((a, b) => a.id.localeCompare(b.id));
+  return vehicles;
+}
+
+export function useSimulationBridgeState(
+  options?: UseSimulationBridgeStateOptions
+): UseSimulationBridgeStateResult {
+  //1.- Merge dependency overrides so tests can stub fetch and configuration behaviour.
+  const deps = useMemo(
+    () => ({ ...DEFAULT_DEPENDENCIES, ...(options?.dependencies ?? {}) }),
+    [options?.dependencies]
+  );
+  const [status, setStatus] = useState<SimulationBridgeStatus>('idle');
+  const [snapshot, setSnapshot] = useState<SimulationBridgeSnapshot | null>(null);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    //1.- Resolve the simulation bridge configuration and surface actionable guidance when absent.
+    const config = deps.resolveConfig();
+    if (!config) {
+      setStatus('disabled');
+      setSnapshot(null);
+      setError(DEFAULT_HINT);
+      return () => undefined;
+    }
+
+    let cancelled = false;
+    let controller: AbortController | null = null;
+
+    const pollState = async () => {
+      //1.- Abort the previous request to avoid overlapping polls when the interval fires quickly.
+      controller?.abort();
+      const nextController = new AbortController();
+      controller = nextController;
+      setStatus((previous) => (previous === 'ready' ? 'ready' : 'loading'));
+      setError(undefined);
+      try {
+        const response = await deps.fetch(config.stateUrl, {
+          cache: 'no-store',
+          signal: nextController.signal
+        });
+        const payload = (await response.json().catch(() => ({}))) as BridgeStatePayload;
+        if (!response.ok) {
+          const message =
+            typeof payload.message === 'string'
+              ? payload.message
+              : `State request failed with status ${response.status}`;
+          throw new Error(message);
+        }
+        if (cancelled || nextController.signal.aborted) {
+          return;
+        }
+        const receivedAtMs = deps.now();
+        const tickId = typeof payload.tickId === 'number' ? payload.tickId : 0;
+        const capturedAtMs =
+          typeof payload.capturedAtMs === 'number' ? payload.capturedAtMs : receivedAtMs;
+        const vehicles = normaliseVehicles(payload.vehicles);
+        setSnapshot({
+          tickId,
+          capturedAtMs,
+          receivedAtMs,
+          vehicles
+        });
+        setStatus('ready');
+        setError(undefined);
+      } catch (cause) {
+        if (cancelled || nextController.signal.aborted) {
+          return;
+        }
+        const message = cause instanceof Error ? cause.message : 'Unknown state error';
+        setStatus('error');
+        setError(`State error: ${message}`);
+      }
+    };
+
+    void pollState();
+    const intervalMs = Math.max(1_000, options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    const intervalId = window.setInterval(() => {
+      void pollState();
+    }, intervalMs);
+
+    return () => {
+      cancelled = true;
+      controller?.abort();
+      window.clearInterval(intervalId);
+    };
+  }, [deps, options?.pollIntervalMs]);
+
+  return useMemo(
+    () => ({
+      status,
+      snapshot,
+      error
+    }),
+    [status, snapshot, error]
+  );
+}

--- a/planet_sandbox_web/src/hooks/useWorldEntities.ts
+++ b/planet_sandbox_web/src/hooks/useWorldEntities.ts
@@ -1,0 +1,136 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createWorldSession,
+  type EntityTransform,
+  type WorldSessionHandle
+} from '@client/networking/worldSession';
+import {
+  buildFallbackToken,
+  resolveBrokerConfig,
+  type BrokerConfig
+} from '../lib/backendConfig';
+
+type WorldStatus = 'idle' | 'connecting' | 'connected' | 'error';
+
+type Dependencies = {
+  resolveConfig: () => BrokerConfig | null;
+  createSession: typeof createWorldSession;
+  buildToken: (subject: string) => string;
+};
+
+const DEFAULT_DEPENDENCIES: Dependencies = {
+  resolveConfig: resolveBrokerConfig,
+  createSession: createWorldSession,
+  buildToken: buildFallbackToken
+};
+
+export interface UseWorldEntitiesOptions {
+  dependencies?: Partial<Dependencies>;
+}
+
+export interface UseWorldEntitiesResult {
+  status: WorldStatus;
+  entities: Map<string, EntityTransform>;
+  error?: string;
+}
+
+export function useWorldEntities(options?: UseWorldEntitiesOptions): UseWorldEntitiesResult {
+  //1.- Merge optional dependency overrides so tests can inject fakes without mutating globals.
+  const deps = useMemo(() => ({ ...DEFAULT_DEPENDENCIES, ...(options?.dependencies ?? {}) }), [options?.dependencies]);
+  const [status, setStatus] = useState<WorldStatus>('idle');
+  const [error, setError] = useState<string | undefined>();
+  const [entities, setEntities] = useState<Map<string, EntityTransform>>(new Map());
+  const sessionRef = useRef<WorldSessionHandle | null>(null);
+
+  useEffect(() => {
+    //1.- Resolve the broker configuration up front to short-circuit when misconfigured.
+    const config = deps.resolveConfig();
+    if (!config) {
+      setStatus('error');
+      setError('Broker URL not configured. Set VITE_BROKER_URL to enable live telemetry.');
+      setEntities(new Map());
+      return () => undefined;
+    }
+
+    let cancelled = false;
+    const authToken = config.token && config.token.trim() !== '' ? config.token : undefined;
+    const authSecret = config.secret && config.secret.trim() !== '' ? config.secret : undefined;
+    const token = authToken ?? (authSecret ? undefined : deps.buildToken(config.subject));
+
+    //2.- Create the world session so the hook can listen for roster and transform updates.
+    const session = deps.createSession({
+      dial: {
+        url: config.url,
+        protocols: config.protocols,
+        auth: {
+          subject: config.subject,
+          token,
+          secret: authSecret,
+          audience: config.audience,
+          ttlSeconds: config.ttlSeconds
+        }
+      }
+    });
+    sessionRef.current = session;
+
+    const unsubscribe = session.store.subscribe((snapshot) => {
+      //3.- Clone the world snapshot into component state whenever the broker publishes updates.
+      if (cancelled) {
+        return;
+      }
+      setEntities(new Map(snapshot));
+    });
+
+    const statusListener = (event: Event) => {
+      //4.- Surface disconnects as actionable errors while leaving reconnect logic to the caller.
+      if (cancelled) {
+        return;
+      }
+      const detail = (event as CustomEvent<string>).detail;
+      if (detail === 'disconnected') {
+        setStatus('error');
+        setError('Disconnected from broker.');
+      }
+    };
+    session.client.addEventListener('status', statusListener as EventListener);
+
+    setStatus('connecting');
+    setError(undefined);
+
+    session
+      .connect()
+      .then(() => {
+        //5.- Confirm the live telemetry feed is active once the session resolves its first dial attempt.
+        if (cancelled) {
+          return;
+        }
+        setStatus('connected');
+      })
+      .catch((reason: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        setStatus('error');
+        const message = reason instanceof Error ? reason.message : 'Failed to connect to broker.';
+        setError(message);
+      });
+
+    return () => {
+      //6.- Dispose of the session cleanly to avoid leaking timers or WebSocket handles across re-renders.
+      cancelled = true;
+      session.client.removeEventListener('status', statusListener as EventListener);
+      unsubscribe();
+      session.dispose();
+      sessionRef.current = null;
+    };
+  }, [deps]);
+
+  return useMemo(
+    () => ({
+      status,
+      entities,
+      error
+    }),
+    [status, entities, error]
+  );
+}

--- a/planet_sandbox_web/src/lib/__tests__/backendConfig.test.ts
+++ b/planet_sandbox_web/src/lib/__tests__/backendConfig.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildFallbackToken,
+  resolveBrokerConfig,
+  resolveSimulationBridgeConfig
+} from '../backendConfig';
+
+declare const process: { env: Record<string, string | undefined> };
+
+const originalEnv = { ...process.env };
+
+describe('backendConfig', () => {
+  beforeEach(() => {
+    //1.- Reset the environment map before each assertion to avoid cross-test pollution.
+    process.env = {};
+  });
+
+  afterEach(() => {
+    //1.- Restore the captured environment so other suites observe their preferred configuration.
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null when the broker URL is missing', () => {
+    //1.- Without an explicit broker endpoint the hook should decline to connect.
+    expect(resolveBrokerConfig()).toBeNull();
+  });
+
+  it('captures broker configuration from Vite-prefixed environment variables', () => {
+    //1.- Seed the environment with Vite-compatible keys so the resolver can harvest them.
+    process.env.VITE_BROKER_URL = ' ws://localhost:43127/ws ';
+    process.env.VITE_BROKER_SUBJECT = ' Pilot 01 ';
+    process.env.VITE_BROKER_PROTOCOLS = ' proto1 , proto2 ';
+    process.env.VITE_BROKER_TTL_SECONDS = '120';
+    process.env.VITE_BROKER_AUDIENCE = 'driftpursuit';
+    process.env.VITE_BROKER_TOKEN = ' token-value ';
+
+    const result = resolveBrokerConfig();
+    expect(result).not.toBeNull();
+    expect(result?.url).toBe('ws://localhost:43127/ws');
+    expect(result?.subject).toBe('pilot-01');
+    expect(result?.protocols).toEqual(['proto1', 'proto2']);
+    expect(result?.ttlSeconds).toBe(120);
+    expect(result?.audience).toBe('driftpursuit');
+    expect(result?.token).toBe('token-value');
+  });
+
+  it('derives a fallback token using the sandbox prefix', () => {
+    //1.- Construct a deterministic credential for local development scenarios.
+    expect(buildFallbackToken('pilot-03')).toBe('sandbox-pilot-03');
+  });
+
+  it('produces simulation bridge URLs when configured', () => {
+    //1.- Provide the bridge origin so the resolver can expand the endpoint paths.
+    process.env.VITE_SIM_BRIDGE_URL = 'http://localhost:8000/';
+    const config = resolveSimulationBridgeConfig();
+    expect(config).not.toBeNull();
+    expect(config?.baseUrl).toBe('http://localhost:8000');
+    expect(config?.handshakeUrl).toBe('http://localhost:8000/handshake');
+    expect(config?.commandUrl).toBe('http://localhost:8000/command');
+    expect(config?.stateUrl).toBe('http://localhost:8000/state');
+  });
+});

--- a/planet_sandbox_web/src/lib/backendConfig.ts
+++ b/planet_sandbox_web/src/lib/backendConfig.ts
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare const process: undefined | { env?: Record<string, string | undefined> };
+
+export interface BrokerConfig {
+  url: string;
+  subject: string;
+  token?: string;
+  secret?: string;
+  audience?: string;
+  ttlSeconds?: number;
+  protocols?: string | string[];
+}
+
+export interface SimulationBridgeConfig {
+  baseUrl: string;
+  handshakeUrl: string;
+  commandUrl: string;
+  stateUrl: string;
+}
+
+const DEFAULT_SUBJECT = 'planet-sandbox';
+
+function getMetaEnv(): Record<string, string | undefined> {
+  //1.- Reach into the Vite-provided environment map while guarding against undefined during tests.
+  const meta = (typeof import.meta !== 'undefined' ? (import.meta as any).env : undefined) as
+    | Record<string, string | undefined>
+    | undefined;
+  return meta ?? {};
+}
+
+function getProcessEnv(): Record<string, string | undefined> {
+  //1.- Capture Node-style environment variables so Vitest and scripts can override configuration.
+  if (typeof process !== 'undefined' && process?.env) {
+    return process.env;
+  }
+  return {};
+}
+
+function normalise(value: string | undefined): string {
+  //1.- Trim whitespace and collapse empty strings to a single reusable sentinel value.
+  const trimmed = value?.trim() ?? '';
+  return trimmed;
+}
+
+function readEnvValue(...names: string[]): string {
+  //1.- Resolve the first matching environment entry across Vite, Node, and compatibility prefixes.
+  const metaEnv = getMetaEnv();
+  const procEnv = getProcessEnv();
+  for (const name of names) {
+    const direct = normalise(metaEnv[name]);
+    if (direct) {
+      return direct;
+    }
+    if (!name.startsWith('VITE_')) {
+      const viteAlias = normalise(metaEnv[`VITE_${name}`]);
+      if (viteAlias) {
+        return viteAlias;
+      }
+    }
+    if (name.startsWith('NEXT_PUBLIC_')) {
+      const suffix = name.replace(/^NEXT_PUBLIC_/, '');
+      const vitePublic = normalise(metaEnv[`VITE_${suffix}`]);
+      if (vitePublic) {
+        return vitePublic;
+      }
+    }
+    const proc = normalise(procEnv[name]);
+    if (proc) {
+      return proc;
+    }
+  }
+  return '';
+}
+
+function normaliseSubject(candidate: string | undefined): string {
+  //1.- Canonicalise the pilot subject so broker topics remain URL friendly.
+  const trimmed = normalise(candidate);
+  if (!trimmed) {
+    return DEFAULT_SUBJECT;
+  }
+  const slug = trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || DEFAULT_SUBJECT;
+}
+
+export function resolveBrokerConfig(): BrokerConfig | null {
+  //1.- Collect the broker connection URL, returning null when it is missing.
+  const url = normalise(readEnvValue('VITE_BROKER_URL', 'NEXT_PUBLIC_BROKER_URL', 'BROKER_URL'));
+  if (!url) {
+    return null;
+  }
+  //2.- Gather optional authentication material to hand off to the WebSocket dialer.
+  const token = normalise(readEnvValue('VITE_BROKER_TOKEN', 'NEXT_PUBLIC_BROKER_TOKEN'));
+  const secret = normalise(readEnvValue('VITE_BROKER_SECRET', 'NEXT_PUBLIC_BROKER_SECRET'));
+  const audience = normalise(readEnvValue('VITE_BROKER_AUDIENCE', 'NEXT_PUBLIC_BROKER_AUDIENCE'));
+  const ttlRaw = normalise(readEnvValue('VITE_BROKER_TTL_SECONDS', 'NEXT_PUBLIC_BROKER_TTL_SECONDS'));
+  const ttlSeconds = ttlRaw ? Number.parseInt(ttlRaw, 10) : undefined;
+  const protocolsRaw = normalise(readEnvValue('VITE_BROKER_PROTOCOLS', 'NEXT_PUBLIC_BROKER_PROTOCOLS'));
+  const protocolsList = protocolsRaw
+    ? protocolsRaw
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    : [];
+  const protocols: string | string[] | undefined =
+    protocolsList.length === 0 ? undefined : protocolsList.length === 1 ? protocolsList[0] : protocolsList;
+  return {
+    url,
+    subject: normaliseSubject(readEnvValue('VITE_BROKER_SUBJECT', 'NEXT_PUBLIC_BROKER_SUBJECT')),
+    token: token || undefined,
+    secret: secret || undefined,
+    audience: audience || undefined,
+    ttlSeconds: Number.isFinite(ttlSeconds ?? NaN) ? ttlSeconds : undefined,
+    protocols
+  };
+}
+
+export function resolveSimulationBridgeConfig(): SimulationBridgeConfig | null {
+  //1.- Prefer the explicitly configured browser-facing base URL and fall back to server hints.
+  const baseCandidate = normalise(readEnvValue('VITE_SIM_BRIDGE_URL', 'NEXT_PUBLIC_SIM_BRIDGE_URL', 'SIM_BRIDGE_URL'));
+  if (!baseCandidate) {
+    return null;
+  }
+  const baseUrl = baseCandidate.replace(/\/$/, '');
+  return {
+    baseUrl,
+    handshakeUrl: `${baseUrl}/handshake`,
+    commandUrl: `${baseUrl}/command`,
+    stateUrl: `${baseUrl}/state`
+  };
+}
+
+export function buildFallbackToken(subject: string): string {
+  //1.- Create a deterministic developer token so local setups authenticate without extra configuration.
+  return `sandbox-${subject}`;
+}

--- a/planet_sandbox_web/src/networking/WebSocketClient.ts
+++ b/planet_sandbox_web/src/networking/WebSocketClient.ts
@@ -1,0 +1,576 @@
+import { BinaryReader } from "@bufbuild/protobuf/wire";
+import type { Orientation, Vector3 } from "@client/generated/types";
+import { openAuthenticatedSocket, type SocketDialOptions } from "./authenticatedSocket";
+import { SnapshotInterpolator, type InterpolatedState, type SnapshotSample } from "./interpolator";
+import { TimeSyncController } from "./timeSync";
+
+type Logger = {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+const DEFAULT_LOGGER: Logger = {
+  //1.- Route debug output through console.debug so the browser devtools grouping is preserved.
+  debug: (...args: unknown[]) => console.debug(...args),
+  //2.- Emit informational updates such as connection lifecycle changes to the console.
+  info: (...args: unknown[]) => console.info(...args),
+  //3.- Warnings highlight correction events that exceeded reconciliation thresholds.
+  warn: (...args: unknown[]) => console.warn(...args),
+  //4.- Errors funnel into console.error to surface unexpected transport failures.
+  error: (...args: unknown[]) => console.error(...args),
+};
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+export interface WebSocketClientOptions {
+  dial: SocketDialOptions;
+  reconciliationDelayMs?: number;
+  maxBufferedSnapshots?: number;
+  logger?: Partial<Logger>;
+  openSocket?: (options: SocketDialOptions) => Promise<WebSocket>;
+  now?: () => number;
+}
+
+export interface CorrectionEventDetail {
+  entityId: string;
+  positionError: number;
+  orientationError: number;
+  tickId: number;
+}
+
+interface DecodedEntitySnapshot {
+  entityId: string;
+  tickId: number;
+  capturedAtMs: number;
+  keyframe: boolean;
+  position?: Vector3;
+  orientation?: Orientation;
+  active?: boolean;
+}
+
+interface DecodedWorldSnapshot {
+  tickId: number;
+  capturedAtMs: number;
+  keyframe: boolean;
+  entities: DecodedEntitySnapshot[];
+}
+
+interface PendingSnapshot {
+  snapshot: DecodedWorldSnapshot;
+  receivedAtMs: number;
+}
+
+interface ForcedCorrection {
+  state: InterpolatedState;
+  expiresAtMs: number;
+}
+
+export interface EntitiesEventDetail {
+  added: string[];
+  removed: string[];
+}
+
+const POSITION_CORRECTION_THRESHOLD_METERS = 2;
+const ORIENTATION_CORRECTION_THRESHOLD_DEGREES = 15;
+const DEFAULT_RECONCILIATION_DELAY_MS = 150;
+const DEFAULT_MAX_BUFFERED_SNAPSHOTS = 32;
+
+function mergeLogger(overrides?: Partial<Logger>): Logger {
+  //1.- Merge the optional overrides with the default console logger so callers can inject spies in tests.
+  return {
+    debug: overrides?.debug ?? DEFAULT_LOGGER.debug,
+    info: overrides?.info ?? DEFAULT_LOGGER.info,
+    warn: overrides?.warn ?? DEFAULT_LOGGER.warn,
+    error: overrides?.error ?? DEFAULT_LOGGER.error,
+  };
+}
+
+function longToNumber(value: { toString(): string }): number {
+  //1.- Convert 64-bit integers produced by the protobuf reader into JavaScript numbers safely.
+  return Number(value.toString());
+}
+
+function decodeVector3(reader: BinaryReader, length: number): Vector3 {
+  //1.- Traverse the packed Vector3 message and map numeric components into the return structure.
+  const end = reader.pos + length;
+  const vector: Vector3 = { x: 0, y: 0, z: 0 };
+  while (reader.pos < end) {
+    const tag = reader.uint32();
+    switch (tag >>> 3) {
+      case 1:
+        vector.x = reader.double();
+        continue;
+      case 2:
+        vector.y = reader.double();
+        continue;
+      case 3:
+        vector.z = reader.double();
+        continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) {
+      break;
+    }
+    reader.skip(tag & 7);
+  }
+  return vector;
+}
+
+function decodeOrientation(reader: BinaryReader, length: number): Orientation {
+  //1.- Decode the Orientation protobuf payload emitted by the broker snapshots.
+  const end = reader.pos + length;
+  const orientation: Orientation = { yawDeg: 0, pitchDeg: 0, rollDeg: 0 };
+  while (reader.pos < end) {
+    const tag = reader.uint32();
+    switch (tag >>> 3) {
+      case 1:
+        orientation.yawDeg = reader.double();
+        continue;
+      case 2:
+        orientation.pitchDeg = reader.double();
+        continue;
+      case 3:
+        orientation.rollDeg = reader.double();
+        continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) {
+      break;
+    }
+    reader.skip(tag & 7);
+  }
+  return orientation;
+}
+
+function decodeEntitySnapshot(reader: BinaryReader, length: number): DecodedEntitySnapshot {
+  //1.- Walk the embedded EntitySnapshot message extracting the minimal state used by the renderer.
+  const end = reader.pos + length;
+  const entity: DecodedEntitySnapshot = {
+    entityId: "",
+    tickId: 0,
+    capturedAtMs: 0,
+    keyframe: false,
+  };
+  while (reader.pos < end) {
+    const tag = reader.uint32();
+    switch (tag >>> 3) {
+      case 2:
+        entity.entityId = reader.string();
+        continue;
+      case 4:
+        entity.position = decodeVector3(reader, reader.uint32());
+        continue;
+      case 6:
+        entity.orientation = decodeOrientation(reader, reader.uint32());
+        continue;
+      case 8:
+        entity.active = reader.bool();
+        continue;
+      case 10:
+        entity.capturedAtMs = longToNumber(reader.int64());
+        continue;
+      case 11:
+        entity.tickId = longToNumber(reader.uint64());
+        continue;
+      case 12:
+        entity.keyframe = reader.bool();
+        continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) {
+      break;
+    }
+    reader.skip(tag & 7);
+  }
+  return entity;
+}
+
+export function decodeWorldSnapshot(payload: ArrayBuffer | Uint8Array): DecodedWorldSnapshot {
+  //1.- Normalise the input buffer into a Uint8Array so the protobuf reader can traverse it.
+  const buffer = payload instanceof Uint8Array ? payload : new Uint8Array(payload);
+  const reader = new BinaryReader(buffer);
+  const snapshot: DecodedWorldSnapshot = {
+    tickId: 0,
+    capturedAtMs: 0,
+    keyframe: false,
+    entities: [],
+  };
+  while (reader.pos < reader.len) {
+    const tag = reader.uint32();
+    switch (tag >>> 3) {
+      case 2:
+        snapshot.capturedAtMs = longToNumber(reader.int64());
+        continue;
+      case 3:
+        snapshot.entities.push(decodeEntitySnapshot(reader, reader.uint32()));
+        continue;
+      case 6:
+        snapshot.tickId = longToNumber(reader.uint64());
+        continue;
+      case 7:
+        snapshot.keyframe = reader.bool();
+        continue;
+    }
+    if ((tag & 7) === 4 || tag === 0) {
+      break;
+    }
+    reader.skip(tag & 7);
+  }
+  return snapshot;
+}
+
+function vectorDistance(a?: Vector3, b?: Vector3): number {
+  //1.- Compute Euclidean distance in metres between two positions using defensive defaults.
+  const dx = (a?.x ?? 0) - (b?.x ?? 0);
+  const dy = (a?.y ?? 0) - (b?.y ?? 0);
+  const dz = (a?.z ?? 0) - (b?.z ?? 0);
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function orientationDeltaDegrees(a?: Orientation, b?: Orientation): number {
+  //1.- Measure the maximum angular delta across yaw/pitch/roll axes to evaluate correction thresholds.
+  const yaw = Math.abs((a?.yawDeg ?? 0) - (b?.yawDeg ?? 0));
+  const pitch = Math.abs((a?.pitchDeg ?? 0) - (b?.pitchDeg ?? 0));
+  const roll = Math.abs((a?.rollDeg ?? 0) - (b?.rollDeg ?? 0));
+  return Math.max(yaw, Math.max(pitch, roll));
+}
+
+function normaliseWorldSnapshotJson(raw: unknown): DecodedWorldSnapshot | undefined {
+  //1.- Validate that the JSON payload resembles the broker snapshot envelope before coercing values.
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const payload = raw as Record<string, unknown>;
+  if (!Array.isArray(payload.entities)) {
+    return undefined;
+  }
+  const snapshot: DecodedWorldSnapshot = {
+    tickId: Number(payload.tickId ?? 0),
+    capturedAtMs: Number(payload.capturedAtMs ?? 0),
+    keyframe: Boolean(payload.keyframe),
+    entities: [],
+  };
+  for (const candidate of payload.entities as unknown[]) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const entityPayload = candidate as Record<string, unknown>;
+    const entity: DecodedEntitySnapshot = {
+      entityId: String(entityPayload.entityId ?? ""),
+      tickId: Number(entityPayload.tickId ?? 0),
+      capturedAtMs: Number(entityPayload.capturedAtMs ?? snapshot.capturedAtMs ?? 0),
+      keyframe: Boolean(entityPayload.keyframe ?? snapshot.keyframe),
+      position: entityPayload.position as Vector3 | undefined,
+      orientation: entityPayload.orientation as Orientation | undefined,
+      active: entityPayload.active === undefined ? undefined : Boolean(entityPayload.active),
+    };
+    if (entity.entityId !== "") {
+      snapshot.entities.push(entity);
+    }
+  }
+  return snapshot;
+}
+
+export class WebSocketClient extends EventTarget {
+  private readonly options: Required<WebSocketClientOptions>;
+  private socket?: WebSocket;
+  private status: ConnectionStatus = "disconnected";
+  private readonly logger: Logger;
+  private readonly interpolator = new SnapshotInterpolator();
+  private readonly timeSync = new TimeSyncController();
+  private readonly pendingSnapshots: PendingSnapshot[] = [];
+  private readonly latestStates = new Map<string, InterpolatedState>();
+  private readonly forcedCorrections = new Map<string, ForcedCorrection>();
+  private readonly knownEntities = new Set<string>();
+
+  constructor(options: WebSocketClientOptions) {
+    super();
+    //1.- Fold defaults into the provided configuration to keep the constructor lightweight for callers.
+    const nowFn = options.now ?? (() => Date.now());
+    this.options = {
+      reconciliationDelayMs: options.reconciliationDelayMs ?? DEFAULT_RECONCILIATION_DELAY_MS,
+      maxBufferedSnapshots: options.maxBufferedSnapshots ?? DEFAULT_MAX_BUFFERED_SNAPSHOTS,
+      logger: options.logger ?? {},
+      openSocket: options.openSocket ?? openAuthenticatedSocket,
+      now: nowFn,
+      dial: options.dial,
+    };
+    this.logger = mergeLogger(options.logger);
+  }
+
+  async connect(): Promise<void> {
+    //1.- Skip redundant connection attempts while an existing session is active or in-flight.
+    if (this.status !== "disconnected") {
+      return;
+    }
+    this.setStatus("connecting");
+    try {
+      const socket = await this.options.openSocket(this.options.dial);
+      socket.binaryType = "arraybuffer";
+      this.attachSocket(socket);
+    } catch (error) {
+      this.logger.error("websocket connect failed", error);
+      this.setStatus("disconnected");
+      throw error;
+    }
+  }
+
+  disconnect(code?: number, reason?: string): void {
+    //1.- Close the active socket (if any) and reset buffering state to prepare for future reconnects.
+    if (this.socket && this.status !== "disconnected") {
+      try {
+        this.socket.close(code, reason);
+      } catch (error) {
+        this.logger.warn("websocket close raised", error);
+      }
+    }
+    this.socket = undefined;
+    this.pendingSnapshots.length = 0;
+    this.latestStates.clear();
+    this.forcedCorrections.clear();
+    this.knownEntities.clear();
+    this.setStatus("disconnected");
+  }
+
+  getConnectionStatus(): ConnectionStatus {
+    //1.- Expose the latest connection lifecycle state for UI overlays.
+    return this.status;
+  }
+
+  getEntityState(entityId: string, nowMs = this.authoritativeNow()): InterpolatedState | undefined {
+    //1.- Advance the snapshot buffer using the current authoritative clock before sampling the interpolator.
+    this.drainSnapshotBuffer(nowMs);
+    const correction = this.forcedCorrections.get(entityId);
+    if (correction) {
+      if (nowMs <= correction.expiresAtMs) {
+        this.latestStates.set(entityId, correction.state);
+        return correction.state;
+      }
+      this.forcedCorrections.delete(entityId);
+    }
+    const state = this.interpolator.sample(entityId, nowMs);
+    if (state) {
+      this.latestStates.set(entityId, state);
+    }
+    return state;
+  }
+
+  getPlaybackBufferMs(): number {
+    //1.- Surface the adaptive interpolation delay to aid in HUD debugging widgets.
+    return this.interpolator.getBufferMs();
+  }
+
+  getKnownEntityIds(): readonly string[] {
+    //1.- Return a snapshot of identifiers observed in recent snapshots for auto-tracking helpers.
+    return Array.from(this.knownEntities);
+  }
+
+  hasKnownEntity(entityId: string): boolean {
+    //1.- Expose membership checks so higher layers can drop stale trackers predictably.
+    return this.knownEntities.has(entityId);
+  }
+
+  private attachSocket(socket: WebSocket): void {
+    //1.- Register lifecycle handlers so connection state transitions trigger logs and UI events.
+    this.socket = socket;
+    socket.onopen = () => {
+      this.logger.info("websocket connected");
+      this.setStatus("connected");
+    };
+    socket.onclose = (event) => {
+      this.logger.info("websocket closed", event);
+      this.setStatus("disconnected");
+    };
+    socket.onerror = (event) => {
+      this.logger.error("websocket error", event);
+    };
+    socket.onmessage = (event) => {
+      this.handleIncomingMessage(event.data);
+    };
+  }
+
+  private setStatus(status: ConnectionStatus): void {
+    //1.- Update the cached status, broadcast to listeners, and emit console diagnostics.
+    if (this.status === status) {
+      return;
+    }
+    this.status = status;
+    this.dispatchEvent(new CustomEvent<ConnectionStatus>("status", { detail: status }));
+  }
+
+  private authoritativeNow(): number {
+    //1.- Project the server timeline using the synchronised clock helper and injected time source.
+    return this.timeSync.now(this.options.now());
+  }
+
+  private drainSnapshotBuffer(nowMs = this.authoritativeNow()): void {
+    //1.- Pop buffered snapshots whose capture time falls behind the reconciliation horizon.
+    const releaseBefore = nowMs - this.options.reconciliationDelayMs;
+    let drained = false;
+    while (this.pendingSnapshots.length > 0) {
+      const next = this.pendingSnapshots[0];
+      if (next.snapshot.capturedAtMs > releaseBefore) {
+        break;
+      }
+      this.pendingSnapshots.shift();
+      this.ingestSnapshot(next.snapshot, next.receivedAtMs);
+      drained = true;
+    }
+    if (drained) {
+      this.logger.debug("snapshot buffer drained", {
+        buffered: this.pendingSnapshots.length,
+        releaseBefore,
+      });
+    }
+  }
+
+  private ingestSnapshot(snapshot: DecodedWorldSnapshot, receivedAtMs: number): void {
+    //1.- Enqueue each entity sample into the interpolator so downstream systems can blend states.
+    const added: string[] = [];
+    const removed: string[] = [];
+    for (const entity of snapshot.entities) {
+      if (!entity.entityId) {
+        continue;
+      }
+      if (entity.active === false) {
+        //2.- Remove inactive entities from caches so downstream stores can drop them immediately.
+        if (this.knownEntities.delete(entity.entityId)) {
+          removed.push(entity.entityId);
+        }
+        this.latestStates.delete(entity.entityId);
+        this.forcedCorrections.delete(entity.entityId);
+        this.interpolator.forget(entity.entityId);
+        continue;
+      }
+      if (!this.knownEntities.has(entity.entityId)) {
+        //3.- Track newly discovered entities for automatic world session enrolment.
+        this.knownEntities.add(entity.entityId);
+        added.push(entity.entityId);
+      }
+      const sample: SnapshotSample = {
+        tickId: entity.tickId || snapshot.tickId,
+        keyframe: entity.keyframe || snapshot.keyframe,
+        capturedAtMs: entity.capturedAtMs || snapshot.capturedAtMs,
+        position: entity.position ?? { x: 0, y: 0, z: 0 },
+        orientation: entity.orientation ?? { yawDeg: 0, pitchDeg: 0, rollDeg: 0 },
+      };
+      this.interpolator.enqueue(entity.entityId, sample, receivedAtMs);
+      if (sample.keyframe) {
+        this.evaluateCorrection(entity.entityId, sample, receivedAtMs);
+      }
+    }
+    if (added.length > 0 || removed.length > 0) {
+      //4.- Broadcast entity roster changes so session managers can refresh subscriptions instantly.
+      this.dispatchEvent(new CustomEvent<EntitiesEventDetail>("entities", { detail: { added, removed } }));
+    }
+  }
+
+  private evaluateCorrection(entityId: string, sample: SnapshotSample, receivedAtMs: number): void {
+    //1.- Compare the authoritative keyframe with the latest predicted state to decide if a correction is required.
+    const predicted = this.latestStates.get(entityId);
+    if (!predicted) {
+      return;
+    }
+    const positionError = vectorDistance(sample.position, predicted.position);
+    const orientationError = orientationDeltaDegrees(sample.orientation, predicted.orientation);
+    if (
+      positionError <= POSITION_CORRECTION_THRESHOLD_METERS &&
+      orientationError <= ORIENTATION_CORRECTION_THRESHOLD_DEGREES
+    ) {
+      return;
+    }
+    const enforced: InterpolatedState = {
+      tickId: sample.tickId,
+      keyframe: true,
+      capturedAtMs: sample.capturedAtMs,
+      position: sample.position,
+      orientation: sample.orientation,
+    };
+    this.forcedCorrections.set(entityId, {
+      state: enforced,
+      expiresAtMs: sample.capturedAtMs + this.options.reconciliationDelayMs,
+    });
+    this.logger.warn("applying snapshot correction", {
+      entityId,
+      positionError,
+      orientationError,
+      tickId: sample.tickId,
+    });
+    this.dispatchEvent(
+      new CustomEvent<CorrectionEventDetail>("correction", {
+        detail: { entityId, positionError, orientationError, tickId: sample.tickId },
+      }),
+    );
+  }
+
+  private handleIncomingMessage(data: unknown): void {
+    //1.- Branch based on payload type to support both JSON (text frames) and binary snapshots.
+    if (typeof data === "string") {
+      this.handleJsonMessage(data);
+      return;
+    }
+    if (data instanceof ArrayBuffer) {
+      this.handleBinarySnapshot(data);
+      return;
+    }
+    if (ArrayBuffer.isView(data)) {
+      const view = data as ArrayBufferView;
+      const copy = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+      this.handleBinarySnapshot(copy);
+      return;
+    }
+    if (typeof Blob !== "undefined" && data instanceof Blob) {
+      data.arrayBuffer().then((buffer) => this.handleBinarySnapshot(buffer)).catch((error) => {
+        this.logger.error("failed to read snapshot blob", error);
+      });
+      return;
+    }
+    this.logger.debug("unknown websocket payload", data);
+  }
+
+  private handleJsonMessage(raw: string): void {
+    //1.- Parse the JSON envelope and route time-sync or snapshot messages accordingly.
+    try {
+      const payload = JSON.parse(raw);
+      if (payload?.type === "time_sync") {
+        this.timeSync.handleMessage(payload, this.options.now());
+        return;
+      }
+      if (payload?.type === "world_snapshot") {
+        const snapshot = normaliseWorldSnapshotJson(payload);
+        if (snapshot) {
+          this.queueSnapshot(snapshot);
+        }
+        return;
+      }
+      this.logger.debug("unhandled websocket message", payload);
+    } catch (error) {
+      this.logger.debug("invalid json payload", error);
+    }
+  }
+
+  private handleBinarySnapshot(buffer: ArrayBuffer | Uint8Array): void {
+    //1.- Decode protobuf world snapshots and enqueue them for buffered processing.
+    try {
+      const snapshot = decodeWorldSnapshot(buffer);
+      this.queueSnapshot(snapshot);
+    } catch (error) {
+      this.logger.error("failed to decode binary snapshot", error);
+    }
+  }
+
+  private queueSnapshot(snapshot: DecodedWorldSnapshot): void {
+    //1.- Maintain a bounded buffer sorted by capture time to avoid memory growth during packet loss.
+    const entry: PendingSnapshot = {
+      snapshot,
+      receivedAtMs: this.options.now(),
+    };
+    this.pendingSnapshots.push(entry);
+    this.pendingSnapshots.sort((a, b) => a.snapshot.capturedAtMs - b.snapshot.capturedAtMs);
+    if (this.pendingSnapshots.length > this.options.maxBufferedSnapshots) {
+      this.pendingSnapshots.shift();
+      this.logger.warn("dropped oldest snapshot due to buffer limit");
+    }
+    this.drainSnapshotBuffer();
+  }
+}
+

--- a/planet_sandbox_web/src/networking/authenticatedSocket.ts
+++ b/planet_sandbox_web/src/networking/authenticatedSocket.ts
@@ -1,0 +1,39 @@
+import { appendTokenToURL, buildHMACToken } from "@client/authToken";
+
+export type SocketAuthConfig = {
+  subject: string;
+  token?: string;
+  secret?: string;
+  audience?: string;
+  ttlSeconds?: number;
+};
+
+export type SocketDialOptions = {
+  url: string;
+  protocols?: string | string[];
+  auth: SocketAuthConfig;
+};
+
+//1.- Materialise a token using the supplied secret or reuse a pre-issued credential.
+async function resolveToken(config: SocketAuthConfig): Promise<string> {
+  if (config.token && config.token.trim() !== "") {
+    return config.token;
+  }
+  if (!config.secret) {
+    throw new Error("either token or secret must be provided for WebSocket authentication");
+  }
+  const ttlSeconds = config.ttlSeconds ?? 60;
+  const expiresAtMs = Date.now() + ttlSeconds * 1_000;
+  return buildHMACToken(config.secret, {
+    subject: config.subject,
+    expiresAtMs,
+    audience: config.audience,
+  });
+}
+
+//2.- Inject the bearer token into the connection URL and establish the WebSocket.
+export async function openAuthenticatedSocket(options: SocketDialOptions): Promise<WebSocket> {
+  const token = await resolveToken(options.auth);
+  const urlWithToken = appendTokenToURL(options.url, token);
+  return new WebSocket(urlWithToken, options.protocols);
+}

--- a/planet_sandbox_web/src/networking/interpolator.ts
+++ b/planet_sandbox_web/src/networking/interpolator.ts
@@ -1,0 +1,6 @@
+//1.- Re-export the networking interpolator from the shared client package so Vite resolves a single source of truth.
+export {
+  SnapshotInterpolator,
+  type InterpolatedState,
+  type SnapshotSample
+} from '@client/networking/interpolator';

--- a/planet_sandbox_web/src/networking/timeSync.ts
+++ b/planet_sandbox_web/src/networking/timeSync.ts
@@ -1,0 +1,2 @@
+//1.- Delegate to the shared time sync controller so the sandbox mirrors production interpolation timing.
+export { TimeSyncController } from '@client/networking/timeSync';

--- a/planet_sandbox_web/src/style.css
+++ b/planet_sandbox_web/src/style.css
@@ -128,3 +128,118 @@ canvas {
 .vehicle-status ul {
   grid-template-columns: 1fr;
 }
+
+.world-status {
+  /*1.- Highlight the broker connection metrics inside the info panel.*/
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(22, 42, 78, 0.55);
+  border: 1px solid rgba(90, 160, 255, 0.2);
+  font-size: 0.95rem;
+}
+
+.world-status strong {
+  font-size: 1rem;
+}
+
+.world-status span {
+  display: block;
+}
+
+.world-error {
+  color: #ff8686;
+  font-size: 0.85rem;
+}
+
+.bridge-state {
+  /*1.- Present simulation bridge telemetry alongside broker metrics.*/
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(12, 36, 68, 0.55);
+  border: 1px solid rgba(120, 210, 255, 0.2);
+  font-size: 0.95rem;
+}
+
+.bridge-state span {
+  display: block;
+}
+
+.bridge-panel {
+  /*1.- Stack handshake diagnostics and controls with consistent spacing.*/
+  margin-top: 0.75rem;
+  padding: 0.75rem 0.75rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(94, 191, 255, 0.25);
+  background: rgba(10, 29, 52, 0.7);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.bridge-panel header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.bridge-panel header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: #c2daff;
+}
+
+.bridge-status {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.bridge-target {
+  font-size: 0.85rem;
+  color: #9fc7ff;
+}
+
+.bridge-hint {
+  font-size: 0.85rem;
+  color: #ffd7a0;
+}
+
+.bridge-error {
+  color: #ff8686;
+  font-size: 0.85rem;
+}
+
+.bridge-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.bridge-controls button {
+  flex: 1;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(121, 201, 255, 0.35);
+  background: linear-gradient(135deg, rgba(40, 115, 210, 0.9), rgba(18, 70, 160, 0.9));
+  color: #f8fbff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.bridge-controls button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(16, 60, 140, 0.45);
+}
+
+.bridge-controls button:active {
+  transform: translateY(0);
+}
+
+.bridge-last-command {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #cddcff;
+}

--- a/planet_sandbox_web/test/mocks/three.ts
+++ b/planet_sandbox_web/test/mocks/three.ts
@@ -1,0 +1,605 @@
+export class Color {
+  //1.- Minimal color container mirrors the three.js constructor signature.
+  constructor(public value: number | string = 0xffffff) {}
+
+  set(value: number | string): this {
+    this.value = value
+    return this
+  }
+}
+
+export class Vector3 {
+  //1.- Track the vector components to support translation interpolation.
+  x: number
+  y: number
+  z: number
+
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x
+    this.y = y
+    this.z = z
+  }
+
+  set(x: number, y: number, z: number): this {
+    this.x = x
+    this.y = y
+    this.z = z
+    return this
+  }
+
+  clone(): Vector3 {
+    return new Vector3(this.x, this.y, this.z)
+  }
+
+  add(vector: Vector3): this {
+    this.x += vector.x
+    this.y += vector.y
+    this.z += vector.z
+    return this
+  }
+
+  copy(other: Vector3): this {
+    return this.set(other.x, other.y, other.z)
+  }
+
+  lerp(target: Vector3, alpha: number): this {
+    this.x += (target.x - this.x) * alpha
+    this.y += (target.y - this.y) * alpha
+    this.z += (target.z - this.z) * alpha
+    return this
+  }
+
+  lengthSq(): number {
+    //1.- Provide squared length calculations so terrain sampling logic can detect zero vectors.
+    return this.x * this.x + this.y * this.y + this.z * this.z
+  }
+
+  normalize(): this {
+    //2.- Normalise the vector while guarding against division by zero for deterministic slopes.
+    const length = Math.sqrt(this.lengthSq()) || 1
+    this.x /= length
+    this.y /= length
+    this.z /= length
+    return this
+  }
+}
+
+export class Euler {
+  //1.- Represent pitch/yaw/roll with an order string for quaternion conversion.
+  x: number
+  y: number
+  z: number
+  order: string
+
+  constructor(x = 0, y = 0, z = 0, order = 'XYZ') {
+    this.x = x
+    this.y = y
+    this.z = z
+    this.order = order
+  }
+
+  set(x: number, y: number, z: number, order = this.order): this {
+    this.x = x
+    this.y = y
+    this.z = z
+    this.order = order
+    return this
+  }
+}
+
+export class Quaternion {
+  //1.- Store quaternion components to mirror three.js' public interface.
+  x = 0
+  y = 0
+  z = 0
+  w = 1
+
+  set(x: number, y: number, z: number, w: number): this {
+    this.x = x
+    this.y = y
+    this.z = z
+    this.w = w
+    return this
+  }
+
+  copy(other: Quaternion): this {
+    return this.set(other.x, other.y, other.z, other.w)
+  }
+
+  setFromEuler(euler: Euler): this {
+    const c1 = Math.cos(euler.x / 2)
+    const c2 = Math.cos(euler.y / 2)
+    const c3 = Math.cos(euler.z / 2)
+    const s1 = Math.sin(euler.x / 2)
+    const s2 = Math.sin(euler.y / 2)
+    const s3 = Math.sin(euler.z / 2)
+
+    this.x = s1 * c2 * c3 + c1 * s2 * s3
+    this.y = c1 * s2 * c3 - s1 * c2 * s3
+    this.z = c1 * c2 * s3 + s1 * s2 * c3
+    this.w = c1 * c2 * c3 - s1 * s2 * s3
+    return this
+  }
+
+  slerp(target: Quaternion, alpha: number): this {
+    //1.- Perform a simple normalized linear interpolation for determinism in tests.
+    this.x += (target.x - this.x) * alpha
+    this.y += (target.y - this.y) * alpha
+    this.z += (target.z - this.z) * alpha
+    this.w += (target.w - this.w) * alpha
+    const length = Math.hypot(this.x, this.y, this.z, this.w) || 1
+    return this.set(this.x / length, this.y / length, this.z / length, this.w / length)
+  }
+
+  clone(): Quaternion {
+    return new Quaternion().copy(this)
+  }
+
+  setFromAxisAngle(axis: Vector3, angle: number): this {
+    const normalized = axis.clone().normalize()
+    const halfAngle = angle / 2
+    const s = Math.sin(halfAngle)
+    return this.set(normalized.x * s, normalized.y * s, normalized.z * s, Math.cos(halfAngle))
+  }
+}
+
+export class FogExp2 {
+  //1.- Preserve fog parameters so consumers can validate density settings.
+  constructor(public color: Color, public density: number) {}
+}
+
+export class Object3D {
+  //1.- Emulate the scene graph hierarchy with parent/child relationships.
+  children: Object3D[] = []
+  parent: Object3D | null = null
+  position = new Vector3()
+  quaternion = new Quaternion()
+  rotation = new Euler()
+  scale = new Vector3(1, 1, 1)
+  matrixAutoUpdate = true
+  userData: Record<string, unknown> = {}
+  visible = true
+  name = ''
+
+  add(...objects: Object3D[]): this {
+    for (const object of objects) {
+      object.parent = this
+      this.children.push(object)
+    }
+    return this
+  }
+
+  remove(...objects: Object3D[]): this {
+    this.children = this.children.filter((candidate) => !objects.includes(candidate))
+    for (const object of objects) {
+      if (object.parent === this) {
+        object.parent = null
+      }
+    }
+    return this
+  }
+
+  removeFromParent(): this {
+    if (this.parent) {
+      this.parent.remove(this)
+    }
+    return this
+  }
+
+  getObjectByName(name: string): Object3D | undefined {
+    if (this.name === name) {
+      return this
+    }
+    for (const child of this.children) {
+      const match = child.getObjectByName(name)
+      if (match) {
+        return match
+      }
+    }
+    return undefined
+  }
+
+  updateMatrix(): void {
+    //1.- No-op placeholder to keep the API compatible with three.js.
+  }
+
+  updateMatrixWorld(): void {
+    //1.- Match three.js API while staying inert for tests.
+  }
+}
+
+export class Group extends Object3D {}
+
+export class Material {
+  //1.- Allow resources to be released explicitly in cleanup routines.
+  dispose(): void {}
+}
+
+export class Mesh extends Object3D {
+  //1.- Persist geometry and material references for metadata access.
+  geometry: unknown
+  material: unknown
+
+  constructor(geometry?: unknown, material?: unknown) {
+    super()
+    this.geometry = geometry
+    this.material = material
+  }
+
+  clone(): Mesh {
+    const copy = new Mesh(this.geometry, this.material)
+    copy.position = new Vector3(this.position.x, this.position.y, this.position.z)
+    copy.rotation = new Euler(this.rotation.x, this.rotation.y, this.rotation.z, this.rotation.order)
+    copy.scale = new Vector3(this.scale.x, this.scale.y, this.scale.z)
+    copy.userData = { ...this.userData }
+    return copy
+  }
+}
+
+export class Points extends Object3D {
+  //1.- Support particle systems with geometry/material references for assertions.
+  constructor(public geometry: BufferGeometry, public material: Material) {
+    super()
+  }
+}
+
+export class MeshStandardMaterial extends Material {
+  //1.- Store the options so tests can inspect them if required.
+  constructor(public parameters: Record<string, unknown> = {}) {
+    super()
+  }
+}
+
+export class PointsMaterial extends Material {
+  //1.- Mirror the points material interface for additive particle effects.
+  constructor(public parameters: Record<string, unknown> = {}) {
+    super()
+  }
+}
+
+export class AmbientLight extends Object3D {
+  //1.- Preserve light metadata so tests can validate intensity tuning.
+  constructor(public color: Color, public intensity: number) {
+    super()
+  }
+}
+
+export class DirectionalLight extends Object3D {
+  //1.- Mimic directional light placement for scene graph assertions.
+  constructor(public color: Color, public intensity: number) {
+    super()
+  }
+}
+
+export class Scene extends Object3D {
+  //1.- Track fog assignment for atmospheric previews.
+  fog: FogExp2 | null = null
+}
+
+export class PerspectiveCamera extends Object3D {
+  //1.- Mirror camera properties used during preview animation.
+  aspect: number
+
+  constructor(public fov: number, aspect: number, public near: number, public far: number) {
+    super()
+    this.aspect = aspect
+  }
+
+  lookAt(): void {
+    //1.- No-op placeholder to satisfy the interface.
+  }
+
+  updateProjectionMatrix(): void {
+    //1.- Mocked camera does not need to recalculate matrices.
+  }
+}
+
+export const MathUtils = {
+  //1.- Offer a deterministic conversion for Euler helper functions.
+  degToRad(degrees: number): number {
+    return (degrees * Math.PI) / 180
+  },
+}
+
+export class BufferAttribute {
+  //1.- Lightweight attribute helper exposing per-axis accessors.
+  array: Float32Array
+  itemSize: number
+  count: number
+  needsUpdate = false
+
+  constructor(array: ArrayLike<number>, itemSize: number) {
+    this.array = array instanceof Float32Array ? array : new Float32Array(array)
+    this.itemSize = itemSize
+    this.count = this.array.length / itemSize
+  }
+
+  getX(index: number): number {
+    return this.array[index * this.itemSize]
+  }
+
+  getY(index: number): number {
+    return this.array[index * this.itemSize + 1]
+  }
+
+  getZ(index: number): number {
+    return this.array[index * this.itemSize + 2]
+  }
+
+  setX(index: number, value: number): this {
+    this.array[index * this.itemSize] = value
+    return this
+  }
+
+  setY(index: number, value: number): this {
+    this.array[index * this.itemSize + 1] = value
+    return this
+  }
+
+  setZ(index: number, value: number): this {
+    this.array[index * this.itemSize + 2] = value
+    return this
+  }
+
+  setXYZ(index: number, x: number, y: number, z: number): this {
+    this.setX(index, x)
+    this.setY(index, y)
+    this.setZ(index, z)
+    return this
+  }
+}
+
+export class Float32BufferAttribute extends BufferAttribute {}
+
+export class BufferGeometry {
+  //1.- Track indices and attributes to imitate three.js geometry containers.
+  index: number[] | null = null
+  attributes: Record<string, unknown> = {}
+
+  setIndex(index: number[] | ArrayLike<number>): this {
+    this.index = Array.from(index as number[])
+    return this
+  }
+
+  setAttribute(name: string, attribute: unknown): this {
+    this.attributes[name] = attribute
+    return this
+  }
+
+  getAttribute(name: string): unknown {
+    return this.attributes[name]
+  }
+
+  computeVertexNormals(): this {
+    return this
+  }
+
+  translate(): this {
+    return this
+  }
+
+  center(): this {
+    return this
+  }
+
+  toNonIndexed(): this {
+    this.index = null
+    return this
+  }
+
+  clone(): BufferGeometry {
+    const copy = new BufferGeometry()
+    copy.index = this.index ? [...this.index] : null
+    for (const [name, attribute] of Object.entries(this.attributes)) {
+      const value = attribute as unknown
+      if (value instanceof BufferAttribute) {
+        copy.attributes[name] = new BufferAttribute(value.array.slice(0), value.itemSize)
+      } else {
+        copy.attributes[name] = value
+      }
+    }
+    return copy
+  }
+
+  dispose(): void {}
+}
+
+export class Shape {
+  //1.- Record 2D contour points to emulate polygon extrusion inputs.
+  points: { x: number; y: number }[] = []
+
+  moveTo(x: number, y: number): this {
+    this.points = [{ x, y }]
+    return this
+  }
+
+  lineTo(x: number, y: number): this {
+    this.points.push({ x, y })
+    return this
+  }
+}
+
+export class ExtrudeGeometry extends BufferGeometry {
+  //1.- Store references so tests can confirm extrusion parameters.
+  constructor(public shape: Shape, public settings: Record<string, unknown>) {
+    super()
+  }
+}
+
+export class TorusGeometry extends BufferGeometry {
+  //1.- Capture torus dimensions for inspection.
+  constructor(public radius: number, public tube: number, public radialSegments: number, public tubularSegments: number) {
+    super()
+  }
+}
+
+export class SphereGeometry extends BufferGeometry {
+  //1.- Maintain radius metadata for spherical crystal generation.
+  constructor(public radius: number, public widthSegments: number, public heightSegments: number) {
+    super()
+  }
+}
+
+export class ConeGeometry extends BufferGeometry {
+  //1.- Capture cone dimensions for stalactite generation assertions.
+  constructor(public radius: number, public height: number, public radialSegments: number) {
+    super()
+  }
+}
+
+export class BoxGeometry extends BufferGeometry {
+  //1.- Record box dimensions so previews can inspect fuselage proportions.
+  constructor(public width: number, public height: number, public depth: number) {
+    super()
+    const vertexCount = 8
+    const array = new Float32Array(vertexCount * 3)
+    this.setAttribute('position', new BufferAttribute(array, 3))
+  }
+}
+
+export class CylinderGeometry extends BufferGeometry {
+  //1.- Track top/bottom radii for glider fuselage approximations.
+  constructor(public radiusTop: number, public radiusBottom: number, public height: number, public radialSegments: number) {
+    super()
+    const vertexCount = Math.max(1, radialSegments) * 2
+    const array = new Float32Array(vertexCount * 3)
+    this.setAttribute('position', new BufferAttribute(array, 3))
+  }
+}
+
+export class PlaneGeometry extends BufferGeometry {
+  //1.- Mimic plane tessellation so terrain displacement logic has mutable vertices.
+  constructor(
+    public width: number,
+    public height: number,
+    public widthSegments: number,
+    public heightSegments: number,
+  ) {
+    super()
+    const columns = Math.max(1, widthSegments + 1)
+    const rows = Math.max(1, heightSegments + 1)
+    const vertexCount = columns * rows
+    const array = new Float32Array(vertexCount * 3)
+    this.setAttribute('position', new BufferAttribute(array, 3))
+  }
+
+  rotateX(): this {
+    return this
+  }
+}
+
+export class IcosahedronGeometry extends BufferGeometry {
+  //1.- Provide a simple vertex cloud representing the polyhedron surface.
+  constructor(public radius: number, public detail: number) {
+    super()
+    const vertexCount = Math.max(12, detail * 24)
+    const array = new Float32Array(vertexCount * 3)
+    this.setAttribute('position', new BufferAttribute(array, 3))
+  }
+}
+
+export class CapsuleGeometry extends BufferGeometry {
+  //1.- Persist capsule parameters so heavy escort meshes can be asserted without full geometry buffers.
+  constructor(public radius: number, public length: number, public capSegments: number, public radialSegments: number) {
+    super()
+  }
+}
+
+export class CatmullRomCurve3 {
+  //1.- Sample along stored waypoints to approximate spline behaviour for tests.
+  constructor(private readonly points: Vector3[], private readonly closed = false) {}
+
+  getPointAt(t: number): Vector3 {
+    const total = this.points.length
+    if (total === 0) {
+      return new Vector3()
+    }
+    const scaled = t * (total - 1)
+    const index = Math.floor(scaled)
+    const alpha = scaled - index
+    const start = this.points[index % total]
+    const end = this.points[(index + 1) % total]
+    return new Vector3(
+      start.x + (end.x - start.x) * alpha,
+      start.y + (end.y - start.y) * alpha,
+      start.z + (end.z - start.z) * alpha
+    )
+  }
+}
+
+export class TubeGeometry extends BufferGeometry {
+  //1.- Prepare placeholder vertex data so attribute warping logic can run in tests.
+  parameters: { path: CatmullRomCurve3; tubularSegments: number; radialSegments: number }
+
+  constructor(path: CatmullRomCurve3, tubularSegments: number, radius: number, radialSegments: number) {
+    super()
+    this.parameters = { path, tubularSegments, radialSegments }
+    const vertexCount = Math.max(1, tubularSegments) * Math.max(1, radialSegments)
+    const array = new Float32Array(vertexCount * 3)
+    for (let index = 0; index < vertexCount; index += 1) {
+      const base = index * 3
+      array[base] = index
+      array[base + 1] = index
+      array[base + 2] = index
+    }
+    this.setAttribute('position', new BufferAttribute(array, 3))
+  }
+}
+
+export class Matrix4 {
+  //1.- Store composed transforms for instanced mesh updates.
+  position = new Vector3()
+  quaternion = new Quaternion()
+  scale = new Vector3(1, 1, 1)
+
+  compose(position: Vector3, quaternion: Quaternion, scale: Vector3): this {
+    this.position = position.clone()
+    this.quaternion = quaternion.clone()
+    this.scale = scale.clone()
+    return this
+  }
+
+  copy(matrix: Matrix4): this {
+    this.position = matrix.position.clone()
+    this.quaternion = matrix.quaternion.clone()
+    this.scale = matrix.scale.clone()
+    return this
+  }
+
+  clone(): Matrix4 {
+    return new Matrix4().copy(this)
+  }
+}
+
+class InstancedMatrix {
+  usage: number | null = null
+  needsUpdate = false
+  matrices: Matrix4[]
+
+  constructor(count: number) {
+    this.matrices = Array.from({ length: count }, () => new Matrix4())
+  }
+
+  setUsage(usage: number): void {
+    this.usage = usage
+  }
+}
+
+export class InstancedMesh extends Mesh {
+  instanceMatrix: InstancedMatrix
+
+  constructor(geometry: unknown, material: unknown, public count: number) {
+    super(geometry, material)
+    this.instanceMatrix = new InstancedMatrix(count)
+  }
+
+  setMatrixAt(index: number, matrix: Matrix4): void {
+    this.instanceMatrix.matrices[index] = matrix.clone()
+  }
+
+  dispose(): void {}
+}
+
+export const DynamicDrawUsage = 0x88e8
+
+export const BackSide = 1

--- a/planet_sandbox_web/tsconfig.json
+++ b/planet_sandbox_web/tsconfig.json
@@ -11,8 +11,13 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
-    "types": ["vitest", "@testing-library/jest-dom"]
+    "types": ["vitest", "@testing-library/jest-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@client/*": ["../typescript-client/src/*"],
+      "@web/*": ["src/*"]
+    }
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "test", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/planet_sandbox_web/vite.config.ts
+++ b/planet_sandbox_web/vite.config.ts
@@ -1,14 +1,30 @@
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const resolveFromRoot = (relativePath: string) => path.resolve(__dirname, relativePath);
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      //1.- Mirror the monorepo aliases so shared client modules resolve consistently.
+      '@client': resolveFromRoot('../typescript-client/src'),
+      '@web': resolveFromRoot('./src')
+    }
+  },
   build: {
     target: 'es2020'
   },
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['./vitest.setup.ts']
+    setupFiles: ['./vitest.setup.ts'],
+    alias: {
+      //1.- Provide lightweight substitutes for heavy WebGL dependencies during unit tests.
+      three: resolveFromRoot('test/mocks/three.ts'),
+      '@client': resolveFromRoot('../typescript-client/src'),
+      '@web': resolveFromRoot('./src')
+    }
   }
 });

--- a/planet_sandbox_web/vitest.setup.ts
+++ b/planet_sandbox_web/vitest.setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom/vitest';
+import { webcrypto } from 'node:crypto';
+
+//1.- Provide the Web Crypto implementation so HMAC token generation works during unit tests.
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: webcrypto
+  });
+}

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # //1.- Discover the repository root so the script works from any invocation directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-TARGET_FILE="${REPO_ROOT}/tunnelcave_sandbox_web/.env.local"
+TARGET_FILE="${REPO_ROOT}/planet_sandbox_web/.env.local"
 BACKUP_FILE="${TARGET_FILE}.bak"
 
 # //2.- Detect if the caller requested an overwrite via the --force flag.
@@ -14,8 +14,8 @@ if [[ "${1:-}" == "--force" ]]; then
 fi
 
 # //3.- Ensure the Next.js workspace exists before attempting to scaffold.
-if [[ ! -d "${REPO_ROOT}/tunnelcave_sandbox_web" ]]; then
-  echo "error: tunnelcave_sandbox_web workspace not found" >&2
+if [[ ! -d "${REPO_ROOT}/planet_sandbox_web" ]]; then
+  echo "error: planet_sandbox_web workspace not found" >&2
   exit 1
 fi
 
@@ -37,13 +37,10 @@ cat > "${TARGET_FILE}" <<'ENV_TEMPLATE'
 # Update these values to point at your own services when not running locally.
 
 # Websocket endpoint served by the broker (default docker-compose port 43127).
-NEXT_PUBLIC_BROKER_URL=ws://localhost:43127/ws
+VITE_BROKER_URL=ws://localhost:43127/ws
 
-# Server-side origin for the simulation bridge API proxy (default local bridge port 8000).
-SIM_BRIDGE_URL=http://localhost:8000
-
-# HTTP origin for the simulation bridge API (default local bridge port 8000).
-NEXT_PUBLIC_SIM_BRIDGE_URL=http://localhost:8000
+# Direct HTTP origin for the simulation bridge API (default local bridge port 8000).
+VITE_SIM_BRIDGE_URL=http://localhost:8000
 ENV_TEMPLATE
 
 chmod 600 "${TARGET_FILE}"

--- a/typescript-client/src/networking/worldSession.test.ts
+++ b/typescript-client/src/networking/worldSession.test.ts
@@ -1,14 +1,14 @@
 import { BinaryWriter } from "@bufbuild/protobuf/wire";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../tunnelcave_sandbox_web/src/networking/authenticatedSocket", () => {
+vi.mock("../../../planet_sandbox_web/src/networking/authenticatedSocket", () => {
   //1.- Replace the dial helper so tests can intercept outbound websocket connections.
   return {
     openAuthenticatedSocket: vi.fn(),
   };
 });
 
-import { openAuthenticatedSocket } from "../../../tunnelcave_sandbox_web/src/networking/authenticatedSocket";
+import { openAuthenticatedSocket } from "../../../planet_sandbox_web/src/networking/authenticatedSocket";
 import type { Orientation, Vector3 } from "../generated/types";
 import { createWorldSession, type EntityTransform } from "./worldSession";
 

--- a/typescript-client/tsconfig.json
+++ b/typescript-client/tsconfig.json
@@ -9,5 +9,5 @@
     "resolveJsonModule": false,
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts", "../tunnelcave_sandbox_web/src/**/*.ts"]
+  "include": ["src/**/*.ts", "../planet_sandbox_web/src/**/*.ts"]
 }

--- a/typescript-client/vitest.config.ts
+++ b/typescript-client/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   resolve: {
     alias: {
       //1.- Mirror the sandbox alias so networking tests can import the browser client without bundler context.
-      "@web": path.resolve(__dirname, "../tunnelcave_sandbox_web/src"),
+      "@web": path.resolve(__dirname, "../planet_sandbox_web/src"),
       //2.- Point the shared client alias back at this package for cross-package imports.
       "@client": path.resolve(__dirname, "src"),
     },


### PR DESCRIPTION
## Summary
- connect the Planet sandbox view to the Go broker and Python bridge via a reusable world session hook and simulation control panel
- add Vite-friendly environment config helpers, networking shims, and a Docker image so planet_sandbox_web becomes the primary frontend target
- refresh documentation, scripts, and compose settings to reference VITE_* variables and the new web workspace

## Testing
- `CI=1 npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_68e408231de0832989efb0751644a7ec