### PR TITLE
Add weapon systems and integrate controller

### DIFF
--- a/game/src/__tests__/weapons.test.ts
+++ b/game/src/__tests__/weapons.test.ts
@@ -1,0 +1,158 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+import { createHomingMissileSystem } from '@/weapons/homingMissile'
+import { createNeonLaserSystem } from '@/weapons/neonLaser'
+import { createBombSystem } from '@/weapons/bomb'
+import { createGatlingSystem } from '@/weapons/gatling'
+import type { WeaponContext, WeaponTarget } from '@/weapons/types'
+
+function makeContext(overrides: Partial<WeaponContext> = {}): WeaponContext{
+  const base: WeaponContext = {
+    position: new THREE.Vector3(),
+    forward: new THREE.Vector3(0,0,-1),
+    dt: 0.1,
+    targets: [],
+  }
+  return Object.assign(base, overrides)
+}
+
+describe('homing missile system', () => {
+  it('retargets when the tracked enemy dies mid-flight', () => {
+    const system = createHomingMissileSystem({
+      maxConcurrent: 2,
+      cooldownMs: 500,
+      ammo: 2,
+      speed: 100,
+      navigationConstant: 4,
+      lockConeDeg: 60,
+      smokeTrailIntervalMs: 50,
+      detonationRadius: 2,
+      maxLifetimeMs: 8000,
+    })
+
+    const primary: WeaponTarget = {
+      id: 'alpha',
+      position: new THREE.Vector3(0,0,-200),
+      velocity: new THREE.Vector3(),
+      alive: true,
+    }
+    const secondary: WeaponTarget = {
+      id: 'bravo',
+      position: new THREE.Vector3(10,0,-210),
+      velocity: new THREE.Vector3(),
+      alive: true,
+    }
+
+    const context = makeContext({ targets: [primary, secondary] })
+
+    const fired = system.tryFire(context)
+    expect(fired.fired).toBe(true)
+
+    for (let i = 0; i < 5; i++){
+      system.update(context)
+    }
+
+    //1.- Simulate the primary target being destroyed so the missile must react.
+    primary.alive = false
+    for (let i = 0; i < 3; i++){
+      system.update(context)
+    }
+
+    const missile = system.missiles[0]
+    expect(missile).toBeDefined()
+    expect(missile?.targetId).toBe('bravo')
+  })
+})
+
+describe('neon laser system', () => {
+  it('enforces cooldown before allowing a new beam', () => {
+    const system = createNeonLaserSystem({
+      cooldownMs: 1000,
+      durationMs: 200,
+      range: 300,
+      attenuation: 0.005,
+    })
+
+    const context = makeContext()
+
+    const first = system.fire(context)
+    expect(first).toBe(true)
+    system.update(context)
+
+    //2.- Immediately attempting another beam should be rejected until cooldown finishes.
+    expect(system.fire(context)).toBe(false)
+
+    for (let i = 0; i < 15; i++){
+      system.update(makeContext({ dt: 0.1 }))
+    }
+
+    expect(system.fire(context)).toBe(true)
+  })
+})
+
+describe('bomb system', () => {
+  it('detonates after the fuse and reports AoE overlap', () => {
+    const system = createBombSystem({
+      maxConcurrent: 1,
+      ammo: 1,
+      fuseMs: 500,
+      cooldownMs: 0,
+      aoeRadius: 20,
+      craterRadius: 6,
+      debrisCount: 4,
+      gravity: 9.8,
+    })
+
+    const context = makeContext()
+    const fired = system.fire({ ...context, sampleGroundHeight: () => -100 })
+    expect(fired).toBe(true)
+
+    for (let i = 0; i < 6; i++){
+      system.update({ ...context, sampleGroundHeight: () => -100 })
+    }
+
+    expect(system.explosions.length).toBeGreaterThan(0)
+
+    const center = system.explosions[0]?.center
+    if (!center){
+      throw new Error('expected explosion center')
+    }
+
+    //3.- Confirm the query helper reports points within the radius as affected.
+    expect(system.queryAoE(center.clone())).toBe(true)
+    expect(system.queryAoE(center.clone().add(new THREE.Vector3(30,0,0)))).toBe(false)
+  })
+})
+
+describe('gatling system', () => {
+  it('recovers from overheat after cooling down', () => {
+    const system = createGatlingSystem({
+      fireRate: 120,
+      spread: THREE.MathUtils.degToRad(2),
+      maxTracers: 8,
+      tracerLifeMs: 100,
+      ammo: 200,
+      heatPerShot: 20,
+      coolRate: 40,
+      overheatThreshold: 60,
+    })
+
+    const context = makeContext({ dt: 0.05 })
+
+    for (let i = 0; i < 10 && !system.overheated; i++){
+      system.update(context, true)
+    }
+
+    expect(system.overheated).toBe(true)
+
+    for (let i = 0; i < 20; i++){
+      system.update(makeContext({ dt: 0.1 }), false)
+    }
+
+    expect(system.overheated).toBe(false)
+
+    const result = system.update(context, true)
+    //4.- After cooling the cannon should resume firing rounds.
+    expect(result.shots).toBeGreaterThan(0)
+  })
+})

