### PR TITLE
Handle optional delta in streamer update

### DIFF
--- a/game/src/world/chunks/streamer.ts
+++ b/game/src/world/chunks/streamer.ts
@@ -416,7 +416,7 @@ export function createStreamer(scene: THREE.Scene, options: StreamerOptions = {}
   }
 
   return {
-    update(pos: THREE.Vector3, dt: number) {
+    update(pos: THREE.Vector3, dt = 0) {
       // radius can adjust with density if you wish; keep simple & stable here
       const radius = ACTIVE_RADIUS
       const cx = toChunk(pos.x)
@@ -438,8 +438,12 @@ export function createStreamer(scene: THREE.Scene, options: StreamerOptions = {}
         environmentDirty = false
       }
 
-      // fade step
-      stepFades(clock.getElapsedTime())
+      //1.- Combine the monotonically increasing clock time with the supplied dt so fades stay smooth during
+      //    deterministic test runs where requestAnimationFrame never fires.
+      const now = clock.getElapsedTime() + dt
+
+      //2.- Advance chunk fade transitions using the resolved timestamp, guaranteeing consistent cross-environment visuals.
+      stepFades(now)
     },
 
     queryHeight(x: number, z: number) {

--- a/tests/runAllTests.ts
+++ b/tests/runAllTests.ts
@@ -4,6 +4,7 @@ import { testDifficultyScalingAdjustments } from './specs/difficultyScaling.test
 import { testEnvironmentAdjustments } from './specs/environmentAdjustments.test'
 import { testPlayerVehicleCreation } from './specs/playerCreation.test'
 import { testWorldStatusBootstrap } from './specs/worldStatusBootstrap.test'
+import { testStreamerDeltaDefault } from './specs/streamerDeltaDefault.test'
 
 async function main(): Promise<void> {
   //1.- Execute the deterministic boss phase assertions.
@@ -16,9 +17,11 @@ async function main(): Promise<void> {
   await testEnvironmentAdjustments()
   //5.- Confirm the broker world status handshake seeds deterministic terrain streaming across clients.
   await testWorldStatusBootstrap()
-  //6.- Validate the vehicle builder registry for the player stays in sync with the available blueprints.
+  //6.- Confirm streamer updates succeed even when callers omit the optional delta time parameter.
+  await testStreamerDeltaDefault()
+  //7.- Validate the vehicle builder registry for the player stays in sync with the available blueprints.
   testPlayerVehicleCreation()
-  //7.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
+  //8.- All checks passed if execution reaches this point, so emit a concise summary for CI logs.
   console.log('All tests passed')
 }
 

--- a/tests/specs/streamerDeltaDefault.test.ts
+++ b/tests/specs/streamerDeltaDefault.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import * as THREE from 'three'
+import { createStreamer } from '@/world/chunks/streamer'
+import { resetDifficultyState } from '@/engine/difficulty'
+
+export async function testStreamerDeltaDefault(): Promise<void> {
+  //1.- Reset the shared difficulty state so procedural seeds remain deterministic for the test.
+  resetDifficultyState()
+
+  const scene = new THREE.Scene()
+  const previousDocument = (globalThis as any).document
+  if (!previousDocument) {
+    //2.- Provide a lightweight DOM shim so Three.js texture loaders can instantiate without a browser.
+    const factory = () => ({
+      setAttribute: () => {},
+      style: {},
+      appendChild: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {}
+    })
+    ;(globalThis as any).document = {
+      createElementNS: factory,
+      createElement: factory
+    } as unknown as Document
+  }
+
+  const previousImage = (globalThis as any).Image
+  if (!previousImage) {
+    //3.- Shim the Image constructor to immediately resolve loader callbacks during the unit test.
+    ;(globalThis as any).Image = class {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      addEventListener(event: string, handler: () => void) {
+        if (event === 'load') this.onload = handler
+        if (event === 'error') this.onerror = handler
+      }
+      removeEventListener() {}
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.())
+      }
+    }
+  }
+
+  const originalTextureLoader = THREE.TextureLoader.prototype.load
+  THREE.TextureLoader.prototype.load = function (_url: string, onLoad?: (texture: THREE.Texture) => void) {
+    //4.- Return an in-memory texture so chunk materials finalise instantly.
+    const texture = new THREE.Texture()
+    onLoad?.(texture)
+    return texture
+  }
+
+  const streamer = createStreamer(scene)
+  const focus = new THREE.Vector3(0, 0, 0)
+
+  //5.- Invoke the streamer without supplying a delta and confirm terrain still materialises around the player.
+  streamer.update(focus)
+  const chunk = scene.children.find((child) => (child as any).userData?.decorations) as THREE.Mesh | undefined
+  assert(chunk, 'Expected streamer.update to spawn a terrain chunk even without an explicit delta time')
+
+  //6.- Dispose resources and restore global shims before leaving the test.
+  streamer.dispose?.()
+  THREE.TextureLoader.prototype.load = originalTextureLoader
+  if (!previousImage) {
+    delete (globalThis as any).Image
+  }
+  if (!previousDocument) {
+    delete (globalThis as any).document
+  }
+}
+


### PR DESCRIPTION
## Summary
- default the terrain streamer update to accept calls without an explicit delta time and use the value when provided
- register a regression test to exercise the delta-less update path and wire it into the aggregated test harness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5182c89788329a1c76ed548815890