### PR TITLE
feat: broadcast map identifier for shared arena

### DIFF
--- a/go-broker/internal/config/config.go
+++ b/go-broker/internal/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	ReplayRetentionMatches int
 	ReplayRetentionDays    int
 	MatchSeed              string
+	MapID                  string
 	TerrainParams          map[string]float64
 	Logging                LoggingConfig
 	StateSnapshotPath      string
@@ -118,6 +119,7 @@ func Load() (*Config, error) {
 		ReplayRetentionMatches: DefaultReplayRetentionMatches,
 		ReplayRetentionDays:    DefaultReplayRetentionDays,
 		MatchSeed:              strings.TrimSpace(os.Getenv("BROKER_MATCH_SEED")),
+		MapID:                  strings.TrimSpace(os.Getenv("BROKER_MAP_ID")),
 		Logging: LoggingConfig{
 			Level:      strings.TrimSpace(getString("BROKER_LOG_LEVEL", DefaultLogLevel)),
 			Path:       strings.TrimSpace(getString("BROKER_LOG_PATH", DefaultLogPath)),


### PR DESCRIPTION
## Summary
- add a configurable map identifier to the broker and include it in the world_status handshake so every client loads the same arena
- expose a WithMapID option wired through configuration and default to a shared map id when unset
- cover the shared map announcement with a websocket integration test

## Testing
- go test ./go-broker/...


------
https://chatgpt.com/codex/tasks/task_e_68e49d1b1b608329ac463ea2773032d9