### PR TITLE
Invert horizontal mouse steering (yaw) in simpleController

### DIFF
--- a/game/src/vehicles/shared/__tests__/simpleController.test.ts
+++ b/game/src/vehicles/shared/__tests__/simpleController.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+import { createController } from '../simpleController'
+
+describe('simpleController mouse steering', () => {
+  it('yaws left when the mouse moves right', () => {
+    //1.- Compose a controller with neutral orientation to sample yaw updates deterministically.
+    const group = new THREE.Group()
+    const scene = new THREE.Scene()
+    const controller = createController(group, scene)
+    const input = {
+      mouse: { x: 1, y: 0 },
+      pressed: (_code: string) => false,
+    }
+
+    //2.- Advance one frame and verify smoothing trends the yaw toward a negative heading.
+    controller.update(1 / 60, input, () => 0)
+
+    expect(group.rotation.y).toBeLessThan(0)
+
+    //3.- Dispose resources to avoid leaking visuals into subsequent tests.
+    controller.dispose()
+  })
+})

--- a/game/src/vehicles/shared/simpleController.ts
+++ b/game/src/vehicles/shared/simpleController.ts
@@ -150,8 +150,8 @@ export function createController(group: THREE.Group, scene: THREE.Scene){
   computeLauncherClearance()
 
   function update(dt:number, input:any, queryHeight:(x:number,z:number)=>number){
-    // Mouse steering: aim reticle in NDC controls yaw/pitch
-    const targetYaw = input.mouse.x * 0.6
+    //1.- Mouse steering: aim reticle in NDC controls yaw/pitch with inverted horizontal response.
+    const targetYaw = input.mouse.x * -0.6
     const targetPitch = input.mouse.y * 0.4
     group.rotation.y += (targetYaw - group.rotation.y) * (1 - Math.exp(-6*dt))
     group.rotation.x += (targetPitch - group.rotation.x) * (1 - Math.exp(-6*dt))


### PR DESCRIPTION
## Summary
- invert the yaw target computation so positive mouse X input turns the vehicle left while preserving smoothing
- add a unit test that verifies a rightward mouse movement produces a negative yaw update

## Testing
- npx vitest run --config vitest.simpleController.config.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e5425142488329b8e114643c8059b6