### PR TITLE
Fix TypeScript module resolution for protobuf wire import

### DIFF
--- a/planet_sandbox_web/tsconfig.json
+++ b/planet_sandbox_web/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,

--- a/typescript-client/src/networking/protobufWireEntry.test.ts
+++ b/typescript-client/src/networking/protobufWireEntry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
+
+//1.- Verify the protobuf wire entrypoint remains constructible when TypeScript uses package export resolution.
+describe('protobuf wire entrypoint', () => {
+  it('instantiates the canonical reader and writer implementations', () => {
+    const reader = new BinaryReader(new Uint8Array());
+    const writer = new BinaryWriter();
+
+    expect(reader).toBeInstanceOf(BinaryReader);
+    expect(typeof writer.finish).toBe('function');
+  });
+});

--- a/typescript-client/tsconfig.json
+++ b/typescript-client/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
+    "moduleResolution": "node16",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- update the web client TypeScript configuration to use bundler-style module resolution so package exports for @bufbuild/protobuf are honored during builds
- align the shared TypeScript client configuration with Node 16 module resolution and add a regression test ensuring the protobuf wire entrypoint remains usable

## Testing
- npm run build (planet_sandbox_web)
- npx vitest run src/networking/protobufWireEntry.test.ts --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68e41cd450508329a6d1e335191dead3