### PR TITLE
Add poly boss phases with adaptive difficulty scaling

### DIFF
--- a/game/src/enemies/bosses/poly-boss/phases.ts
+++ b/game/src/enemies/bosses/poly-boss/phases.ts
@@ -1,24 +1,306 @@
 import * as THREE from 'three'
+import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js'
+import { createEnemy } from '@/enemies/stellated-octahedron/behavior'
+import { applyBossDefeat, getDifficultyState, onDifficultyChange } from '@/engine/difficulty'
 
-export function createPolyBoss(scene: THREE.Scene, position: THREE.Vector3){
-  const geo = new THREE.IcosahedronGeometry(28, 1)
-  const mat = new THREE.MeshStandardMaterial({ color: 0x3344ff, roughness: 0.4, metalness: 0.3, emissive: 0x000033 })
-  const mesh = new THREE.Mesh(geo, mat)
-  mesh.position.copy(position)
-  scene.add(mesh)
-  const state = { phase: 1, hp: 600, t: 0 }
-  return {
-    mesh,
-    update(dt:number){
-      state.t += dt
-      mesh.rotation.y += dt*0.4
-      mesh.rotation.x += dt*0.2
-      // TODO: sweep lasers / spawn adds
-    },
-    onDeath(){
-      scene.remove(mesh)
-      mesh.geometry.dispose()
-      ;(mesh.material as THREE.Material).dispose?.()
+export type PolyBossPhase = 'shield' | 'assault' | 'core' | 'enrage'
+
+export type PolyBossOptions = {
+  stage?: number
+  addTarget?: THREE.Object3D
+  randomSeed?: number
+}
+
+type BeamController = {
+  pivot: THREE.Object3D
+  mesh: THREE.Mesh
+  angle: number
+  sweepOffset: number
+  speed: number
+}
+
+type BossState = {
+  phase: PolyBossPhase
+  hp: number
+  maxHp: number
+  shieldStrength: number
+  timeInPhase: number
+  stage: number
+  beams: BeamController[]
+  spawnTimer: number
+  enraged: boolean
+  difficulty: ReturnType<typeof getDifficultyState>
+}
+
+function seededRandom(seed: number): () => number {
+  //1.- Implement a small LCG so that randomly generated hulls remain deterministic for tests when a seed is supplied.
+  let value = (seed >>> 0) || 1
+  return () => {
+    value = (value * 1664525 + 1013904223) >>> 0
+    return (value & 0xfffffff) / 0xfffffff
+  }
+}
+
+function buildConvexHull(stage: number, seed?: number): THREE.BufferGeometry {
+  //1.- Create a seeded RNG if a caller wants deterministic hull generation.
+  const rand = seed !== undefined ? seededRandom(seed) : Math.random
+  const radius = 22 + stage * 4
+  const count = Math.min(28, 12 + stage * 3)
+  const points: THREE.Vector3[] = []
+  for (let i = 0; i < count; i++) {
+    //2.- Sample points on a sphere before jittering the radial distance to keep the hull convex but interesting.
+    const theta = rand() * Math.PI * 2
+    const phi = Math.acos(2 * rand() - 1)
+    const jitter = 0.6 + rand() * 0.4
+    const r = radius * jitter
+    const x = Math.sin(phi) * Math.cos(theta) * r
+    const y = Math.cos(phi) * r * 0.7
+    const z = Math.sin(phi) * Math.sin(theta) * r
+    points.push(new THREE.Vector3(x, y, z))
+  }
+  //3.- Feed the sampled points into the convex hull helper and smooth the result for proper lighting.
+  const geometry = new ConvexGeometry(points)
+  geometry.computeVertexNormals()
+  return geometry
+}
+
+function createShieldRing(stage: number): { group: THREE.Group, strength: number } {
+  //1.- Assemble a rotating array of hexagonal plates to serve as the boss shield visual.
+  const group = new THREE.Group()
+  const segmentCount = Math.min(10, 6 + stage)
+  const radius = 34 + stage * 2
+  for (let i = 0; i < segmentCount; i++) {
+    const angle = (i / segmentCount) * Math.PI * 2
+    const plate = new THREE.Mesh(
+      new THREE.CylinderGeometry(6, 4, 1.6, 6),
+      new THREE.MeshStandardMaterial({ color: 0x44bbff, emissive: 0x112244, transparent: true, opacity: 0.75 })
+    )
+    plate.position.set(Math.cos(angle) * radius, 0, Math.sin(angle) * radius)
+    plate.lookAt(new THREE.Vector3(0, 0, 0))
+    group.add(plate)
+  }
+  const strength = 180 + stage * 80
+  return { group, strength }
+}
+
+function createBeamArray(stage: number): BeamController[] {
+  //1.- Create sweeping beam pylons that orbit the boss while oscillating vertically.
+  const beams: BeamController[] = []
+  const baseCount = 2 + Math.floor(stage / 2)
+  for (let i = 0; i < baseCount; i++) {
+    const pivot = new THREE.Object3D()
+    const mesh = new THREE.Mesh(
+      new THREE.CylinderGeometry(2.4, 2.4, 120, 8, 1, true),
+      new THREE.MeshBasicMaterial({ color: 0xff6611, transparent: true, opacity: 0.55 })
+    )
+    mesh.position.x = 48 + stage * 4
+    mesh.rotation.z = Math.PI / 2
+    pivot.add(mesh)
+    beams.push({ pivot, mesh, angle: (i / baseCount) * Math.PI * 2, sweepOffset: i * 0.9, speed: 0.6 + stage * 0.08 })
+  }
+  return beams
+}
+
+function disposeObject(object: THREE.Object3D): void {
+  //1.- Traverse the hierarchy and release GPU resources associated with meshes.
+  object.traverse((child) => {
+    if (child instanceof THREE.Mesh) {
+      child.geometry.dispose()
+      const material = child.material
+      if (Array.isArray(material)) {
+        for (const mat of material) mat.dispose?.()
+      } else {
+        material.dispose?.()
+      }
+    }
+  })
+}
+
+function phaseToString(state: BossState): PolyBossPhase {
+  //1.- Expose the phase directly since we track it as a string literal internally.
+  return state.phase
+}
+
+export function createPolyBoss(scene: THREE.Scene, position: THREE.Vector3, options: PolyBossOptions = {}) {
+  //1.- Resolve configuration defaults before constructing the boss hierarchy.
+  const stage = Math.max(1, options.stage ?? 1)
+  const difficulty = getDifficultyState()
+  const hullMesh = new THREE.Mesh(
+    buildConvexHull(stage, options.randomSeed),
+    new THREE.MeshStandardMaterial({
+      color: 0x3344ff,
+      roughness: 0.35,
+      metalness: 0.45,
+      emissive: 0x05091a
+    })
+  )
+  const bossGroup = new THREE.Group()
+  bossGroup.add(hullMesh)
+  bossGroup.position.copy(position)
+
+  //2.- Prepare shield and beam attachments used by the phase logic.
+  const { group: shieldGroup, strength: baseShield } = createShieldRing(stage)
+  const beams = createBeamArray(stage)
+  for (const beam of beams) bossGroup.add(beam.pivot)
+  bossGroup.add(shieldGroup)
+
+  //3.- Add an inner core that only becomes vulnerable during later phases.
+  const core = new THREE.Mesh(
+    new THREE.SphereGeometry(9 + stage * 0.8, 24, 24),
+    new THREE.MeshStandardMaterial({ color: 0xff3366, emissive: 0x440011, metalness: 0.3, roughness: 0.35 })
+  )
+  core.visible = false
+  bossGroup.add(core)
+
+  scene.add(bossGroup)
+
+  const state: BossState = {
+    phase: 'shield',
+    hp: 1200 + stage * 420,
+    maxHp: 1200 + stage * 420,
+    shieldStrength: baseShield,
+    timeInPhase: 0,
+    stage,
+    beams,
+    spawnTimer: 4,
+    enraged: false,
+    difficulty
+  }
+
+  let unsubscribe = onDifficultyChange((next) => {
+    //1.- Capture live difficulty adjustments so spawn cadence reacts mid-fight.
+    state.difficulty = next
+  })
+
+  function spawnAdd(): void {
+    //1.- Spawn a reinforcement enemy using the difficulty unlocked roster.
+    const add = createEnemy(
+      scene,
+      bossGroup.position.clone().add(new THREE.Vector3((Math.random() - 0.5) * 160, 40 + Math.random() * 40, (Math.random() - 0.5) * 160)),
+      { difficulty: state.difficulty, variant: state.enraged ? 'strafer' : 'pursuer' }
+    )
+    if (options.addTarget) {
+      add.target = options.addTarget
     }
   }
+
+  function advancePhase(next: PolyBossPhase): void {
+    //1.- Swap to the requested phase and reset the timer bookkeeping.
+    if (state.phase === next) return
+    state.phase = next
+    state.timeInPhase = 0
+
+    //2.- Toggle visuals based on the current phase specification.
+    if (next === 'shield') {
+      shieldGroup.visible = true
+      core.visible = false
+    } else if (next === 'assault') {
+      shieldGroup.visible = false
+      core.visible = false
+    } else {
+      shieldGroup.visible = false
+      core.visible = true
+    }
+  }
+
+  function updateBeams(dt: number): void {
+    //1.- Animate every beam pivot to achieve sweeping arcs that track the player area.
+    for (const beam of state.beams) {
+      beam.angle += dt * beam.speed * (state.enraged ? 2.2 : 1)
+      beam.pivot.rotation.y = beam.angle
+      beam.pivot.rotation.x = Math.sin(state.timeInPhase * 0.9 + beam.sweepOffset) * (state.enraged ? 0.9 : 0.6)
+    }
+  }
+
+  function updatePhase(dt: number): void {
+    //1.- Advance the timer and evaluate transitions in priority order.
+    state.timeInPhase += dt
+    const hpRatio = state.hp / state.maxHp
+
+    if (state.phase === 'shield') {
+      shieldGroup.rotation.y += dt * 0.8
+      if (state.shieldStrength <= 0 || state.timeInPhase > 18) {
+        advancePhase('assault')
+      }
+    } else if (state.phase === 'assault') {
+      updateBeams(dt)
+      state.spawnTimer -= dt / state.difficulty.spawnIntervalMultiplier
+      if (state.spawnTimer <= 0) {
+        spawnAdd()
+        state.spawnTimer = Math.max(2.4, 5.5 * state.difficulty.spawnIntervalMultiplier)
+      }
+      if (hpRatio < 0.62 || state.timeInPhase > 24) {
+        advancePhase('core')
+      }
+    } else if (state.phase === 'core') {
+      updateBeams(dt)
+      hullMesh.rotation.y += dt * 0.3
+      if (hpRatio < 0.28 || state.timeInPhase > 16) {
+        state.enraged = true
+        advancePhase('enrage')
+      }
+    } else if (state.phase === 'enrage') {
+      updateBeams(dt)
+      hullMesh.rotation.y += dt * 0.7
+      state.spawnTimer -= dt / (state.difficulty.spawnIntervalMultiplier * 0.7)
+      if (state.spawnTimer <= 0) {
+        spawnAdd()
+        state.spawnTimer = Math.max(1.4, 4.2 * state.difficulty.spawnIntervalMultiplier)
+      }
+    }
+  }
+
+  function takeDamage(amount: number): void {
+    //1.- Route damage to shields first before allowing the hull to take meaningful losses.
+    if (state.shieldStrength > 0) {
+      const absorbed = Math.min(state.shieldStrength, amount)
+      state.shieldStrength -= absorbed
+      amount -= absorbed
+      if (state.shieldStrength <= 0 && state.phase === 'shield') {
+        advancePhase('assault')
+      }
+    }
+    if (amount > 0) {
+      const multiplier = state.phase === 'core' ? 1.4 : state.enraged ? 1.2 : 1
+      state.hp = Math.max(0, state.hp - amount * multiplier)
+    }
+  }
+
+  const api = {
+    mesh: bossGroup,
+    getPhase(): PolyBossPhase {
+      //1.- Allow external systems (and tests) to query the live phase label.
+      return phaseToString(state)
+    },
+    getStateSnapshot() {
+      //1.- Expose immutable state data for diagnostics without breaking encapsulation.
+      return {
+        phase: state.phase,
+        hp: state.hp,
+        shieldStrength: state.shieldStrength,
+        timeInPhase: state.timeInPhase,
+        enraged: state.enraged
+      }
+    },
+    takeDamage(amount: number) {
+      //1.- Forward incoming damage values through the shield/hull resolution helper.
+      takeDamage(amount)
+    },
+    update(dt: number) {
+      //1.- Rotate the entire boss hull for motion and tick the active phase logic each frame.
+      hullMesh.rotation.y += dt * 0.25
+      hullMesh.rotation.x += dt * 0.12
+      updatePhase(dt)
+    },
+    onDeath() {
+      //1.- Remove all scene resources and propagate the defeat to the shared difficulty system.
+      scene.remove(bossGroup)
+      disposeObject(bossGroup)
+      unsubscribe?.()
+      unsubscribe = undefined
+      applyBossDefeat(stage)
+    }
+  }
+
+  return api
 }

--- a/game/src/enemies/stellated-octahedron/behavior.test.ts
+++ b/game/src/enemies/stellated-octahedron/behavior.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as THREE from 'three'
 import { createEnemy, updateEnemies } from './behavior'
+import { getDifficultyState } from '@/engine/difficulty'
 import { createSpawner } from '@/spawn/spawnTable'
 
 describe('stellated octahedron enemy', () => {
@@ -30,7 +31,7 @@ describe('stellated octahedron enemy', () => {
     enemy.target = target
 
     //2.- Advance the simulation and confirm the enemy drifted towards the target.
-    updateEnemies(scene, 0.5)
+    updateEnemies(scene, 0.5, getDifficultyState())
     expect(enemy.mesh.position.x).toBeGreaterThan(0)
 
     //3.- Invoke the death handler and ensure cleanup removes the mesh from the scene.

--- a/game/src/engine/difficulty.ts
+++ b/game/src/engine/difficulty.ts
@@ -1,0 +1,113 @@
+import type { Vector3 } from 'three'
+
+export type DifficultyEnvironmentState = {
+  propDensity: number
+  windStrength: number
+  canyonWidth: number
+}
+
+export type DifficultyState = {
+  enemyHpMultiplier: number
+  enemyDpsMultiplier: number
+  spawnIntervalMultiplier: number
+  enemyAccuracy: number
+  unlockedAddTypes: number
+  bossClears: number
+  lastClearedStage: number
+  environment: DifficultyEnvironmentState
+}
+
+type DifficultyListener = (state: DifficultyState) => void
+
+const BASE_STATE: DifficultyState = {
+  enemyHpMultiplier: 1,
+  enemyDpsMultiplier: 1,
+  spawnIntervalMultiplier: 1,
+  enemyAccuracy: 0.55,
+  unlockedAddTypes: 1,
+  bossClears: 0,
+  lastClearedStage: 0,
+  environment: {
+    propDensity: 0.6,
+    windStrength: 0.4,
+    canyonWidth: 1
+  }
+}
+
+let state: DifficultyState = structuredClone(BASE_STATE)
+const listeners = new Set<DifficultyListener>()
+
+function cloneState(): DifficultyState {
+  //1.- Provide callers with a defensive copy so internal difficulty bookkeeping remains encapsulated.
+  return {
+    enemyHpMultiplier: state.enemyHpMultiplier,
+    enemyDpsMultiplier: state.enemyDpsMultiplier,
+    spawnIntervalMultiplier: state.spawnIntervalMultiplier,
+    enemyAccuracy: state.enemyAccuracy,
+    unlockedAddTypes: state.unlockedAddTypes,
+    bossClears: state.bossClears,
+    lastClearedStage: state.lastClearedStage,
+    environment: { ...state.environment }
+  }
+}
+
+function emit(): void {
+  //1.- Notify every subscriber using the freshly cloned snapshot to prevent accidental mutation.
+  const snapshot = cloneState()
+  for (const listener of listeners) {
+    listener(snapshot)
+  }
+}
+
+export function getDifficultyState(): DifficultyState {
+  //1.- Surface the current state without exposing the mutable singleton to consumers.
+  return cloneState()
+}
+
+export function onDifficultyChange(listener: DifficultyListener): () => void {
+  //1.- Register listeners lazily and hand back an unsubscribe hook for lifecycle management.
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function applyBossDefeat(stage: number): DifficultyState {
+  //1.- Increment the defeat counter before computing the compound scaling adjustments.
+  state.bossClears += 1
+  state.lastClearedStage = Math.max(state.lastClearedStage, stage)
+
+  //2.- Increase enemy durability and damage output multiplicatively to keep pressure scaling noticeable.
+  const hpScalar = 1 + 0.08 + stage * 0.015
+  const dpsScalar = 1 + 0.05 + stage * 0.01
+  state.enemyHpMultiplier = Math.min(6, state.enemyHpMultiplier * hpScalar)
+  state.enemyDpsMultiplier = Math.min(5, state.enemyDpsMultiplier * dpsScalar)
+
+  //3.- Tighten spawn intervals while ensuring they do not collapse entirely.
+  state.spawnIntervalMultiplier = Math.max(0.32, state.spawnIntervalMultiplier * 0.9)
+
+  //4.- Improve AI accuracy and unlock extra add archetypes gradually.
+  state.enemyAccuracy = Math.min(0.98, state.enemyAccuracy + 0.04 + stage * 0.005)
+  const unlocked = 1 + Math.floor(state.bossClears / 2)
+  state.unlockedAddTypes = Math.min(3, Math.max(state.unlockedAddTypes, unlocked))
+
+  //5.- Enrich the world ambience so victories feel impactful in the overworld streaming logic.
+  state.environment.propDensity = Math.min(3, state.environment.propDensity + 0.18 + stage * 0.02)
+  state.environment.windStrength = Math.min(4, state.environment.windStrength + 0.16 + stage * 0.01)
+  state.environment.canyonWidth = Math.min(3.2, state.environment.canyonWidth + 0.12 + stage * 0.008)
+
+  //6.- Emit the updated snapshot to listeners and provide the caller the same information for chaining.
+  emit()
+  return cloneState()
+}
+
+export function resetDifficultyState(): void {
+  //1.- Restore baseline values primarily for deterministic testing scenarios.
+  state = structuredClone(BASE_STATE)
+  emit()
+}
+
+export function applyEnvironmentVectorAttenuation(vec: Vector3): Vector3 {
+  //1.- Adjust a direction vector to simulate wind influence according to the current scaling knobs.
+  const { windStrength } = state.environment
+  vec.multiplyScalar(1 + windStrength * 0.05)
+  return vec
+}

--- a/game/src/spawn/spawnTable.ts
+++ b/game/src/spawn/spawnTable.ts
@@ -1,22 +1,43 @@
 import * as THREE from 'three'
 import { createEnemy, updateEnemies } from '@/enemies/stellated-octahedron/behavior'
+import { getDifficultyState, onDifficultyChange } from '@/engine/difficulty'
 
 export function createSpawner(scene: THREE.Scene, player: any, streamer: any){
   let t = 0
+  let difficulty = getDifficultyState()
+  const unsubscribe = onDifficultyChange((next) => {
+    //1.- Store the fresh difficulty snapshot to keep cadence, density, and unlocks in sync.
+    difficulty = next
+  })
+
+  function spawnWave(center: THREE.Vector3){
+    //1.- Create one or more adds using offsets that widen with each difficulty unlock.
+    const count = difficulty.unlockedAddTypes >= 3 ? 3 : difficulty.unlockedAddTypes === 2 ? 2 : 1
+    for (let i = 0; i < count; i++) {
+      const spread = 60 + i * 20
+      const offset = new THREE.Vector3((Math.random() - 0.5) * spread, 0, (Math.random() - 0.5) * spread)
+      const pos = center.clone().add(offset)
+      pos.y = streamer.queryHeight(pos.x,pos.z) + 30 + Math.random() * 50
+      const enemy = createEnemy(scene, pos, { difficulty })
+      enemy.target = player.group
+    }
+  }
+
   return {
     update(dt:number, stage:number){
       //1.- Ensure previously spawned enemies pursue their assigned targets before handling cadence logic.
-      updateEnemies(scene, dt)
+      updateEnemies(scene, dt, difficulty)
       t += dt
-      if (t > Math.max(0.6, 2.5 - stage*0.2)){
+      const interval = Math.max(0.45, (2.8 - stage * 0.18) * difficulty.spawnIntervalMultiplier)
+      if (t > interval){
         t = 0
-        const pos = player.group.position.clone().addScaledVector(player.group.getWorldDirection(new THREE.Vector3()), -200)
-        pos.x += (Math.random()-0.5)*200
-        pos.z += (Math.random()-0.5)*200
-        pos.y = streamer.queryHeight(pos.x,pos.z) + 30 + Math.random()*50
-        const e = createEnemy(scene, pos)
-        e.target = player.group
+        const pos = player.group.position.clone().addScaledVector(player.group.getWorldDirection(new THREE.Vector3()), -220)
+        spawnWave(pos)
       }
+    },
+    dispose(){
+      //1.- Release the difficulty subscription when the spawner lifecycle concludes.
+      unsubscribe?.()
     }
   }
 }

--- a/game/src/world/chunks/streamer.ts
+++ b/game/src/world/chunks/streamer.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import { heightAt, normalAt } from './generateHeight'
+import { getDifficultyState, onDifficultyChange } from '@/engine/difficulty'
 
 const CHUNK_SIZE = 128
 const VERTS = 64
@@ -7,6 +8,8 @@ const HALF = CHUNK_SIZE/2
 
 function key(ix:number, iz:number){ return ix+','+iz }
 function toChunk(x:number){ return Math.floor(x / CHUNK_SIZE) }
+
+let envCache = getDifficultyState().environment
 
 function buildChunk(ix:number, iz:number){
   const g = new THREE.PlaneGeometry(CHUNK_SIZE, CHUNK_SIZE, VERTS, VERTS)
@@ -29,14 +32,75 @@ function buildChunk(ix:number, iz:number){
   const mesh = new THREE.Mesh(g, mat)
   mesh.position.set(ix*CHUNK_SIZE, 0, iz*CHUNK_SIZE)
   mesh.receiveShadow = true
-  mesh.userData = { ix, iz }
+  mesh.userData = { ix, iz, decorations: [] as THREE.Object3D[] }
+  decorateChunk(mesh)
   return mesh
+}
+
+function decorateChunk(mesh: THREE.Mesh){
+  //1.- Clear any existing decoration objects so density changes can rebuild them idempotently.
+  const previous: THREE.Object3D[] = mesh.userData.decorations ?? []
+  for (const obj of previous) {
+    mesh.remove(obj)
+    obj.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.geometry.dispose()
+        const material = child.material
+        if (Array.isArray(material)) {
+          for (const mat of material) mat.dispose?.()
+        } else {
+          material.dispose?.()
+        }
+      }
+    })
+  }
+
+  const decorations: THREE.Object3D[] = []
+  const { propDensity, windStrength } = envCache
+  const propCount = Math.max(0, Math.round(propDensity * 4))
+  for (let i = 0; i < propCount; i++) {
+    const rock = new THREE.Mesh(
+      new THREE.IcosahedronGeometry(2 + Math.random() * 3, 0),
+      new THREE.MeshStandardMaterial({ color: 0x4a4f44, roughness: 0.8 })
+    )
+    const localX = (Math.random() - 0.5) * CHUNK_SIZE
+    const localZ = (Math.random() - 0.5) * CHUNK_SIZE
+    const worldX = mesh.userData.ix * CHUNK_SIZE + localX
+    const worldZ = mesh.userData.iz * CHUNK_SIZE + localZ
+    const baseHeight = heightAt(worldX, worldZ) - mesh.position.y
+    rock.position.set(localX, baseHeight + 1.6, localZ)
+    decorations.push(rock)
+  }
+
+  const windCount = Math.max(1, Math.round(windStrength))
+  for (let i = 0; i < windCount; i++) {
+    const column = new THREE.Mesh(
+      new THREE.CylinderGeometry(3 + windStrength, 3 + windStrength, 90 + windStrength * 10, 12, 1, true),
+      new THREE.MeshStandardMaterial({ color: 0x88ccff, transparent: true, opacity: 0.18 })
+    )
+    const localX = (Math.random() - 0.5) * CHUNK_SIZE
+    const localZ = (Math.random() - 0.5) * CHUNK_SIZE
+    column.position.set(localX, 45, localZ)
+    column.rotation.x = Math.PI / 2
+    decorations.push(column)
+  }
+
+  for (const deco of decorations) {
+    mesh.add(deco)
+  }
+  mesh.userData.decorations = decorations
 }
 
 export function createStreamer(scene: THREE.Scene){
   const chunks = new Map<string, THREE.Mesh>()
   const activeRadius = 2 // 5x5 ring (0,1,2)
   const tmp = new THREE.Vector3()
+  let environmentDirty = false
+  const unsubscribe = onDifficultyChange((state) => {
+    //1.- Mark existing chunks dirty so the next update rebuilds their decoration sets.
+    envCache = state.environment
+    environmentDirty = true
+  })
 
   function ensure(ix:number, iz:number){
     const k = key(ix, iz)
@@ -54,6 +118,21 @@ export function createStreamer(scene: THREE.Scene){
         scene.remove(m)
         m.geometry.dispose()
         ;(m.material as THREE.Material).dispose?.()
+        const decorations: THREE.Object3D[] = m.userData.decorations ?? []
+        for (const deco of decorations) {
+          scene.remove(deco)
+          deco.traverse((child) => {
+            if (child instanceof THREE.Mesh) {
+              child.geometry.dispose()
+              const material = child.material
+              if (Array.isArray(material)) {
+                for (const mat of material) mat.dispose?.()
+              } else {
+                material.dispose?.()
+              }
+            }
+          })
+        }
         chunks.delete(k)
       }
     }
@@ -69,6 +148,12 @@ export function createStreamer(scene: THREE.Scene){
         }
       }
       prune(pos.x, pos.z)
+      if (environmentDirty) {
+        for (const mesh of chunks.values()) {
+          decorateChunk(mesh)
+        }
+        environmentDirty = false
+      }
     },
     queryHeight(x:number,z:number){
       return heightAt(x,z)
@@ -76,6 +161,10 @@ export function createStreamer(scene: THREE.Scene){
     queryNormal(x:number,z:number){
       const n = normalAt(x,z)
       return tmp.set(n.x, n.y, n.z)
+    },
+    dispose(){
+      //1.- Allow manual disposal to release the difficulty subscription when the streamer is torn down.
+      unsubscribe?.()
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,20 @@
 {
-  "name": "DriftPursuit",
+  "name": "driftpursuit",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "driftpursuit",
+      "version": "0.0.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.9.0"
+        "@bufbuild/protobuf": "^2.9.0",
+        "three": "^0.162.0"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -13,6 +22,280 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
       "integrity": "sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.14.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.162.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
+      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,16 @@
 {
+  "name": "driftpursuit",
+  "version": "0.0.0",
   "dependencies": {
-    "@bufbuild/protobuf": "^2.9.0"
+    "@bufbuild/protobuf": "^2.9.0",
+    "three": "^0.162.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.4.5"
+  },
+  "scripts": {
+    "test": "node -r ts-node/register -r tsconfig-paths/register tests/runAllTests.ts"
   }
 }

--- a/tests/runAllTests.ts
+++ b/tests/runAllTests.ts
@@ -1,0 +1,20 @@
+import { testBossPhasesStateMachine } from './specs/bossPhases.test'
+import { testDifficultyScalingAdjustments } from './specs/difficultyScaling.test'
+import { testEnvironmentAdjustments } from './specs/environmentAdjustments.test'
+
+async function main(): Promise<void> {
+  //1.- Execute the deterministic boss phase assertions.
+  testBossPhasesStateMachine()
+  //2.- Validate difficulty scaling math remains monotonic as new clears accrue.
+  testDifficultyScalingAdjustments()
+  //3.- Await the asynchronous environment inspection so decorators refresh before checking counts.
+  await testEnvironmentAdjustments()
+  //4.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
+  console.log('All tests passed')
+}
+
+main().catch((error) => {
+  //1.- Surface the failure and exit non-zero to ensure CI is aware.
+  console.error('Test failure:', error)
+  process.exitCode = 1
+})

--- a/tests/specs/bossPhases.test.ts
+++ b/tests/specs/bossPhases.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import * as THREE from 'three'
+import { createPolyBoss } from '@/enemies/bosses/poly-boss/phases'
+import { getDifficultyState, resetDifficultyState } from '@/engine/difficulty'
+
+export function testBossPhasesStateMachine(): void {
+  //1.- Start from a clean slate so prior tests do not leak altered difficulty state.
+  resetDifficultyState()
+  const scene = new THREE.Scene()
+  const boss = createPolyBoss(scene, new THREE.Vector3(), { stage: 2, randomSeed: 42 })
+
+  //2.- Validate the boss opens in the shield phase and reacts when the barrier is depleted.
+  boss.update(0.16)
+  assert.equal(boss.getPhase(), 'shield')
+  boss.takeDamage(800)
+  boss.update(0.16)
+  assert.equal(boss.getPhase(), 'assault')
+
+  //3.- Strip additional health to trigger the core exposure stage and verify the enraged flip once low.
+  boss.takeDamage(1200)
+  boss.update(0.16)
+  assert.equal(boss.getPhase(), 'core')
+  boss.takeDamage(200)
+  for (let i = 0; i < 10; i++) boss.update(0.5)
+  assert.equal(boss.getPhase(), 'enrage')
+  const snapshot = boss.getStateSnapshot()
+  assert.equal(snapshot.enraged, true)
+
+  //4.- Destroy the boss and confirm the defeat propagated to the shared difficulty tracker.
+  boss.onDeath()
+  const difficulty = getDifficultyState()
+  assert.equal(difficulty.bossClears > 0, true)
+  assert.equal(scene.children.includes(boss.mesh), false)
+}

--- a/tests/specs/difficultyScaling.test.ts
+++ b/tests/specs/difficultyScaling.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { applyBossDefeat, getDifficultyState, resetDifficultyState } from '@/engine/difficulty'
+
+export function testDifficultyScalingAdjustments(): void {
+  //1.- Reset the singleton state to capture deterministic baseline values.
+  resetDifficultyState()
+  const base = getDifficultyState()
+
+  //2.- Apply multiple boss defeats and validate each key multiplier increases as expected.
+  const afterFirst = applyBossDefeat(3)
+  const afterSecond = applyBossDefeat(4)
+  assert(afterFirst.enemyHpMultiplier > base.enemyHpMultiplier)
+  assert(afterSecond.enemyDpsMultiplier > afterFirst.enemyDpsMultiplier)
+  assert(afterSecond.spawnIntervalMultiplier < base.spawnIntervalMultiplier)
+
+  //3.- Confirm auxiliary systems (accuracy, unlocks, environment) scale together for downstream consumers.
+  assert(afterSecond.enemyAccuracy > base.enemyAccuracy)
+  assert(afterSecond.unlockedAddTypes >= afterFirst.unlockedAddTypes)
+  assert(afterSecond.environment.propDensity > base.environment.propDensity)
+}

--- a/tests/specs/environmentAdjustments.test.ts
+++ b/tests/specs/environmentAdjustments.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import * as THREE from 'three'
+import { createStreamer } from '@/world/chunks/streamer'
+import { applyBossDefeat, resetDifficultyState } from '@/engine/difficulty'
+
+export async function testEnvironmentAdjustments(): Promise<void> {
+  //1.- Initialise a streamer and materialise the origin chunk at baseline difficulty.
+  resetDifficultyState()
+  const scene = new THREE.Scene()
+  const streamer = createStreamer(scene)
+  const focus = new THREE.Vector3(0, 0, 0)
+  streamer.update(focus)
+  const initialChunk = scene.children.find((child) => (child as any).userData?.decorations) as THREE.Mesh | undefined
+  assert(initialChunk, 'Expected a terrain chunk to be present after initial update')
+  const initialDecorations = (initialChunk!.userData.decorations as THREE.Object3D[]).length
+
+  //2.- Escalate difficulty to trigger higher environmental density and process the refresh tick.
+  applyBossDefeat(5)
+  streamer.update(focus)
+  const refreshedDecorations = (initialChunk!.userData.decorations as THREE.Object3D[]).length
+  assert(refreshedDecorations >= initialDecorations)
+
+  //3.- Dispose the streamer to avoid leaking difficulty subscriptions once the test concludes.
+  streamer.dispose?.()
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["game/src/*"]
+    }
+  },
+  "include": ["game/src", "tests"]
+}


### PR DESCRIPTION
## Summary
- Implement a multi-phase poly boss that generates stage-aware convex hulls, rotates shields, sweeps beams, spawns reinforcements, and enrages while notifying the global difficulty system on defeat.
- Introduce a central difficulty manager that scales enemy stats, spawn cadence, and unlocked add counts while propagating updates to spawners, enemy controllers, and world generation.
- Enrich streamed terrain chunks with density-aware props and wind columns and add automated tests for boss phases, difficulty progression, and environment refresh logic.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e46a32541883298e0f28fc9f54680a