### PR TITLE
Ensure broker client closes connecting sockets

### DIFF
--- a/game/src/__tests__/brokerClient.test.ts
+++ b/game/src/__tests__/brokerClient.test.ts
@@ -129,4 +129,21 @@ describe("broker client", () => {
 
     client.close();
   });
+
+  it("closes sockets that are still connecting", () => {
+    const client = createBrokerClient({ clientId: "closing-pilot", reconnectDelayMs: 0 });
+    const socket = MockWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected websocket to be constructed");
+    }
+
+    //5.- Validate that terminating during CONNECTING invokes close() and suppresses the broker handshake.
+    const closeSpy = vi.spyOn(socket, "close");
+    client.close();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED);
+
+    socket.simulateOpen();
+    expect(socket.sent).toHaveLength(0);
+  });
 });

--- a/game/src/lib/brokerClient.ts
+++ b/game/src/lib/brokerClient.ts
@@ -198,13 +198,19 @@ class BrokerClientImpl {
   }
 
   close() {
-    //14.- Terminate the websocket and suppress future reconnect attempts during teardown.
+    //14.- Terminate the websocket regardless of whether the handshake completed while suppressing future reconnect attempts during teardown.
     this.shouldReconnect = false;
     this.clearTimer();
     this.listeners.clear();
-    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-      this.socket.close();
+    const socket = this.socket;
+    if (
+      socket &&
+      (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)
+    ) {
+      socket.close();
     }
+    this.socket = null;
+    this.state = "closed";
   }
 }
 


### PR DESCRIPTION
## Summary
- update the broker client's close logic to terminate sockets that are still connecting or open and clear internal references
- add a regression test ensuring closing before the handshake stops the mock socket from sending a handshake

## Testing
- npx vitest run src/__tests__/brokerClient.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e45f6b547c8329ad1261911f1eda5d