### PR TITLE
Fix planet sandbox web build path alias resolution

### DIFF
--- a/planet_sandbox_web/Dockerfile
+++ b/planet_sandbox_web/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM node:20-alpine AS builder
-WORKDIR /app
+WORKDIR /app/planet_sandbox_web
 
 #1.- Install dependencies using the npm lockfile when available.
 COPY planet_sandbox_web/package.json planet_sandbox_web/package-lock.json* ./
@@ -9,7 +9,7 @@ RUN npm ci
 
 #2.- Copy the application source and shared client library into the build context.
 COPY planet_sandbox_web/ ./
-COPY typescript-client ./typescript-client
+COPY typescript-client ../typescript-client
 
 #3.- Produce the static Vite build artefacts.
 RUN npm run build
@@ -18,7 +18,7 @@ FROM nginx:1.25-alpine AS runner
 WORKDIR /usr/share/nginx/html
 
 #1.- Copy the compiled assets into the nginx document root.
-COPY --from=builder /app/dist ./
+COPY --from=builder /app/planet_sandbox_web/dist ./
 
 #2.- Expose the default HTTP port for the static site.
 EXPOSE 80

--- a/planet_sandbox_web/src/hooks/useWorldEntities.ts
+++ b/planet_sandbox_web/src/hooks/useWorldEntities.ts
@@ -73,7 +73,7 @@ export function useWorldEntities(options?: UseWorldEntitiesOptions): UseWorldEnt
     });
     sessionRef.current = session;
 
-    const unsubscribe = session.store.subscribe((snapshot) => {
+    const unsubscribe = session.store.subscribe((snapshot: ReadonlyMap<string, EntityTransform>) => {
       //3.- Clone the world snapshot into component state whenever the broker publishes updates.
       if (cancelled) {
         return;


### PR DESCRIPTION
## Summary
- adjust the web Dockerfile to mirror the repository layout so shared client modules resolve when building
- tighten the world entities hook subscription typing to satisfy the strict TypeScript build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41b8760b08329ab1202a09fc27be8