### PR TITLE
Add ability slots with unlimited meteor missiles

### DIFF
--- a/game/src/__tests__/abilities.test.ts
+++ b/game/src/__tests__/abilities.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { createSupportAbilitySystem } from '@/vehicles/shared/supportAbilities'
+
+describe('support ability system', () => {
+  it('activates shield for a fixed duration', () => {
+    const abilities = createSupportAbilitySystem({ shieldDurationMs: 1000, shieldCooldownMs: 2000 })
+
+    const fired = abilities.triggerShield()
+    expect(fired).toBe(true)
+    expect(abilities.state.shield.active).toBe(true)
+
+    for (let i = 0; i < 12; i++){
+      abilities.update(0.1)
+    }
+
+    //1.- After the timer lapses the shield should automatically retract.
+    expect(abilities.state.shield.active).toBe(false)
+    expect(abilities.state.shield.cooldownRemainingMs).toBeGreaterThan(0)
+  })
+
+  it('heals hull while respecting cooldown gates', () => {
+    const abilities = createSupportAbilitySystem({ healAmount: 20, healCooldownMs: 1000, maxHull: 100 })
+
+    abilities.state.heal.hull = 40
+    const first = abilities.triggerHeal()
+    expect(first).toBe(true)
+    expect(abilities.state.heal.hull).toBe(60)
+
+    const second = abilities.triggerHeal()
+    //2.- Immediate reactivation should fail until the cooldown clears.
+    expect(second).toBe(false)
+
+    abilities.update(1.2)
+    expect(abilities.triggerHeal()).toBe(true)
+    expect(Math.round(abilities.state.heal.hull)).toBeGreaterThanOrEqual(80)
+    expect(abilities.state.heal.hull).toBeLessThanOrEqual(abilities.state.heal.maxHull)
+  })
+
+  it('ultimate grants concurrent shield and dash uptime', () => {
+    const abilities = createSupportAbilitySystem({
+      ultimateDurationMs: 1500,
+      ultimateCooldownMs: 4000,
+      ultimateShieldBonusMs: 1500,
+      ultimateDashBonusMs: 1500,
+      dashDurationMs: 800,
+      dashCooldownMs: 1200,
+    })
+
+    const fired = abilities.triggerUltimate()
+    expect(fired).toBe(true)
+    expect(abilities.state.ultimate.active).toBe(true)
+    expect(abilities.state.shield.active).toBe(true)
+    expect(abilities.state.dash.active).toBe(true)
+
+    for (let i = 0; i < 20; i++){
+      abilities.update(0.1)
+    }
+
+    //3.- Once elapsed the ability must return to standby with cooldown applied.
+    expect(abilities.state.ultimate.active).toBe(false)
+    expect(abilities.state.ultimate.cooldownRemainingMs).toBeGreaterThan(0)
+    expect(abilities.state.shield.active).toBe(false)
+    expect(abilities.state.dash.active).toBe(false)
+  })
+})
+

--- a/game/src/__tests__/weapons.test.ts
+++ b/game/src/__tests__/weapons.test.ts
@@ -136,6 +136,35 @@ describe('meteor missile system', () => {
     //2.- Without a contact to chase the missile should be removed once ignition completes.
     expect(system.activeCount).toBe(0)
   })
