### PR TITLE
feat: render local pilot nameplate

### DIFF
--- a/game/src/__tests__/playerNameplate.test.ts
+++ b/game/src/__tests__/playerNameplate.test.ts
@@ -1,0 +1,28 @@
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+import { createPlayer } from '@/vehicles/shared/player'
+
+describe('createPlayer nameplate integration', () => {
+  it('attaches and refreshes the pilot nameplate across vehicle swaps', () => {
+    //1.- Force the helper to render by faking a browser-like user agent that bypasses the jsdom guard.
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('driftpursuit-test')
+    const scene = new THREE.Scene()
+    const pilotName = 'Test Pilot'
+
+    try {
+      const { group, setVehicle } = createPlayer('arrowhead', scene, pilotName)
+
+      const initialSprites = group.children.filter((child): child is THREE.Sprite => child instanceof THREE.Sprite)
+      expect(initialSprites).toHaveLength(1)
+      expect(initialSprites[0].userData.nameplate).toEqual({ pilotName, vehicleKey: 'arrowhead' })
+
+      setVehicle('cube')
+
+      const refreshedSprites = group.children.filter((child): child is THREE.Sprite => child instanceof THREE.Sprite)
+      expect(refreshedSprites).toHaveLength(1)
+      expect(refreshedSprites[0].userData.nameplate).toEqual({ pilotName, vehicleKey: 'cube' })
+    } finally {
+      userAgentSpy.mockRestore()
+    }
+  })
+})

