### PR TITLE
Fix TypeScript protobuf wire module resolution for web client build

### DIFF
--- a/planet_sandbox_web/test/protobufWireImport.test.ts
+++ b/planet_sandbox_web/test/protobufWireImport.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { BinaryWriter } from '@bufbuild/protobuf/wire';
+
+//1.- Ensure the shimmed module resolution yields the expected class exported by the protobuf wire helpers.
+describe('protobuf wire module declaration', () => {
+  //2.- Verify that importing BinaryWriter produces a usable constructor at runtime and during type-checking.
+  it('exposes the BinaryWriter constructor', () => {
+    //3.- Instantiate the writer and assert the instance matches the exported type, confirming the shim behaves correctly.
+    const writer = new BinaryWriter();
+    expect(writer).toBeInstanceOf(BinaryWriter);
+  });
+});

--- a/planet_sandbox_web/tsconfig.json
+++ b/planet_sandbox_web/tsconfig.json
@@ -18,6 +18,6 @@
       "@web/*": ["src/*"]
     }
   },
-  "include": ["src", "test", "vite.config.ts"],
+  "include": ["src", "test", "types", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/planet_sandbox_web/types/protobuf-wire.d.ts
+++ b/planet_sandbox_web/types/protobuf-wire.d.ts
@@ -1,0 +1,5 @@
+//1.- Provide a module declaration so the TypeScript compiler can resolve the wire helpers during type-checking.
+declare module "@bufbuild/protobuf/wire" {
+  //2.- Re-export the generated ESM wire entry which mirrors the runtime export structure shipped by the package.
+  export * from "@bufbuild/protobuf/dist/esm/wire/index.js";
+}


### PR DESCRIPTION
## Summary
- add a local module declaration that re-exports the protobuf wire helpers so TypeScript can resolve the package during builds
- include the new declaration directory in the TypeScript project and cover it with a regression test that instantiates a BinaryWriter

## Testing
- npm run build
- CI=1 npm run test -- --run test/protobufWireImport.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e41f69e148832995db2b5d0dcb6a44