### PR TITLE
Fix type-only imports for planet sandbox web build

### DIFF
--- a/planet_sandbox_web/src/components/PlanetSandbox.tsx
+++ b/planet_sandbox_web/src/components/PlanetSandbox.tsx
@@ -1,15 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { describeAtmosphere } from '../lib/atmosphere';
-import { defaultPlanetaryShell, MovementCommand, SphericalPosition } from '../lib/planetConfig';
+import { defaultPlanetaryShell } from '../lib/planetConfig';
+import type { MovementCommand, SphericalPosition } from '../lib/planetConfig';
 import { PlanetTraveler } from '../lib/sphericalNavigator';
-import {
-  VehicleBlueprint,
-  VehicleFleet,
-  VehicleSnapshot,
-  blueprintToSnapshot,
-  enforceSurfaceClearance
-} from '../lib/vehicleFleet';
+import { VehicleFleet, blueprintToSnapshot, enforceSurfaceClearance } from '../lib/vehicleFleet';
+import type { VehicleBlueprint, VehicleSnapshot } from '../lib/vehicleFleet';
 import { useWorldEntities } from '../hooks/useWorldEntities';
 import { useSimulationBridgeState } from '../hooks/useSimulationBridgeState';
 import type { EntityTransform } from '@client/networking/worldSession';

--- a/planet_sandbox_web/src/lib/atmosphere.ts
+++ b/planet_sandbox_web/src/lib/atmosphere.ts
@@ -1,4 +1,4 @@
-import { PlanetaryShell, SphericalPosition } from './planetConfig';
+import type { PlanetaryShell, SphericalPosition } from './planetConfig';
 
 export interface AtmosphereState {
   altitudeToSurface: number;

--- a/planet_sandbox_web/src/lib/sphericalNavigator.ts
+++ b/planet_sandbox_web/src/lib/sphericalNavigator.ts
@@ -1,4 +1,9 @@
-import { MovementCommand, MovementResult, PlanetaryShell, SphericalPosition } from './planetConfig';
+import type {
+  MovementCommand,
+  MovementResult,
+  PlanetaryShell,
+  SphericalPosition
+} from './planetConfig';
 
 const DEG_TO_RAD = Math.PI / 180;
 const RAD_TO_DEG = 180 / Math.PI;

--- a/planet_sandbox_web/src/lib/vehicleFleet.ts
+++ b/planet_sandbox_web/src/lib/vehicleFleet.ts
@@ -1,4 +1,4 @@
-import { MovementCommand, PlanetaryShell, SphericalPosition } from './planetConfig';
+import type { MovementCommand, PlanetaryShell, SphericalPosition } from './planetConfig';
 import { PlanetTraveler } from './sphericalNavigator';
 
 export interface VehicleBlueprint {


### PR DESCRIPTION
## Summary
- update planet sandbox components and libraries to import shared interfaces using type-only syntax
- ensure fleet and navigator modules still expose runtime exports while satisfying verbatimModuleSyntax

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4259ac21c8329aeea0d27532438fb