### PR TITLE
Fix poly boss unsubscribe typing and add cleanup test

### DIFF
--- a/game/src/enemies/bosses/poly-boss/phases.ts
+++ b/game/src/enemies/bosses/poly-boss/phases.ts
@@ -167,7 +167,7 @@ export function createPolyBoss(scene: THREE.Scene, position: THREE.Vector3, opti
     difficulty
   }
 
-  let unsubscribe = onDifficultyChange((next) => {
+  let unsubscribe: (() => void) | undefined = onDifficultyChange((next) => {
     //1.- Capture live difficulty adjustments so spawn cadence reacts mid-fight.
     state.difficulty = next
   })
@@ -279,7 +279,8 @@ export function createPolyBoss(scene: THREE.Scene, position: THREE.Vector3, opti
         hp: state.hp,
         shieldStrength: state.shieldStrength,
         timeInPhase: state.timeInPhase,
-        enraged: state.enraged
+        enraged: state.enraged,
+        difficulty: state.difficulty
       }
     },
     takeDamage(amount: number) {

--- a/game/src/engine/bootstrap.ts
+++ b/game/src/engine/bootstrap.ts
@@ -139,7 +139,7 @@ export function initGame(
     player.controller.update(dt, input, streamer.queryHeight)
 
     // Stream world around the player
-    streamer.update(player.group.position)
+    streamer.update(player.group.position, dt)
 
     // Spawning / encounters
     spawner.update(dt, stage)

--- a/game/src/weapons/visuals/gatlingGunVisual.ts
+++ b/game/src/weapons/visuals/gatlingGunVisual.ts
@@ -85,10 +85,17 @@ export function createGatlingVisual(scene: THREE.Scene, options: GatlingOptions,
 
   function dispose() {
     // 5. Release GPU buffers when the owning entity despawns to prevent leaks.
-    tracers.forEach(tracer => {
+    tracers.forEach((tracer) => {
       scene.remove(tracer);
       tracer.geometry.dispose();
-      tracer.material.dispose();
+      const material = tracer.material;
+      if (Array.isArray(material)) {
+        //1.- Safely dispose layered materials when instancing supplied an array for complex shaders.
+        for (const entry of material) entry.dispose?.();
+      } else {
+        //2.- Dispose the solitary material variant typically used for the tracer mesh.
+        material.dispose?.();
+      }
     });
   }
 

--- a/tests/runAllTests.ts
+++ b/tests/runAllTests.ts
@@ -1,4 +1,5 @@
 import { testBossPhasesStateMachine } from './specs/bossPhases.test'
+import { testBossDifficultyListenerCleanup } from './specs/bossDifficultyCleanup.test'
 import { testDifficultyScalingAdjustments } from './specs/difficultyScaling.test'
 import { testEnvironmentAdjustments } from './specs/environmentAdjustments.test'
 import { testPlayerVehicleCreation } from './specs/playerCreation.test'
@@ -7,15 +8,17 @@ import { testWorldStatusBootstrap } from './specs/worldStatusBootstrap.test'
 async function main(): Promise<void> {
   //1.- Execute the deterministic boss phase assertions.
   testBossPhasesStateMachine()
-  //2.- Validate difficulty scaling math remains monotonic as new clears accrue.
+  //2.- Validate boss difficulty listeners detach after death to avoid stale updates.
+  testBossDifficultyListenerCleanup()
+  //3.- Validate difficulty scaling math remains monotonic as new clears accrue.
   testDifficultyScalingAdjustments()
-  //3.- Await the asynchronous environment inspection so decorators refresh before checking counts.
+  //4.- Await the asynchronous environment inspection so decorators refresh before checking counts.
   await testEnvironmentAdjustments()
-  //4.- Confirm the broker world status handshake seeds deterministic terrain streaming across clients.
+  //5.- Confirm the broker world status handshake seeds deterministic terrain streaming across clients.
   await testWorldStatusBootstrap()
-  //5.- Validate the vehicle builder registry for the player stays in sync with the available blueprints.
+  //6.- Validate the vehicle builder registry for the player stays in sync with the available blueprints.
   testPlayerVehicleCreation()
-  //6.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
+  //7.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
   console.log('All tests passed')
 }
 

--- a/tests/specs/bossDifficultyCleanup.test.ts
+++ b/tests/specs/bossDifficultyCleanup.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import * as THREE from 'three'
+import { applyBossDefeat, getDifficultyState, resetDifficultyState } from '@/engine/difficulty'
+import { createPolyBoss } from '@/enemies/bosses/poly-boss/phases'
+
+export function testBossDifficultyListenerCleanup(): void {
+  //1.- Ensure a stable baseline difficulty snapshot before creating the boss fixture.
+  resetDifficultyState()
+  const scene = new THREE.Scene()
+  const boss = createPolyBoss(scene, new THREE.Vector3(), { stage: 3, randomSeed: 9 })
+
+  //2.- Advance difficulty once and confirm the boss mirrors the broadcast values while alive.
+  const beforeDefeat = boss.getStateSnapshot().difficulty.bossClears
+  applyBossDefeat(3)
+  const duringFight = boss.getStateSnapshot().difficulty.bossClears
+  assert.equal(duringFight, beforeDefeat + 1)
+
+  //3.- Kill the boss to trigger lifecycle cleanup and repeat the broadcast to verify no further updates propagate.
+  boss.onDeath()
+  applyBossDefeat(4)
+  const afterDeath = boss.getStateSnapshot().difficulty.bossClears
+  assert.equal(afterDeath, duringFight)
+
+  //4.- Reset global difficulty so subsequent tests observe a deterministic baseline.
+  resetDifficultyState()
+  const finalSnapshot = getDifficultyState()
+  assert.equal(finalSnapshot.bossClears, 0)
+}


### PR DESCRIPTION
## Summary
- allow the poly boss difficulty listener to be reset cleanly and expose the current difficulty snapshot for diagnostics
- add a regression test covering boss difficulty listener cleanup and wire it into the test harness sequence
- pass delta time to the world streamer loop and guard tracer material disposal when arrays are returned

## Testing
- npm test
- CI=1 npm --prefix game run build *(fails: useSearchParams() needs a suspense boundary in /gameplay)*

------
https://chatgpt.com/codex/tasks/task_e_68e5094c5a30832998d768aa01f6b073