### PR TITLE
Add Docker ignore rules for web client build context

### DIFF
--- a/planet_sandbox_web/.dockerignore
+++ b/planet_sandbox_web/.dockerignore
@@ -1,0 +1,14 @@
+#1.- Ignore installed dependencies copied from the host to avoid conflicts with container installs.
+node_modules
+
+#2.- Skip build artefacts and temporary outputs.
+dist
+coverage
+
+#3.- Prevent local configuration and logs from being copied.
+.env
+*.log
+
+#4.- Exclude version control metadata.
+.git
+.gitignore


### PR DESCRIPTION
## Summary
- add a Docker ignore file for the planet sandbox web client to avoid copying host artifacts into the image build
- exclude dependencies, build outputs, and local config files from the image context to fix the node_modules copy conflict during builds

## Testing
- CI=1 npm test -- src/lib/__tests__/vehicleFleet.test.ts
- CI=1 npm test -- src/components/__tests__/SimulationBridgePanel.test.tsx
- CI=1 npm test -- src/hooks/__tests__/useSimulationBridgeState.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68e41435bba08329b315b4955c0431ba