### PR TITLE
Allow overriding game host port via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Runtime behaviour is configuration‑driven. Environment variable defaults and o
    ```
 - Web: **http://localhost:3000**
 - Broker: **localhost:43127**
+- To avoid host port conflicts set a different port before running Compose:
+  ```bash
+  export GAME_HOST_PORT=3001
+  docker compose up
+  ```
 - The web client container builds the production Next.js bundle with `NEXT_PUBLIC_BROKER_WS_URL=ws://broker:43127/ws` and `NEXT_PUBLIC_BROKER_HTTP_URL=http://broker:43127` so in-cluster requests resolve correctly. You may override these values at runtime if required.
 - Stop with `docker compose down`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       NEXT_PUBLIC_BROKER_WS_URL: ws://broker:43127/ws
       NEXT_PUBLIC_BROKER_HTTP_URL: http://broker:43127
     ports:
-      - "3000:3000"
+      - "${GAME_HOST_PORT:-3000}:3000"
     networks:
       - battleground
     restart: unless-stopped

--- a/tests/test_compose_contexts.py
+++ b/tests/test_compose_contexts.py
@@ -28,6 +28,16 @@ class ComposeContextTest(unittest.TestCase):
         # //5.- Fail the test when any context path is absent so Compose builds cannot break silently.
         self.assertFalse(missing_paths, f"Missing build contexts: {missing_paths}")
 
+    def test_game_service_host_port_is_configurable(self) -> None:
+        """The game service must expose a configurable host port to avoid collisions."""
+        # //1.- Load the docker-compose file so we can inspect the port mapping definition.
+        contents = self.COMPOSE_PATH.read_text(encoding="utf-8")
+        # //2.- Look for the exact Compose syntax that expands the GAME_HOST_PORT variable with a default.
+        pattern = r'ports:\s*\n\s+- "\$\{GAME_HOST_PORT:-3000\}:3000"'
+        match = re.search(pattern, contents)
+        # //3.- Ensure the pattern is present; otherwise developers cannot override the host port cleanly.
+        self.assertIsNotNone(match, "Expected game service ports to use ${GAME_HOST_PORT:-3000}:3000 mapping")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow the game service host port to be overridden via the GAME_HOST_PORT environment variable in docker-compose
- document how to select an alternate port when running the stack
- add a regression test ensuring the compose file retains the configurable port mapping

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e448f186688329a55fca0c6ffd8136