### PR TITLE
Fix poly boss unsubscribe cleanup

### DIFF
--- a/game/src/enemies/bosses/poly-boss/phases.ts
+++ b/game/src/enemies/bosses/poly-boss/phases.ts
@@ -298,7 +298,8 @@ export function createPolyBoss(scene: THREE.Scene, position: THREE.Vector3, opti
       scene.remove(bossGroup)
       disposeObject(bossGroup)
       unsubscribe?.()
-      unsubscribe = undefined
+      //2.- Replace the listener reference with a no-op to avoid accidental double-unsubscribe attempts.
+      unsubscribe = () => {}
       applyBossDefeat(stage)
     }
   }


### PR DESCRIPTION
## Summary
- prevent the poly boss difficulty unsubscribe handle from being reset to `undefined`
- replace it with a no-op function so TypeScript accepts the reassignment after cleanup

## Testing
- node -r ts-node/register -r tsconfig-paths/register tests/runAllTests.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5125eb2448329b538050046e5da8e