### PR TITLE
Add deterministic world seeding via broker world status

### DIFF
--- a/game/src/engine/bootstrap.ts
+++ b/game/src/engine/bootstrap.ts
@@ -47,6 +47,8 @@ export type GameAPI = {
 export type InitGameOptions = {
   initialVehicle?: VehicleKey
   pilotId?: string
+  worldId?: string
+  mapId?: string
 }
 
 export const DEFAULT_SCENE_OPTS = {
@@ -87,7 +89,7 @@ export function initGame(
   // Systems
   const input = createInput(container)
   const chase = createChaseCam(camera)
-  const streamer = createStreamer(scene)
+  const streamer = createStreamer(scene, { worldId: options?.worldId, mapId: options?.mapId })
   const remotePlayers = createRemotePlayerManager(scene)
 
   //1.- Spawn the player with the requested vehicle or gracefully fall back to the Arrowhead chassis.

--- a/game/src/world/chunks/worldSeed.ts
+++ b/game/src/world/chunks/worldSeed.ts
@@ -1,0 +1,77 @@
+type SeedSnapshot = {
+  worldId: string
+  mapId: string
+  worldSeed: number
+  mapSeed: number
+  decorationSeed: number
+  noiseOffsetX: number
+  noiseOffsetZ: number
+  frequencyJitter: number
+}
+
+const DEFAULT_WORLD_ID = 'default-world'
+const DEFAULT_MAP_ID = 'default-map'
+
+let snapshot: SeedSnapshot = computeSnapshot({ worldId: DEFAULT_WORLD_ID, mapId: DEFAULT_MAP_ID })
+
+function hashString(input: string): number {
+  //1.- Apply an FNV-1a style hash so identical identifiers collapse to a deterministic 32-bit seed.
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return hash >>> 0
+}
+
+function mixSeeds(a: number, b: number): number {
+  //2.- Combine two 32-bit seeds while preserving diffusion across the full integer range.
+  let h = Math.imul(a ^ 0x9e3779b9, 0x7f4a7c15)
+  h = Math.imul(h ^ (h >>> 15), 0x94d049bb)
+  h ^= b
+  h = Math.imul(h ^ (h >>> 13), 0x5bd1e995)
+  return h >>> 0
+}
+
+function normalise(seed: number): number {
+  //3.- Project a 32-bit unsigned integer into [0,1) space without floating-point drift.
+  return seed / 0xffffffff
+}
+
+function computeSnapshot({ worldId, mapId }: { worldId: string; mapId: string }): SeedSnapshot {
+  //4.- Derive the hashed seeds while tracking the canonical identifier strings for diagnostics.
+  const trimmedWorld = worldId.trim() || DEFAULT_WORLD_ID
+  const trimmedMap = mapId.trim() || DEFAULT_MAP_ID
+  const worldSeed = hashString(trimmedWorld)
+  const mapSeed = hashString(trimmedMap)
+  const decorationSeed = mixSeeds(worldSeed, mapSeed)
+  const offsetScalar = 4096
+  const noiseOffsetX = (normalise(worldSeed) - 0.5) * offsetScalar
+  const noiseOffsetZ = (normalise(mapSeed) - 0.5) * offsetScalar
+  const jitterRaw = normalise(decorationSeed) * 1.2
+  const frequencyJitter = Math.min(1, Math.max(0, jitterRaw))
+  return {
+    worldId: trimmedWorld,
+    mapId: trimmedMap,
+    worldSeed,
+    mapSeed,
+    decorationSeed,
+    noiseOffsetX,
+    noiseOffsetZ,
+    frequencyJitter
+  }
+}
+
+export function configureWorldSeeds({ worldId, mapId }: { worldId?: string; mapId?: string } = {}): SeedSnapshot {
+  //5.- Store the freshly computed seed snapshot so shared terrain helpers can stay in sync.
+  snapshot = computeSnapshot({
+    worldId: worldId ?? DEFAULT_WORLD_ID,
+    mapId: mapId ?? DEFAULT_MAP_ID
+  })
+  return snapshot
+}
+
+export function getWorldSeedSnapshot(): SeedSnapshot {
+  //6.- Surface the cached seed metadata for consumers that need deterministic offsets.
+  return snapshot
+}

--- a/tests/runAllTests.ts
+++ b/tests/runAllTests.ts
@@ -2,6 +2,7 @@ import { testBossPhasesStateMachine } from './specs/bossPhases.test'
 import { testDifficultyScalingAdjustments } from './specs/difficultyScaling.test'
 import { testEnvironmentAdjustments } from './specs/environmentAdjustments.test'
 import { testPlayerVehicleCreation } from './specs/playerCreation.test'
+import { testWorldStatusBootstrap } from './specs/worldStatusBootstrap.test'
 
 async function main(): Promise<void> {
   //1.- Execute the deterministic boss phase assertions.
@@ -10,9 +11,11 @@ async function main(): Promise<void> {
   testDifficultyScalingAdjustments()
   //3.- Await the asynchronous environment inspection so decorators refresh before checking counts.
   await testEnvironmentAdjustments()
-  //4.- Validate the vehicle builder registry for the player stays in sync with the available blueprints.
+  //4.- Confirm the broker world status handshake seeds deterministic terrain streaming across clients.
+  await testWorldStatusBootstrap()
+  //5.- Validate the vehicle builder registry for the player stays in sync with the available blueprints.
   testPlayerVehicleCreation()
-  //5.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
+  //6.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
   console.log('All tests passed')
 }
 

--- a/tests/specs/worldStatusBootstrap.test.ts
+++ b/tests/specs/worldStatusBootstrap.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict'
+import * as THREE from 'three'
+import { createBrokerClient } from '@/lib/brokerClient'
+import { createStreamer } from '@/world/chunks/streamer'
+import { configureWorldSeeds, getWorldSeedSnapshot } from '@/world/chunks/worldSeed'
+import { resetDifficultyState } from '@/engine/difficulty'
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+  url: string
+  sent: string[] = []
+  private listeners: Map<string, Set<(event: any) => void>> = new Map()
+
+  constructor(url: string) {
+    //1.- Capture the constructor URL so assertions can confirm the client respects the resolved endpoint.
+    this.url = url
+    mockSockets.push(this)
+  }
+
+  addEventListener(type: string, handler: (event: any) => void) {
+    //2.- Allow the broker client to register lifecycle handlers just like a real browser WebSocket.
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set())
+    }
+    this.listeners.get(type)!.add(handler)
+  }
+
+  removeEventListener(type: string, handler: (event: any) => void) {
+    //3.- Support listener removal for parity with the real DOM API.
+    this.listeners.get(type)?.delete(handler)
+  }
+
+  send(payload: string) {
+    //4.- Record outbound frames so tests can introspect handshake behaviour if required.
+    this.sent.push(payload)
+  }
+
+  close() {
+    //5.- Transition to the CLOSED state and notify observers so the client cleans up timers.
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.dispatch('close', {})
+  }
+
+  open() {
+    //6.- Simulate the broker acknowledging the connection so queued frames flush immediately.
+    if (this.readyState !== MockWebSocket.CONNECTING) return
+    this.readyState = MockWebSocket.OPEN
+    this.dispatch('open', {})
+  }
+
+  emitMessage(data: string) {
+    //7.- Deliver a payload to the client exactly as the browser would surface broker updates.
+    this.dispatch('message', { data })
+  }
+
+  private dispatch(type: string, event: any) {
+    for (const handler of this.listeners.get(type) ?? []) {
+      handler(event)
+    }
+  }
+}
+
+const mockSockets: MockWebSocket[] = []
+
+export async function testWorldStatusBootstrap(): Promise<void> {
+  //1.- Ensure deterministic defaults so the new snapshot emitted by the test is isolated.
+  configureWorldSeeds()
+  resetDifficultyState()
+
+  const previousDocument = (globalThis as any).document
+  if (!previousDocument) {
+    //2.- Provide a barebones DOM shim for Three.js texture and canvas creation in the Node runtime.
+    const factory = () => ({
+      setAttribute: () => {},
+      style: {},
+      appendChild: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {}
+    })
+    ;(globalThis as any).document = {
+      createElementNS: factory,
+      createElement: factory
+    } as unknown as Document
+  }
+  const previousImage = (globalThis as any).Image
+  if (!previousImage) {
+    ;(globalThis as any).Image = class {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      addEventListener(event: string, handler: () => void) {
+        if (event === 'load') this.onload = handler
+        if (event === 'error') this.onerror = handler
+      }
+      removeEventListener() {}
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.())
+      }
+    }
+  }
+
+  const originalTextureLoader = THREE.TextureLoader.prototype.load
+  THREE.TextureLoader.prototype.load = function (_url: string, onLoad?: (texture: THREE.Texture) => void) {
+    const texture = new THREE.Texture()
+    onLoad?.(texture)
+    return texture
+  }
+
+  const previousWebSocket = (globalThis as any).WebSocket
+  ;(globalThis as any).WebSocket = MockWebSocket as any
+
+  const broker = createBrokerClient({ clientId: 'spec-world-seed' })
+  const socket = mockSockets[0]
+  assert.ok(socket, 'Expected a WebSocket instance to be created')
+
+  const statusPromise = new Promise<{ worldId: string; mapId: string }>((resolve) => {
+    broker.onWorldStatus((status) => resolve(status))
+  })
+
+  socket.open()
+  socket.emitMessage(
+    JSON.stringify({ type: 'world_status', world_id: 'alpha-sector', map_id: 'delta-map' })
+  )
+
+  const status = await statusPromise
+  assert.equal(status.worldId, 'alpha-sector')
+  assert.equal(status.mapId, 'delta-map')
+
+  const sceneA = new THREE.Scene()
+  const streamerA = createStreamer(sceneA, status)
+  const focus = new THREE.Vector3(0, 0, 0)
+  streamerA.update(focus, 0)
+  const chunkA = sceneA.children.find((child) => (child as any).userData?.decorations) as THREE.Mesh
+  assert(chunkA, 'Expected streamer to materialise a terrain chunk after initial update')
+  const decorationsA = chunkA.userData.decorations as THREE.Object3D[]
+  const matrixA = new THREE.Matrix4()
+  if (decorationsA.length > 0) {
+    const instancedA = decorationsA[0] as THREE.InstancedMesh
+    instancedA.getMatrixAt(0, matrixA)
+  }
+  streamerA.dispose?.()
+
+  const sceneB = new THREE.Scene()
+  const streamerB = createStreamer(sceneB, status)
+  streamerB.update(focus, 0)
+  const chunkB = sceneB.children.find((child) => (child as any).userData?.decorations) as THREE.Mesh
+  assert(chunkB, 'Expected second streamer to materialise a terrain chunk after initial update')
+  const decorationsB = chunkB.userData.decorations as THREE.Object3D[]
+  const matrixB = new THREE.Matrix4()
+  if (decorationsB.length > 0) {
+    const instancedB = decorationsB[0] as THREE.InstancedMesh
+    instancedB.getMatrixAt(0, matrixB)
+  }
+  assert.equal(
+    decorationsA.length,
+    decorationsB.length,
+    'Deterministic seeds should yield identical decoration counts'
+  )
+  if (decorationsA.length > 0) {
+    assert.deepEqual(matrixA.toArray(), matrixB.toArray(), 'Chunk decorations should be identical for matching seeds')
+  }
+
+  const snapshot = getWorldSeedSnapshot()
+  assert.equal(snapshot.worldId, 'alpha-sector')
+  assert.equal(snapshot.mapId, 'delta-map')
+
+  streamerB.dispose?.()
+  broker.close()
+
+  configureWorldSeeds()
+  THREE.TextureLoader.prototype.load = originalTextureLoader
+  if (!previousImage) {
+    delete (globalThis as any).Image
+  }
+  if (!previousDocument) {
+    delete (globalThis as any).document
+  }
+  ;(globalThis as any).WebSocket = previousWebSocket
+  mockSockets.length = 0
+}


### PR DESCRIPTION
## Summary
- extend the broker client with a world status listener to surface world and map identifiers
- bootstrap gameplay only after receiving the identifiers and feed them into the game streamer
- seed terrain generation from the negotiated identifiers so multiple clients share layouts and cover with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4bb3f94a48329a2afaca90de2351c