### PR TITLE
Add pilot profile propagation through broker updates

### DIFF
--- a/game/src/app/gameplay/page.tsx
+++ b/game/src/app/gameplay/page.tsx
@@ -36,7 +36,10 @@ export default function GameplayPage() {
     apiRef.current = api
 
     //2.- Connect to the broker so authoritative world diffs can steer the HUD and server-side actors.
-    const broker = createBrokerClient({ clientId: pilotProfile.clientId })
+    const broker = createBrokerClient({
+      clientId: pilotProfile.clientId,
+      pilotProfile: { name: pilotProfile.name, vehicle: pilotProfile.vehicle }
+    })
     const unsubscribe = broker.onWorldDiff((diff) => {
       apiRef.current?.ingestWorldDiff(diff)
     })
@@ -92,7 +95,7 @@ export default function GameplayPage() {
       window.removeEventListener('beforeunload', announceDeparture)
       dispose()
     }
-  }, [pilotProfile.clientId, pilotProfile.vehicle])
+  }, [pilotProfile.clientId, pilotProfile.name, pilotProfile.vehicle])
 
   return (
     <div style={{ position: 'fixed', inset: 0, overflow: 'hidden' }}>


### PR DESCRIPTION
## Summary
- send the sanitized pilot profile envelope immediately after opening the websocket and plumb the gameplay page profile through the broker client
- persist pilot display name and vehicle key in the broker, embed profile metadata in vehicle diffs, and expose it through the world occupant registry
- add Go and Vitest regression coverage for pilot profile propagation and remote player rendering

## Testing
- go test ./...
- npx vitest run


------
https://chatgpt.com/codex/tasks/task_e_68e4aee33dd0832989c90e6a46ad6690