### PR TITLE
Add occupant metadata handling to remote player overlays

### DIFF
--- a/game/src/engine/bootstrap.ts
+++ b/game/src/engine/bootstrap.ts
@@ -193,8 +193,8 @@ export function initGame(
       }
 
       //3.- Mirror authoritative vehicle transforms so remote pilots appear alongside the local craft.
-      if (diff.vehicles) {
-        remotePlayers.ingestDiff(diff.vehicles)
+      if (diff.vehicles || diff.occupants) {
+        remotePlayers.ingestDiff(diff.vehicles, diff.occupants)
       }
     },
     sampleIntent: () => {

--- a/game/src/lib/brokerClient.ts
+++ b/game/src/lib/brokerClient.ts
@@ -9,6 +9,21 @@ export type BrokerGameEvent = {
   type?: string;
 };
 
+export type BrokerOccupantSnapshot = {
+  vehicle_id: string;
+  player_name?: string;
+  player_id?: string;
+  vehicle_key?: string;
+  life_pct?: number;
+  updated_at_ms?: number;
+  [key: string]: unknown;
+};
+
+export type BrokerOccupantDiff = {
+  updated?: BrokerOccupantSnapshot[];
+  removed?: string[];
+};
+
 export type BrokerWorldDiffEnvelope = {
   type: "world_diff";
   tick: number;
@@ -20,6 +35,7 @@ export type BrokerWorldDiffEnvelope = {
     updated?: Array<Record<string, unknown>>;
     removed?: string[];
   };
+  occupants?: BrokerOccupantDiff;
   events?: BrokerGameEvent[];
 };
 


### PR DESCRIPTION
## Summary
- model broker occupant diffs and keep the raw payload when relaying world updates
- forward occupant updates to the remote player manager and refresh nameplates plus health bars
- add vitest coverage confirming occupant names and health visuals stay in sync

## Testing
- npm test
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e4b877f60483299d42cf5d2cb869c8