### PR TITLE
Fix stellated octahedron enemy mesh composition

### DIFF
--- a/game/src/enemies/stellated-octahedron/behavior.test.ts
+++ b/game/src/enemies/stellated-octahedron/behavior.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { SpyInstance } from 'vitest'
+import * as THREE from 'three'
+
+import { createEnemy, updateEnemies } from './behavior'
+
+describe('stellated octahedron enemy', () => {
+  it('registers the enemy in the scene and tracks position updates', () => {
+    const scene = new THREE.Scene()
+    const position = new THREE.Vector3(1, 2, 3)
+    const enemy = createEnemy(scene, position.clone())
+
+    expect(enemy.mesh.position.clone().toArray()).toEqual(position.toArray())
+    expect(scene.children).toContain(enemy.mesh)
+    expect(((scene as any).__enemies as unknown[]).includes(enemy)).toBe(true)
+
+    enemy.target = new THREE.Object3D()
+    enemy.target.position.set(100, 2, 3)
+    const before = enemy.mesh.position.clone()
+    updateEnemies(scene, 0.1)
+
+    expect(enemy.mesh.position.x).toBeGreaterThan(before.x)
+  })
+
+  it('cleans up mesh resources on death', () => {
+    const scene = new THREE.Scene()
+    const enemy = createEnemy(scene, new THREE.Vector3())
+    const geometrySpies: SpyInstance[] = []
+    const materialSpies: SpyInstance[] = []
+
+    for (const child of enemy.mesh.children) {
+      if (child instanceof THREE.Mesh) {
+        const geoSpy = vi.spyOn(child.geometry, 'dispose')
+        geometrySpies.push(geoSpy)
+
+        if (Array.isArray(child.material)) {
+          child.material.forEach((mat) => {
+            if (!mat.dispose) return
+            materialSpies.push(vi.spyOn(mat, 'dispose'))
+          })
+        } else if (child.material.dispose) {
+          materialSpies.push(vi.spyOn(child.material, 'dispose'))
+        }
+      }
+    }
+
+    enemy.onDeath()
+
+    expect(scene.children).not.toContain(enemy.mesh)
+    expect(geometrySpies.length).toBeGreaterThan(0)
+    expect(geometrySpies.some((spy) => spy.mock.calls.length > 0)).toBe(true)
+    expect(materialSpies.length).toBeGreaterThan(0)
+    expect(materialSpies.every((spy) => spy.mock.calls.length > 0)).toBe(true)
+  })
+})

--- a/game/src/enemies/stellated-octahedron/behavior.ts
+++ b/game/src/enemies/stellated-octahedron/behavior.ts
@@ -1,27 +1,37 @@
 import * as THREE from 'three'
-import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
+
+function disposeMeshLike(object: THREE.Object3D){
+  //1.- Traverse any composed mesh tree and release GPU buffers and materials.
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+    child.geometry.dispose()
+    const material = child.material
+    if (Array.isArray(material)) {
+      for (const mat of material) mat.dispose?.()
+    } else {
+      material.dispose?.()
+    }
+  })
+}
 
 function buildStellatedOctahedron(size=6){
   //1.- Build a pair of tetrahedra whose rotations mirror the stella octangula shape.
-  const tetraPrimary = new THREE.TetrahedronGeometry(size, 0)
-  const tetraSecondary = tetraPrimary.clone()
-  tetraSecondary.rotateX(Math.PI)
-  tetraSecondary.rotateZ(Math.PI/2)
+  const geometryPrimary = new THREE.TetrahedronGeometry(size, 0)
+  const geometrySecondary = geometryPrimary.clone()
+  geometrySecondary.rotateX(Math.PI)
+  geometrySecondary.rotateZ(Math.PI/2)
 
-  //2.- Combine the tetrahedra into a single buffer geometry for efficient rendering.
-  const merged = mergeGeometries([tetraPrimary, tetraSecondary], false)
-  const geometry = merged ?? tetraPrimary
-  if (merged) {
-    tetraPrimary.dispose()
-  }
-  tetraSecondary.dispose()
-
-  //3.- Wrap the merged geometry in a material tuned for the enemy aesthetic.
-  return new THREE.Mesh(geometry, new THREE.MeshStandardMaterial({ color: 0xff5533, metalness: 0.2, roughness: 0.6, emissive: 0x220000 }))
+  //2.- Wrap both geometries into meshes and group them for compound motion without BufferGeometryUtils.
+  const material = new THREE.MeshStandardMaterial({ color: 0xff5533, metalness: 0.2, roughness: 0.6, emissive: 0x220000 })
+  const meshPrimary = new THREE.Mesh(geometryPrimary, material)
+  const meshSecondary = new THREE.Mesh(geometrySecondary, material)
+  const group = new THREE.Group()
+  group.add(meshPrimary, meshSecondary)
+  return group
 }
 
 export function createEnemy(scene: THREE.Scene, position: THREE.Vector3){
-  //4.- Materialise the mesh, position it, and append it to the active scene graph.
+  //1.- Materialise the mesh, position it, and append it to the active scene graph.
   const mesh = buildStellatedOctahedron(5)
   mesh.position.copy(position)
   scene.add(mesh)
@@ -43,18 +53,17 @@ export function createEnemy(scene: THREE.Scene, position: THREE.Vector3){
     },
     onDeath(){
       scene.remove(mesh)
-      mesh.geometry.dispose()
-      ;(mesh.material as THREE.Material).dispose?.()
+      disposeMeshLike(mesh)
     }
   }
-  //5.- Track the enemy so the wave manager can iterate and update per frame.
+  //2.- Track the enemy so the wave manager can iterate and update per frame.
   ;(scene as any).__enemies ??= []
   ;(scene as any).__enemies.push(obj)
   return obj
 }
 
 export function updateEnemies(scene: THREE.Scene, dt:number){
-  //6.- Advance each tracked enemy AI using the shared scene registry.
+  //1.- Advance each tracked enemy AI using the shared scene registry.
   const arr = (scene as any).__enemies as any[] | undefined
   if (!arr) return
   for (const e of arr) e.update(dt)


### PR DESCRIPTION
## Summary
- replace the stellated octahedron mesh merge with a grouped pair of tetrahedra and centralized disposal helpers to avoid runtime errors
- add unit coverage to ensure the enemy registers, moves toward targets, and cleans up geometry/material resources

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e44a27f5488329b0f1449617b8f8c6