+
+  it('supports unlimited ammunition when configured with infinity', () => {
+    const system = createMeteorMissileSystem({
+      maxConcurrent: 1,
+      cooldownMs: 0,
+      ammo: Number.POSITIVE_INFINITY,
+      ejectionDurationMs: 200,
+      ejectionSpeed: 30,
+      burnSpeed: 180,
+      navigationConstant: 3,
+      detonationRadius: 5,
+      smokeTrailIntervalMs: 50,
+      maxLifetimeMs: 4000,
+    })
+
+    const target: WeaponTarget = {
+      id: 'alpha',
+      position: new THREE.Vector3(0, 0, -200),
+      velocity: new THREE.Vector3(),
+      alive: true,
+    }
+
+    const context = makeContext({ targets: [target] })
+
+    const fired = system.tryFire(context)
+    expect(fired.fired).toBe(true)
+    //3.- Firing should not reduce the ammo counter when using an infinite pool.
+    expect(system.ammo).toBe(Number.POSITIVE_INFINITY)
+  })
 })
 
 describe('neon laser system', () => {

--- a/game/src/components/HUD.tsx
+++ b/game/src/components/HUD.tsx
@@ -11,6 +11,11 @@ type HudState = {
   missiles: number
   laserCooldown: number
   bombArmed: boolean
+  ability: string
+  shieldActive: boolean
+  dashActive: boolean
+  ultimateActive: boolean
+  hull: number
 }
 
 export function HUD({ getState, actions }: { getState: () => HudState | undefined, actions: () => any }) {
@@ -34,10 +39,14 @@ export function HUD({ getState, actions }: { getState: () => HudState | undefine
         <div>SCORE: <b>{state?.score ?? 0}</b></div>
       </div>
       <div style={{ position:'absolute', right:16, top:12, textAlign:'right', fontFamily:'monospace' }}>
-        <div>WEAPON: <b>{state?.weapon ?? 'GATLING'}</b></div>
-        <div>AMMO: <b>{state?.ammo ?? 0}</b></div>
-        <div>MIS: <b>{state?.missiles ?? 0}</b></div>
+        <div>ABILITY: <b>{state?.ability ?? 'GATLING'}</b></div>
+        <div>AMMO: <b>{state?.ammo === Infinity ? '∞' : state?.ammo ?? 0}</b></div>
+        <div>MIS: <b>{state?.missiles === Infinity ? '∞' : state?.missiles ?? 0}</b></div>
         <div>LASER CD: <b>{Math.max(0, (state?.laserCooldown ?? 0)/1000).toFixed(1)}</b>s</div>
+        <div>HULL: <b>{state ? Math.round(state.hull) : 0}</b></div>
+        <div>SHIELD: <b>{state?.shieldActive ? 'ON' : 'OFF'}</b></div>
+        <div>DASH: <b>{state?.dashActive ? 'ON' : 'OFF'}</b></div>
+        <div>ULT: <b>{state?.ultimateActive ? 'ON' : 'OFF'}</b></div>
       </div>
       <div style={{ position:'absolute', inset:0, display:'grid', placeItems:'center', opacity:0.85 }}>
         <div style={{
@@ -46,7 +55,7 @@ export function HUD({ getState, actions }: { getState: () => HudState | undefine
         }}/>
       </div>
       <div style={{ position:'absolute', left:'50%', top:'50%', transform:'translate(-50%, -50%) translateY(32px)', fontSize:12, opacity:.6 }}>
-        move: mouse • throttle: W/S • roll: Q/E • yaw: A/D • boost: Shift • fire: Space • bomb: F • 1..4 switch
+        move: mouse • throttle: W/S • roll: Q/E • yaw: A/D • boost: Shift • fire: Space • slots: 1..9
       </div>
     </div>
   )

--- a/game/src/engine/bootstrap.ts
+++ b/game/src/engine/bootstrap.ts
@@ -21,6 +21,11 @@ export type GameAPI = {
     missiles: number
     laserCooldown: number
     bombArmed: boolean
+    ability: string
+    shieldActive: boolean
+    dashActive: boolean
+    ultimateActive: boolean
+    hull: number
     difficulty: ReturnType<typeof getDifficultyState>
   }
   ingestWorldDiff: (diff: BrokerWorldDiffEnvelope) => void
@@ -128,6 +133,11 @@ export function initGame(container: HTMLDivElement, opts = DEFAULT_SCENE_OPTS, o
       missiles: player.controller.missiles,
       laserCooldown: player.controller.laserCooldownMs,
       bombArmed: player.controller.bombArmed,
+      ability: player.controller.weaponName,
+      shieldActive: player.controller.shieldActive,
+      dashActive: player.controller.dashActive,
+      ultimateActive: player.controller.ultimateActive,
+      hull: player.controller.hull,
       difficulty: difficultyState
     }),
     ingestWorldDiff: (diff) => {

--- a/game/src/vehicles/shared/abilityVisuals.ts
+++ b/game/src/vehicles/shared/abilityVisuals.ts
@@ -1,0 +1,73 @@
+import * as THREE from 'three'
+import type { SupportAbilityState } from '@/vehicles/shared/supportAbilities'
+
+export type AbilityVisuals = {
+  update: (state: SupportAbilityState, parent: THREE.Group) => void
+  dispose: (parent: THREE.Group) => void
+}
+
+export function createAbilityVisuals(group: THREE.Group): AbilityVisuals {
+  const shieldGeometry = new THREE.SphereGeometry(3.5, 24, 16)
+  const shieldMaterial = new THREE.MeshBasicMaterial({ color: 0x4cbcff, transparent: true, opacity: 0.28, wireframe: true })
+  const shieldMesh = new THREE.Mesh(shieldGeometry, shieldMaterial)
+  shieldMesh.visible = false
+  group.add(shieldMesh)
+
+  const healGeometry = new THREE.RingGeometry(1.2, 1.9, 32)
+  const healMaterial = new THREE.MeshBasicMaterial({ color: 0x66ff9c, side: THREE.DoubleSide, transparent: true, opacity: 0.6 })
+  const healMesh = new THREE.Mesh(healGeometry, healMaterial)
+  healMesh.rotation.x = Math.PI / 2
+  healMesh.position.y = -0.6
+  healMesh.visible = false
+  group.add(healMesh)
+
+  const dashGeometry = new THREE.ConeGeometry(0.9, 3.6, 20)
+  const dashMaterial = new THREE.MeshBasicMaterial({ color: 0xffe066, transparent: true, opacity: 0.45 })
+  const dashMesh = new THREE.Mesh(dashGeometry, dashMaterial)
+  dashMesh.rotation.x = Math.PI
+  dashMesh.position.z = 2.2
+  dashMesh.visible = false
+  group.add(dashMesh)
+
+  const ultimateGeometry = new THREE.TorusGeometry(2.8, 0.18, 16, 36)
+  const ultimateMaterial = new THREE.MeshBasicMaterial({ color: 0xff47c2, transparent: true, opacity: 0.5 })
+  const ultimateMesh = new THREE.Mesh(ultimateGeometry, ultimateMaterial)
+  ultimateMesh.rotation.x = Math.PI / 2
+  ultimateMesh.visible = false
+  group.add(ultimateMesh)
+
+  function update(state: SupportAbilityState, parent: THREE.Group) {
+    //1.- Follow the owning craft so each indicator hugs the vehicle in world space.
+    shieldMesh.visible = state.shield.active
+    shieldMesh.position.set(0, 0, 0)
+    shieldMesh.quaternion.copy(parent.quaternion)
+
+    healMesh.visible = state.heal.cooldownRemainingMs > 0
+    healMesh.position.set(0, -0.6, 0)
+    healMesh.quaternion.copy(parent.quaternion)
+
+    dashMesh.visible = state.dash.active
+    dashMesh.position.set(0, 0, -2.6)
+    dashMesh.quaternion.copy(parent.quaternion)
+
+    ultimateMesh.visible = state.ultimate.active
+    ultimateMesh.position.set(0, 0, 0)
+    ultimateMesh.quaternion.copy(parent.quaternion)
+  }
+
+  function dispose(parent: THREE.Group) {
+    //2.- Remove helper meshes when the controller shuts down to prevent leaks.
+    parent.remove(shieldMesh, healMesh, dashMesh, ultimateMesh)
+    shieldGeometry.dispose()
+    shieldMaterial.dispose()
+    healGeometry.dispose()
+    healMaterial.dispose()
+    dashGeometry.dispose()
+    dashMaterial.dispose()
+    ultimateGeometry.dispose()
+    ultimateMaterial.dispose()
+  }
+
+  return { update, dispose }
+}
+

--- a/game/src/vehicles/shared/supportAbilities.ts
+++ b/game/src/vehicles/shared/supportAbilities.ts
@@ -1,0 +1,159 @@
+export type SupportAbilityOptions = {
+  shieldDurationMs: number
+  shieldCooldownMs: number
+  healAmount: number
+  healCooldownMs: number
+  maxHull: number
+  dashDurationMs: number
+  dashCooldownMs: number
+  dashSpeedBonus: number
+  ultimateDurationMs: number
+  ultimateCooldownMs: number
+  ultimateShieldBonusMs: number
+  ultimateDashBonusMs: number
+}
+
+export type SupportAbilityState = {
+  shield: {
+    active: boolean
+    remainingMs: number
+    cooldownRemainingMs: number
+  }
+  heal: {
+    cooldownRemainingMs: number
+    hull: number
+    maxHull: number
+  }
+  dash: {
+    active: boolean
+    remainingMs: number
+    cooldownRemainingMs: number
+    speedBonus: number
+  }
+  ultimate: {
+    active: boolean
+    remainingMs: number
+    cooldownRemainingMs: number
+  }
+}
+
+const DEFAULT_OPTIONS: SupportAbilityOptions = {
+  shieldDurationMs: 5000,
+  shieldCooldownMs: 8000,
+  healAmount: 25,
+  healCooldownMs: 6000,
+  maxHull: 100,
+  dashDurationMs: 1500,
+  dashCooldownMs: 5000,
+  dashSpeedBonus: 60,
+  ultimateDurationMs: 4000,
+  ultimateCooldownMs: 16000,
+  ultimateShieldBonusMs: 4000,
+  ultimateDashBonusMs: 2000,
+}
+
+export type SupportAbilitySystem = {
+  readonly state: SupportAbilityState
+  update: (dt: number) => void
+  triggerShield: () => boolean
+  triggerHeal: () => boolean
+  triggerDash: () => boolean
+  triggerUltimate: () => boolean
+}
+
+export function createSupportAbilitySystem(overrides: Partial<SupportAbilityOptions> = {}): SupportAbilitySystem {
+  const options = { ...DEFAULT_OPTIONS, ...overrides }
+
+  const state: SupportAbilityState = {
+    shield: { active: false, remainingMs: 0, cooldownRemainingMs: 0 },
+    heal: { cooldownRemainingMs: 0, hull: options.maxHull, maxHull: options.maxHull },
+    dash: { active: false, remainingMs: 0, cooldownRemainingMs: 0, speedBonus: options.dashSpeedBonus },
+    ultimate: { active: false, remainingMs: 0, cooldownRemainingMs: 0 },
+  }
+
+  function update(dt: number) {
+    const deltaMs = dt * 1000
+
+    //1.- Decay active timers so effects expire naturally without extra bookkeeping.
+    if (state.shield.active) {
+      state.shield.remainingMs = Math.max(0, state.shield.remainingMs - deltaMs)
+      if (state.shield.remainingMs === 0) {
+        state.shield.active = false
+      }
+    }
+    if (state.dash.active) {
+      state.dash.remainingMs = Math.max(0, state.dash.remainingMs - deltaMs)
+      if (state.dash.remainingMs === 0) {
+        state.dash.active = false
+      }
+    }
+    if (state.ultimate.active) {
+      state.ultimate.remainingMs = Math.max(0, state.ultimate.remainingMs - deltaMs)
+      if (state.ultimate.remainingMs === 0) {
+        state.ultimate.active = false
+      }
+    }
+
+    //2.- Reduce cooldown trackers so triggers can reactivate once the timers elapse.
+    state.shield.cooldownRemainingMs = Math.max(0, state.shield.cooldownRemainingMs - deltaMs)
+    state.heal.cooldownRemainingMs = Math.max(0, state.heal.cooldownRemainingMs - deltaMs)
+    state.dash.cooldownRemainingMs = Math.max(0, state.dash.cooldownRemainingMs - deltaMs)
+    state.ultimate.cooldownRemainingMs = Math.max(0, state.ultimate.cooldownRemainingMs - deltaMs)
+
+    //3.- Passively regenerate a trickle of hull while idle so healing has a baseline effect.
+    if (!state.ultimate.active) {
+      const regen = deltaMs * 0.0025
+      state.heal.hull = Math.min(state.heal.maxHull, state.heal.hull + regen)
+    }
+  }
+
+  function triggerShield() {
+    //4.- Allow activation only when the recharge cycle completed.
+    if (state.shield.cooldownRemainingMs > 0) return false
+    state.shield.active = true
+    state.shield.remainingMs = options.shieldDurationMs
+    state.shield.cooldownRemainingMs = options.shieldCooldownMs
+    return true
+  }
+
+  function triggerHeal() {
+    //5.- Raise hull integrity while enforcing a cooldown gate to prevent spam.
+    if (state.heal.cooldownRemainingMs > 0) return false
+    state.heal.cooldownRemainingMs = options.healCooldownMs
+    state.heal.hull = Math.min(state.heal.maxHull, state.heal.hull + options.healAmount)
+    return true
+  }
+
+  function triggerDash() {
+    //6.- Start the burst if the thrusters have cooled down enough since the last use.
+    if (state.dash.cooldownRemainingMs > 0) return false
+    state.dash.active = true
+    state.dash.remainingMs = options.dashDurationMs
+    state.dash.cooldownRemainingMs = options.dashCooldownMs
+    return true
+  }
+
+  function triggerUltimate() {
+    //7.- Fire the signature move which layers extra shield and dash uptime.
+    if (state.ultimate.cooldownRemainingMs > 0) return false
+    state.ultimate.active = true
+    state.ultimate.remainingMs = options.ultimateDurationMs
+    state.ultimate.cooldownRemainingMs = options.ultimateCooldownMs
+    state.shield.active = true
+    state.shield.remainingMs = Math.max(state.shield.remainingMs, options.ultimateShieldBonusMs)
+    state.dash.active = true
+    state.dash.remainingMs = Math.max(state.dash.remainingMs, options.ultimateDashBonusMs)
+    state.dash.cooldownRemainingMs = Math.max(state.dash.cooldownRemainingMs, options.dashCooldownMs)
+    return true
+  }
+
+  return {
+    state,
+    update,
+    triggerShield,
+    triggerHeal,
+    triggerDash,
+    triggerUltimate,
+  }
+}
+

--- a/game/src/weapons/visuals/homingMissileVisual.ts
+++ b/game/src/weapons/visuals/homingMissileVisual.ts
@@ -1,6 +1,12 @@
 import * as THREE from 'three'
 import type { HomingMissileState } from '@/weapons/homingMissile'
 
+export type MissilePalette = {
+  body: number
+  emissive: number
+  trail: number
+}
+
 const BASE_FORWARD = new THREE.Vector3(0, 0, 1)
 const TMP_FORWARD = new THREE.Vector3()
 
@@ -15,20 +21,24 @@ type MissileRenderState = {
   trail: THREE.Line
 }
 
-export function createHomingMissileVisual(scene: THREE.Scene): HomingMissileVisual {
+export function createHomingMissileVisual(scene: THREE.Scene, palette: MissilePalette = {
+  body: 0xd36f39,
+  emissive: 0xff6b2f,
+  trail: 0xffc48a,
+}): HomingMissileVisual {
   const group = new THREE.Group()
   scene.add(group)
 
   const bodyMaterial = new THREE.MeshStandardMaterial({
-    color: 0xd36f39,
+    color: palette.body,
     metalness: 0.35,
     roughness: 0.4,
-    emissive: new THREE.Color(0xff6b2f),
+    emissive: new THREE.Color(palette.emissive),
     emissiveIntensity: 0.4,
   })
   const finMaterial = new THREE.MeshStandardMaterial({ color: 0x333845, metalness: 0.15, roughness: 0.6 })
   const trailMaterial = new THREE.LineBasicMaterial({
-    color: 0xffc48a,
+    color: palette.trail,
     transparent: true,
     opacity: 0.55,
     blending: THREE.AdditiveBlending,

--- a/game/src/weapons/visuals/neonLaserVisual.ts
+++ b/game/src/weapons/visuals/neonLaserVisual.ts
@@ -1,6 +1,10 @@
 import * as THREE from 'three'
 import type { NeonLaserState } from '@/weapons/neonLaser'
 
+export type NeonLaserPalette = {
+  color: number
+}
+
 const DEFAULT_FORWARD = new THREE.Vector3(0, 0, 1)
 const TMP_DIRECTION = new THREE.Vector3()
 const TMP_POSITION = new THREE.Vector3()
@@ -12,9 +16,9 @@ export type NeonLaserVisual = {
   readonly beam: THREE.Mesh
 }
 
-export function createNeonLaserVisual(scene: THREE.Scene): NeonLaserVisual {
+export function createNeonLaserVisual(scene: THREE.Scene, palette: NeonLaserPalette = { color: 0x45ffff }): NeonLaserVisual {
   const material = new THREE.MeshBasicMaterial({
-    color: 0x45ffff,
+    color: palette.color,
     transparent: true,
     opacity: 0.75,
     blending: THREE.AdditiveBlending,


### PR DESCRIPTION
## Summary
- add twin infinite meteor BVRAAM launchers with color-coded visuals and extended ability slots
- introduce reusable support ability system with accompanying cockpit indicators and HUD readouts
- cover the new systems with ability-focused vitest suites and ensure unlimited ammo handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e478cbdf488329a5397f95a8a0547d