--- a/game/src/app/gameplay/page.tsx
+++ b/game/src/app/gameplay/page.tsx
@@ -76,6 +76,7 @@ function GameplayContent() {
         {
           initialVehicle: pilotProfile.vehicle,
           pilotId: pilotProfile.clientId,
+          pilotName: pilotProfile.name,
           worldId: status.worldId,
           mapId: status.mapId
         }

--- a/game/src/engine/bootstrap.ts
+++ b/game/src/engine/bootstrap.ts
@@ -57,6 +57,7 @@ export type MinimapSnapshot = {
 export type InitGameOptions = {
   initialVehicle?: VehicleKey
   pilotId?: string
+  pilotName?: string
   worldId?: string
   mapId?: string
 }
@@ -102,9 +103,9 @@ export function initGame(
   const streamer = createStreamer(scene, { worldId: options?.worldId, mapId: options?.mapId })
   const remotePlayers = createRemotePlayerManager(scene)
 
-  //1.- Spawn the player with the requested vehicle or gracefully fall back to the Arrowhead chassis.
+  //1.- Spawn the player with the requested vehicle and name, or gracefully fall back to defaults.
   const startingVehicle = options?.initialVehicle ?? DEFAULT_VEHICLE_KEY
-  const player = createPlayer(startingVehicle, scene)
+  const player = createPlayer(startingVehicle, scene, options?.pilotName)
   const pilotId = options?.pilotId ?? 'pilot-local'
 
   // Spawn corridor and spawner

--- a/game/src/engine/remotePlayers.ts
+++ b/game/src/engine/remotePlayers.ts
@@ -6,6 +6,7 @@ import {
   normalizeVehicleChoice,
   type VehicleKey
 } from '@/lib/pilotProfile'
+import { createNameplate } from '@/ui/nameplate'
 import type { BrokerOccupantDiff, BrokerOccupantSnapshot } from '@/lib/brokerClient'
 import { buildArrowhead } from '@/vehicles/arrowhead/build'
 import { buildCube } from '@/vehicles/cube/build'
@@ -124,41 +125,6 @@ function instantiateVehicleMesh(vehicleKey: VehicleKey): THREE.Object3D {
 function formatGroupName(name: string, vehicleKey: VehicleKey) {
   //1.- Embed the effective display name and vehicle key in the group name to simplify scene graph inspection tools.
   return `remote-player:${name} (${vehicleKey})`
-}
-
-function createNameplate(profile: RemoteProfile): THREE.Sprite | null {
-  //1.- Render a light-weight sprite label when the DOM is available so spectators can identify remote pilots.
-  if (typeof document === 'undefined') {
-    return null
-  }
-  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent ?? '' : ''
-  if (userAgent.toLowerCase().includes('jsdom')) {
-    //2.- Skip label generation entirely during tests so jsdom's incomplete canvas API does not spam the console.
-    return null
-  }
-  const canvas = document.createElement('canvas')
-  canvas.width = 256
-  canvas.height = 128
-  const ctx = canvas.getContext('2d')
-  if (!ctx) {
-    return null
-  }
-  ctx.clearRect(0, 0, canvas.width, canvas.height)
-  ctx.fillStyle = 'rgba(0, 0, 0, 0.6)'
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
-  ctx.fillStyle = '#ffffff'
-  ctx.font = 'bold 40px sans-serif'
-  ctx.textAlign = 'center'
-  ctx.textBaseline = 'middle'
-  ctx.fillText(profile.pilotName, canvas.width / 2, canvas.height / 2 - 20)
-  ctx.font = '28px sans-serif'
-  ctx.fillText(profile.vehicleKey, canvas.width / 2, canvas.height / 2 + 32)
-  const texture = new THREE.CanvasTexture(canvas)
-  const material = new THREE.SpriteMaterial({ map: texture, depthTest: false })
-  const sprite = new THREE.Sprite(material)
-  sprite.position.set(0, 6, 0)
-  sprite.scale.set(6, 3, 1)
-  return sprite
 }
 
 function disposeLabel(label: THREE.Sprite | null) {

--- a/game/src/ui/nameplate.ts
+++ b/game/src/ui/nameplate.ts
@@ -1,0 +1,44 @@
+import * as THREE from 'three'
+import type { VehicleKey } from '@/lib/pilotProfile'
+
+export type NameplateProfile = {
+  pilotName: string
+  vehicleKey: VehicleKey
+}
+
+export function createNameplate(profile: NameplateProfile): THREE.Sprite | null {
+  //1.- Render a light-weight sprite label when the DOM is available so spectators can identify remote pilots.
+  if (typeof document === 'undefined') {
+    return null
+  }
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent ?? '' : ''
+  if (userAgent.toLowerCase().includes('jsdom')) {
+    //2.- Skip label generation entirely during tests so jsdom's incomplete canvas API does not spam the console.
+    return null
+  }
+  const canvas = document.createElement('canvas')
+  canvas.width = 256
+  canvas.height = 128
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return null
+  }
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.6)'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = '#ffffff'
+  ctx.font = 'bold 40px sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(profile.pilotName, canvas.width / 2, canvas.height / 2 - 20)
+  ctx.font = '28px sans-serif'
+  ctx.fillText(profile.vehicleKey, canvas.width / 2, canvas.height / 2 + 32)
+  const texture = new THREE.CanvasTexture(canvas)
+  const material = new THREE.SpriteMaterial({ map: texture, depthTest: false })
+  const sprite = new THREE.Sprite(material)
+  sprite.position.set(0, 6, 0)
+  sprite.scale.set(6, 3, 1)
+  sprite.userData.nameplate = { pilotName: profile.pilotName, vehicleKey: profile.vehicleKey }
+  //3.- Persist the rendered metadata on the sprite for tests and debugging overlays without re-reading the canvas.
+  return sprite
+}

--- a/game/src/vehicles/shared/player.ts
+++ b/game/src/vehicles/shared/player.ts
@@ -6,10 +6,11 @@ import { buildIcosahedron } from '@/vehicles/icosahedron/build'
 import { buildCube } from '@/vehicles/cube/build'
 import { buildTransformer } from '@/vehicles/transformer/build'
 import { createController } from '@/vehicles/shared/simpleController'
+import { createNameplate } from '@/ui/nameplate'
 
 type VehicleKey = 'arrowhead' | 'octahedron' | 'pyramid' | 'icosahedron' | 'cube' | 'transformer'
 
-export function createPlayer(initial: VehicleKey, scene: THREE.Scene) {
+export function createPlayer(initial: VehicleKey, scene: THREE.Scene, pilotName?: string) {
   //1.- Instantiate the player anchor group and populate the builder registry keyed by vehicle ids.
   const group = new THREE.Group()
   scene.add(group)
@@ -37,6 +38,37 @@ export function createPlayer(initial: VehicleKey, scene: THREE.Scene) {
   const controller = createController(group, scene)
   controller.refreshVehicleClearance?.()
 
+  let nameplate: THREE.Sprite | null = null
+
+  function disposeNameplate() {
+    //1.- Remove the current nameplate sprite and free its GPU resources before recreating it.
+    if (!nameplate) {
+      return
+    }
+    nameplate.parent?.remove(nameplate)
+    const material = nameplate.material as THREE.SpriteMaterial | undefined
+    material?.map?.dispose?.()
+    material?.dispose?.()
+    nameplate = null
+  }
+
+  function refreshNameplate() {
+    //1.- Skip nameplate creation entirely when no pilot name is provided or the DOM is unavailable.
+    if (!pilotName || typeof document === 'undefined') {
+      disposeNameplate()
+      return
+    }
+    disposeNameplate()
+    const label = createNameplate({ pilotName, vehicleKey: currentKey })
+    if (label) {
+      group.add(label)
+      nameplate = label
+    }
+  }
+
+  //2.- Prime the HUD label so the local pilot mirrors remote displays immediately after spawning.
+  refreshNameplate()
+
   //3.- Allow downstream consumers to swap vehicles while keeping the controller in sync.
   function setVehicle(key: VehicleKey) {
     if (currentMesh) group.remove(currentMesh)
@@ -44,6 +76,7 @@ export function createPlayer(initial: VehicleKey, scene: THREE.Scene) {
     currentMesh = resolveVehicle(currentKey)
     group.add(currentMesh)
     controller.refreshVehicleClearance?.()
+    refreshNameplate()
   }
 
   //4.- Provide a convenience cycle helper for sequential vehicle selection.


### PR DESCRIPTION
## Summary
- extract the canvas sprite nameplate helper for reuse by local and remote pilots
- thread the pilot name through gameplay bootstrap so the local craft instantiates a label
- ensure vehicle swaps refresh the nameplate and add a regression test for the behaviour

## Testing
- npm test -- playerNameplate

------
https://chatgpt.com/codex/tasks/task_e_68e540a9136883299e8caa06d1281be0