--- a/game/src/vehicles/shared/simpleController.ts
+++ b/game/src/vehicles/shared/simpleController.ts
@@ -1,17 +1,71 @@
 import * as THREE from 'three'
+import { createGatlingSystem } from '@/weapons/gatling'
+import { createHomingMissileSystem } from '@/weapons/homingMissile'
+import { createNeonLaserSystem } from '@/weapons/neonLaser'
+import { createBombSystem } from '@/weapons/bomb'
+import type { WeaponContext, WeaponTarget } from '@/weapons/types'
 
 export function createController(group: THREE.Group){
   const vel = new THREE.Vector3(0,0,60)
-  const tmp = new THREE.Vector3()
   const forward = new THREE.Vector3(0,0,-1)
-  const mouseWorld = new THREE.Vector2(0,0)
+  const weaponContext: WeaponContext = {
+    position: new THREE.Vector3(),
+    forward: new THREE.Vector3(0,0,-1),
+    dt: 0,
+    targets: []
+  }
+  let targetProvider: () => WeaponTarget[] = () => []
+
+  const gatling = createGatlingSystem({
+    fireRate: 25,
+    spread: THREE.MathUtils.degToRad(1.5),
+    maxTracers: 32,
+    tracerLifeMs: 250,
+    ammo: 1200,
+    heatPerShot: 1,
+    coolRate: 12,
+    overheatThreshold: 120,
+  })
+
+  const missilesSystem = createHomingMissileSystem({
+    maxConcurrent: 4,
+    cooldownMs: 1200,
+    ammo: 4,
+    speed: 180,
+    navigationConstant: 3,
+    lockConeDeg: 45,
+    smokeTrailIntervalMs: 80,
+    detonationRadius: 4,
+    maxLifetimeMs: 12000,
+  })
+
+  const laserSystem = createNeonLaserSystem({
+    cooldownMs: 2000,
+    durationMs: 600,
+    range: 800,
+    attenuation: 0.002,
+  })
+
+  const bombSystem = createBombSystem({
+    maxConcurrent: 2,
+    ammo: 6,
+    fuseMs: 2500,
+    cooldownMs: 1500,
+    aoeRadius: 40,
+    craterRadius: 18,
+    debrisCount: 8,
+    gravity: 30,
+  })
 
   let speed = 60
   let weaponName = 'GATLING'
-  let ammo = 999
-  let missiles = 4
-  let laserCooldownMs = 0
-  let bombArmed = true
+  let ammo = gatling.ammo
+  let missiles = missilesSystem.ammo
+  let laserCooldownMs = laserSystem.cooldownMs
+  let bombArmed = bombSystem.isArmed
+  let fireHeld = false
+  let fireJustPressed = false
+  let fireJustReleased = false
 
   function update(dt:number, input:any, queryHeight:(x:number,z:number)=>number){
     // Mouse steering: aim reticle in NDC controls yaw/pitch
@@ -45,15 +99,63 @@ export function createController(group: THREE.Group){
     const ceiling = 2000
     if (group.position.y > ceiling) group.position.y = ceiling
 
+    const previouslyHeld = fireHeld
+    fireHeld = Boolean(input.pressed('Space'))
+    fireJustPressed = fireHeld && !previouslyHeld
+    fireJustReleased = !fireHeld && previouslyHeld
+
     // Weapons input (placeholders)
     if (input.pressed('Digit1')) weaponName = 'GATLING'
     if (input.pressed('Digit2')) weaponName = 'MISSILE'
     if (input.pressed('Digit3')) weaponName = 'LASER'
     if (input.pressed('Digit4')) weaponName = 'BOMB'
-    // TODO: spawn bullets/missiles/laser/bomb
+
+    weaponContext.position.copy(group.position)
+    weaponContext.forward.copy(forward)
+    weaponContext.dt = dt
+    weaponContext.targets = targetProvider()
+
+    if (weaponName === 'GATLING'){
+      //1.- Advance the hitscan gun and respect trigger state.
+      gatling.update(weaponContext, fireHeld)
+    } else {
+      gatling.update(weaponContext, false)
+    }
+
+    if (weaponName === 'MISSILE' && fireJustPressed){
+      //2.- Launch homing missiles when ammo and pool constraints allow.
+      missilesSystem.tryFire(weaponContext)
+    }
+    missilesSystem.update(weaponContext)
+
+    if (weaponName === 'LASER'){
+      if (fireJustPressed){
+        laserSystem.fire(weaponContext)
+      }
+      if (fireHeld){
+        laserSystem.sustain(weaponContext)
+      }
+      if (fireJustReleased){
+        laserSystem.release()
+      }
+    } else {
+      if (laserSystem.state.active){
+        laserSystem.release()
+      }
+    }
+    laserSystem.update(weaponContext)
+
+    if (weaponName === 'BOMB' && fireJustPressed){
+      //3.- Drop a bomb while relaying the terrain sampler to trigger ground detonation.
+      bombSystem.fire({ ...weaponContext, sampleGroundHeight: queryHeight })
+    }
+    bombSystem.update({ ...weaponContext, sampleGroundHeight: queryHeight })
 
     // Cooldowns
-    if (laserCooldownMs > 0) laserCooldownMs = Math.max(0, laserCooldownMs - dt*1000)
+    ammo = gatling.ammo
+    missiles = missilesSystem.ammo
+    laserCooldownMs = laserSystem.cooldownMs
+    bombArmed = bombSystem.isArmed
   }
 
   return {
@@ -63,6 +165,9 @@ export function createController(group: THREE.Group){
     get ammo(){ return ammo },
     get missiles(){ return missiles },
     get laserCooldownMs(){ return laserCooldownMs },
-    get bombArmed(){ return bombArmed }
+    get bombArmed(){ return bombArmed },
+    setTargetProvider(provider: () => WeaponTarget[]){
+      targetProvider = provider
+    }
   }
 }

--- a/game/src/weapons/bomb.ts
+++ b/game/src/weapons/bomb.ts
@@ -1,0 +1,130 @@
+import * as THREE from 'three'
+import { GroundedWeaponContext } from '@/weapons/types'
+
+export type BombOptions = {
+  maxConcurrent: number
+  ammo: number
+  fuseMs: number
+  cooldownMs: number
+  aoeRadius: number
+  craterRadius: number
+  debrisCount: number
+  gravity: number
+}
+
+export type BombState = {
+  id: number
+  position: THREE.Vector3
+  velocity: THREE.Vector3
+  fuseMs: number
+}
+
+export type ExplosionState = {
+  id: number
+  center: THREE.Vector3
+  radius: number
+  craterRadius: number
+  debris: THREE.Vector3[]
+}
+
+export function createBombSystem(options: BombOptions){
+  const bombs: BombState[] = []
+  const explosions: ExplosionState[] = []
+  let ammo = options.ammo
+  let cooldownMs = 0
+  let idCounter = 0
+
+  const gravityVec = new THREE.Vector3(0, -options.gravity, 0)
+  const tmp = new THREE.Vector3()
+
+  function spawnDebris(center: THREE.Vector3){
+    const parts: THREE.Vector3[] = []
+    for (let i = 0; i < options.debrisCount; i++){
+      //1.- Scatter fragments radially with gentle upward bias for a quick debris visualization.
+      const angle = (i / Math.max(1, options.debrisCount)) * Math.PI * 2
+      const radius = options.craterRadius * 0.6
+      parts.push(new THREE.Vector3(
+        center.x + Math.cos(angle) * radius,
+        center.y + options.craterRadius * 0.2,
+        center.z + Math.sin(angle) * radius,
+      ))
+    }
+    return parts
+  }
+
+  function detonate(index: number, context: GroundedWeaponContext){
+    const bomb = bombs[index]
+    const center = bomb.position.clone()
+    const explosion: ExplosionState = {
+      id: bomb.id,
+      center,
+      radius: options.aoeRadius,
+      craterRadius: options.craterRadius,
+      debris: spawnDebris(center),
+    }
+    //2.- Record the blast so the HUD/tests can query area-of-effect interactions.
+    explosions.push(explosion)
+    bombs.splice(index, 1)
+    cooldownMs = options.cooldownMs
+  }
+
+  function update(context: GroundedWeaponContext){
+    if (cooldownMs > 0){
+      cooldownMs = Math.max(0, cooldownMs - context.dt * 1000)
+    }
+
+    for (let i = bombs.length - 1; i >= 0; i--){
+      const bomb = bombs[i]
+      bomb.fuseMs -= context.dt * 1000
+      if (bomb.fuseMs <= 0){
+        detonate(i, context)
+        continue
+      }
+
+      bomb.velocity.addScaledVector(gravityVec, context.dt)
+      bomb.position.addScaledVector(bomb.velocity, context.dt)
+
+      const sample = context.sampleGroundHeight
+      if (sample){
+        const ground = sample(bomb.position.x, bomb.position.z)
+        if (bomb.position.y <= ground){
+          //3.- Trigger the fuse early if the shell contacts the terrain before timing out.
+          detonate(i, context)
+        }
+      }
+    }
+  }
+
+  function fire(context: GroundedWeaponContext){
+    if (ammo <= 0) return false
+    if (cooldownMs > 0) return false
+    if (bombs.length >= options.maxConcurrent) return false
+
+    const bomb: BombState = {
+      id: ++idCounter,
+      position: context.position.clone(),
+      velocity: context.forward.clone().multiplyScalar(60).add(tmp.set(0, -10, 0)),
+      fuseMs: options.fuseMs,
+    }
+
+    bombs.push(bomb)
+    ammo -= 1
+    return true
+  }
+
+  function queryAoE(point: THREE.Vector3){
+    //4.- Provide a helper for tests and gameplay to evaluate explosion overlap.
+    return explosions.some(explosion => explosion.center.distanceTo(point) <= explosion.radius)
+  }
+
+  return {
+    update,
+    fire,
+    queryAoE,
+    get ammo(){ return ammo },
+    get cooldownMs(){ return cooldownMs },
+    get activeCount(){ return bombs.length },
+    get explosions(){ return explosions },
+    get isArmed(){ return ammo > 0 && cooldownMs === 0 && bombs.length < options.maxConcurrent },
+  }
+}

--- a/game/src/weapons/gatling.ts
+++ b/game/src/weapons/gatling.ts
@@ -1,0 +1,121 @@
+import * as THREE from 'three'
+import { WeaponContext } from '@/weapons/types'
+
+export type GatlingOptions = {
+  fireRate: number
+  spread: number
+  maxTracers: number
+  tracerLifeMs: number
+  ammo: number
+  heatPerShot: number
+  coolRate: number
+  overheatThreshold: number
+}
+
+export type TracerState = {
+  id: number
+  origin: THREE.Vector3
+  direction: THREE.Vector3
+  lifeMs: number
+}
+
+export type GatlingState = {
+  ammo: number
+  heat: number
+  overheated: boolean
+  tracers: TracerState[]
+  accumulator: number
+}
+
+export function createGatlingSystem(options: GatlingOptions){
+  const state: GatlingState = {
+    ammo: options.ammo,
+    heat: 0,
+    overheated: false,
+    tracers: [],
+    accumulator: 0,
+  }
+
+  let tracerId = 0
+
+  function spawnTracer(context: WeaponContext){
+    const tracer: TracerState = {
+      id: ++tracerId,
+      origin: context.position.clone(),
+      direction: context.forward.clone(),
+      lifeMs: options.tracerLifeMs,
+    }
+
+    //1.- Impose deterministic spread so tests can predictably assert ray casts.
+    const seed = tracer.id * 12.9898
+    const yaw = (Math.sin(seed) * 0.5) * options.spread
+    const pitch = (Math.sin(seed * 0.5) * 0.5) * options.spread
+    const rotation = new THREE.Euler(pitch, yaw, 0, 'XYZ')
+    tracer.direction.applyEuler(rotation).normalize()
+
+    if (state.tracers.length >= options.maxTracers){
+      state.tracers.shift()
+    }
+    state.tracers.push(tracer)
+    return tracer
+  }
+
+  function coolDown(dt: number){
+    //2.- Dissipate heat over time so prolonged bursts eventually recover.
+    if (state.heat > 0){
+      state.heat = Math.max(0, state.heat - options.coolRate * dt)
+      if (state.overheated && state.heat <= options.overheatThreshold * 0.25){
+        state.overheated = false
+      }
+    }
+  }
+
+  function update(context: WeaponContext, triggerHeld: boolean){
+    const dt = context.dt
+
+    for (let i = state.tracers.length - 1; i >= 0; i--){
+      const tracer = state.tracers[i]
+      tracer.lifeMs -= dt * 1000
+      if (tracer.lifeMs <= 0){
+        state.tracers.splice(i, 1)
+      }
+    }
+
+    if (!triggerHeld){
+      //3.- When idle, only cool the barrels.
+      coolDown(dt)
+      state.accumulator = 0
+      return { shots: 0 }
+    }
+
+    if (state.overheated || state.ammo <= 0){
+      coolDown(dt)
+      return { shots: 0 }
+    }
+
+    state.accumulator += dt * options.fireRate
+    let shots = 0
+
+    while (state.accumulator >= 1 && state.ammo > 0 && !state.overheated){
+      spawnTracer(context)
+      state.accumulator -= 1
+      state.ammo -= 1
+      state.heat += options.heatPerShot
+      shots++
+      if (state.heat >= options.overheatThreshold){
+        //4.- Flag the weapon as overheated so callers must ease off the trigger.
+        state.overheated = true
+      }
+    }
+
+    coolDown(dt)
+    return { shots }
+  }
+
+  return {
+    update,
+    get state(){ return state },
+    get ammo(){ return state.ammo },
+    get overheated(){ return state.overheated },
+  }
+}

--- a/game/src/weapons/homingMissile.ts
+++ b/game/src/weapons/homingMissile.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three'
+import { WeaponContext, WeaponTarget } from '@/weapons/types'
+
+export type HomingMissileOptions = {
+  maxConcurrent: number
+  cooldownMs: number
+  ammo: number
+  speed: number
+  navigationConstant: number
+  lockConeDeg: number
+  smokeTrailIntervalMs: number
+  detonationRadius: number
+  maxLifetimeMs: number
+}
+
+export type HomingMissileState = {
+  id: number
+  position: THREE.Vector3
+  velocity: THREE.Vector3
+  targetId: string | null
+  lifetimeMs: number
+  smokeTrail: THREE.Vector3[]
+  smokeAccumulatorMs: number
+}
+
+export type HomingMissileFireResult = {
+  fired: boolean
+  missile?: HomingMissileState
+  reason?: string
+}
+
+export function createHomingMissileSystem(options: HomingMissileOptions){
+  const missiles: HomingMissileState[] = []
+  let ammo = options.ammo
+  let cooldownMs = 0
+  let idCounter = 0
+
+  const toTarget = new THREE.Vector3()
+  const los = new THREE.Vector3()
+  const relVel = new THREE.Vector3()
+  const navAccel = new THREE.Vector3()
+  const forwardTmp = new THREE.Vector3()
+
+  //1.- Clamp expensive configuration upfront so the system always behaves predictably.
+  const coneCos = Math.cos(THREE.MathUtils.degToRad(Math.max(0.1, Math.min(89.9, options.lockConeDeg))))
+
+  function acquireTarget(context: WeaponContext, origin: THREE.Vector3){
+    let best: WeaponTarget | null = null
+    let bestDot = coneCos
+    for (const target of context.targets){
+      if (!target.alive) continue
+      toTarget.copy(target.position).sub(origin)
+      const distance = toTarget.length()
+      if (distance <= 0.001) continue
+      toTarget.divideScalar(distance)
+      const dot = toTarget.dot(context.forward)
+      if (dot < bestDot) continue
+      bestDot = dot
+      best = target
+    }
+    return best
+  }
+
+  function detonate(index: number){
+    missiles.splice(index, 1)
+  }
+
+  function update(context: WeaponContext){
+    //2.- Reduce global cooldown so the caller knows when the next missile is ready.
+    if (cooldownMs > 0){
+      cooldownMs = Math.max(0, cooldownMs - context.dt * 1000)
+    }
+
+    for (let i = missiles.length - 1; i >= 0; i--){
+      const missile = missiles[i]
+      missile.lifetimeMs += context.dt * 1000
+      if (missile.lifetimeMs > options.maxLifetimeMs){
+        detonate(i)
+        continue
+      }
+
+      let target = context.targets.find(t => t.id === missile.targetId && t.alive) ?? null
+      if (!target){
+        //3.- Automatically reacquire the best available target inside the cone when the original dies.
+        const reacquired = acquireTarget(context, missile.position)
+        missile.targetId = reacquired?.id ?? null
+        target = reacquired
+      }
+
+      if (target){
+        los.copy(target.position).sub(missile.position)
+        const distance = los.length()
+        if (distance < options.detonationRadius){
+          detonate(i)
+          continue
+        }
+        los.normalize()
+        relVel.copy(target.velocity).sub(missile.velocity)
+        navAccel.copy(relVel.cross(los).cross(los)).multiplyScalar(options.navigationConstant)
+        missile.velocity.addScaledVector(navAccel, context.dt)
+        missile.velocity.setLength(options.speed)
+      }
+
+      missile.position.addScaledVector(missile.velocity, context.dt)
+
+      missile.smokeAccumulatorMs += context.dt * 1000
+      if (missile.smokeAccumulatorMs >= options.smokeTrailIntervalMs){
+        //4.- Append downsampled smoke trail points to emulate the visual exhaust ribbon.
+        missile.smokeAccumulatorMs = 0
+        missile.smokeTrail.push(missile.position.clone())
+        if (missile.smokeTrail.length > 32){
+          missile.smokeTrail.shift()
+        }
+      }
+    }
+  }
+
+  function tryFire(context: WeaponContext): HomingMissileFireResult{
+    if (ammo <= 0) return { fired: false, reason: 'empty' }
+    if (cooldownMs > 0) return { fired: false, reason: 'cooldown' }
+    if (missiles.length >= options.maxConcurrent) return { fired: false, reason: 'pool' }
+
+    const target = acquireTarget(context, context.position)
+    if (!target) return { fired: false, reason: 'no-target' }
+
+    const missile: HomingMissileState = {
+      id: ++idCounter,
+      position: context.position.clone(),
+      velocity: forwardTmp.copy(context.forward).multiplyScalar(options.speed),
+      targetId: target.id,
+      lifetimeMs: 0,
+      smokeTrail: [],
+      smokeAccumulatorMs: 0,
+    }
+
+    missiles.push(missile)
+    ammo -= 1
+    cooldownMs = options.cooldownMs
+    return { fired: true, missile }
+  }
+
+  return {
+    update,
+    tryFire,
+    get ammo(){ return ammo },
+    get cooldownMs(){ return cooldownMs },
+    get activeCount(){ return missiles.length },
+    get missiles(){ return missiles },
+  }
+}

--- a/game/src/weapons/neonLaser.ts
+++ b/game/src/weapons/neonLaser.ts
@@ -1,0 +1,90 @@
+import * as THREE from 'three'
+import { WeaponContext } from '@/weapons/types'
+
+export type NeonLaserOptions = {
+  cooldownMs: number
+  durationMs: number
+  range: number
+  attenuation: number
+}
+
+export type NeonLaserState = {
+  active: boolean
+  remainingMs: number
+  cooldownMs: number
+  origin: THREE.Vector3
+  direction: THREE.Vector3
+  length: number
+  intensity: number
+}
+
+export function createNeonLaserSystem(options: NeonLaserOptions){
+  const state: NeonLaserState = {
+    active: false,
+    remainingMs: 0,
+    cooldownMs: 0,
+    origin: new THREE.Vector3(),
+    direction: new THREE.Vector3(0, 0, -1),
+    length: options.range,
+    intensity: 0,
+  }
+
+  const hitPoint = new THREE.Vector3()
+
+  function refreshRay(context: WeaponContext){
+    state.origin.copy(context.position)
+    state.direction.copy(context.forward).normalize()
+    state.length = options.range
+    hitPoint.copy(state.direction).multiplyScalar(state.length)
+    state.intensity = Math.exp(-options.attenuation * state.length)
+  }
+
+  function update(context: WeaponContext){
+    //1.- Tick the cooldown timer so subsequent trigger pulls respect the gating window.
+    if (state.cooldownMs > 0){
+      state.cooldownMs = Math.max(0, state.cooldownMs - context.dt * 1000)
+    }
+
+    if (state.active){
+      state.remainingMs = Math.max(0, state.remainingMs - context.dt * 1000)
+      refreshRay(context)
+      if (state.remainingMs === 0){
+        //2.- Automatically release the beam when its sustain window elapses.
+        state.active = false
+      }
+    }
+  }
+
+  function fire(context: WeaponContext){
+    if (state.cooldownMs > 0 || state.active){
+      return false
+    }
+    state.active = true
+    state.remainingMs = options.durationMs
+    state.cooldownMs = options.cooldownMs + options.durationMs
+    refreshRay(context)
+    return true
+  }
+
+  function sustain(context: WeaponContext){
+    //3.- Keep the ray anchored while the trigger remains held.
+    if (state.active){
+      refreshRay(context)
+    }
+  }
+
+  function release(){
+    //4.- Allow callers to terminate the beam early so burst firing becomes possible.
+    state.active = false
+    state.remainingMs = 0
+  }
+
+  return {
+    update,
+    fire,
+    sustain,
+    release,
+    get state(){ return state },
+    get cooldownMs(){ return state.cooldownMs },
+  }
+}

--- a/game/src/weapons/types.ts
+++ b/game/src/weapons/types.ts
@@ -1,0 +1,22 @@
+import * as THREE from 'three'
+
+//1.- Shared type for targetable entities used by the weapon simulations.
+export type WeaponTarget = {
+  id: string
+  position: THREE.Vector3
+  velocity: THREE.Vector3
+  alive: boolean
+}
+
+//2.- Context handed to weapons so they can reason about the shooter pose and available targets.
+export type WeaponContext = {
+  position: THREE.Vector3
+  forward: THREE.Vector3
+  dt: number
+  targets: WeaponTarget[]
+}
+
+//3.- Extension that provides optional terrain sampling used by ground-interacting ordnance.
+export type GroundedWeaponContext = WeaponContext & {
+  sampleGroundHeight?: (x: number, z: number) => number
+}


### PR DESCRIPTION
## Summary
- add dedicated weapon simulation modules for homing missiles, neon laser, bombs, and the gatling cannon
- integrate the simple vehicle controller with the weapon systems, ammo tracking, and HUD-facing state
- cover missile retargeting, laser cooldown gating, bomb detonation queries, and gatling overheat recovery with Vitest

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e462fa6b248329ad2a4e054eeae4bb