### PR TITLE
Scale homing missile visuals (+20%) and shorten ejection phase (10% clearance)

### DIFF
--- a/game/src/weapons/__tests__/homingMissileVisual.test.ts
+++ b/game/src/weapons/__tests__/homingMissileVisual.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+import { createHomingMissileVisual } from '@/weapons/visuals/homingMissileVisual'
+
+describe('homingMissileVisual', () => {
+  it('scales pooled missile meshes to 1.2', () => {
+    //1.- Build a scene and invoke the factory so we can inspect the pooled instances.
+    const scene = new THREE.Scene()
+    const visual = createHomingMissileVisual(scene)
+
+    //2.- Feed a minimal missile state so the visual system instantiates one pooled mesh.
+    visual.update([
+      {
+        id: 1,
+        position: new THREE.Vector3(),
+        velocity: new THREE.Vector3(0, 0, 1),
+        smokeTrail: [],
+        targetId: null,
+        lifetimeMs: 0,
+        smokeAccumulatorMs: 0,
+        stage: 'ejecting',
+        stageMs: 0,
+      } as any,
+    ])
+
+    //3.- Confirm the pooled mesh was uniformly scaled by 20% as part of its construction.
+    const missileMesh = visual.group.children[0]
+    expect(missileMesh.scale.x).toBeCloseTo(1.2)
+    expect(missileMesh.scale.y).toBeCloseTo(1.2)
+    expect(missileMesh.scale.z).toBeCloseTo(1.2)
+  })
+})

--- a/game/src/weapons/__tests__/meteorMissile.test.ts
+++ b/game/src/weapons/__tests__/meteorMissile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+import { createMeteorMissileSystem } from '@/weapons/meteorMissile'
+import type { WeaponContext } from '@/weapons/types'
+
+describe('meteorMissile', () => {
+  it('ignites once ejection travel reaches ten percent of the clearance distance', () => {
+    //1.- Configure a launcher with an exaggerated clearance so the shortened ejection distance is obvious.
+    const clearanceDistance = 20
+    const system = createMeteorMissileSystem({
+      maxConcurrent: 4,
+      cooldownMs: 0,
+      ammo: 3,
+      ejectionDurationMs: 5000,
+      ejectionSpeed: 10,
+      burnSpeed: 40,
+      navigationConstant: 4,
+      detonationRadius: 5,
+      smokeTrailIntervalMs: 100,
+      maxLifetimeMs: 30000,
+      clearanceDistance,
+      swayAmplitude: 0,
+      swayFrequency: 1,
+    })
+
+    const context: WeaponContext = {
+      position: new THREE.Vector3(),
+      forward: new THREE.Vector3(0, 0, 1),
+      dt: 0.05,
+      targets: [],
+    }
+
+    //2.- Fire a missile and iterate the simulation until it exits the ejection phase.
+    const fireResult = system.tryFire(context)
+    expect(fireResult.fired).toBe(true)
+    const missile = fireResult.missile!
+
+    const ejectionThreshold = clearanceDistance * 0.1
+    let steps = 0
+    while (missile.stage === 'ejecting' && steps < 100) {
+      system.update(context)
+      steps += 1
+    }
+
+    //3.- Verify the booster lights once 10% of the clearance has been traveled, well before the physical stand-off distance.
+    expect(missile.stage).toBe('burning')
+    expect(missile.ejectionTravel).toBeGreaterThanOrEqual(ejectionThreshold)
+    expect(missile.ejectionTravel).toBeLessThan(clearanceDistance)
+    const elapsedMs = steps * context.dt * 1000
+    expect(elapsedMs).toBeLessThan(5000)
+  })
+})

--- a/game/src/weapons/meteorMissile.ts
+++ b/game/src/weapons/meteorMissile.ts
@@ -165,7 +165,9 @@ export function createMeteorMissileSystem(options: MeteorMissileOptions){
         missile.position.addScaledVector(missile.ejectionDirection, travel)
         missile.velocity.copy(missile.ejectionDirection).multiplyScalar(options.ejectionSpeed)
         missile.ejectionTravel += travel
-        if (missile.ejectionTravel >= clearanceDistance || missile.stageMs >= options.ejectionDurationMs){
+        const ejectionThreshold = clearanceDistance * 0.1
+        //4.- Stop the ballistic push once the missile is 10% clear so the booster lights earlier than the physical stand-off.
+        if (missile.ejectionTravel >= ejectionThreshold || missile.stageMs >= options.ejectionDurationMs){
           igniteMissile(missile, context)
         }
       } else {
@@ -273,6 +275,7 @@ export function createMeteorMissileSystem(options: MeteorMissileOptions){
   }
 
   function setLauncherClearance(distance: number){
+    //5.- Only the spawn offset honors this distance; the ejection threshold derives its own 10% window.
     clearanceDistance = Math.max(1, distance)
   }
 

--- a/game/src/weapons/visuals/homingMissileVisual.ts
+++ b/game/src/weapons/visuals/homingMissileVisual.ts
@@ -75,8 +75,9 @@ export function createHomingMissileVisual(scene: THREE.Scene, palette: MissilePa
   const renderStates = new Map<number, MissileRenderState>()
 
   function buildMissile(): MissileRenderState {
-    //1.- Construct a reusable missile rig so pooled projectiles share GPU buffers.
+    //1.- Construct a reusable missile rig so pooled projectiles share GPU buffers and pre-scale the assembly.
     const missileGroup = new THREE.Group()
+    missileGroup.scale.setScalar(1.2)
 
     const body = new THREE.Mesh(bodyGeometry, bodyMaterial)
     body.rotation.x = Math.PI / 2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
-//1.- Align Vitest's module resolution with the tsconfig alias and scope coverage to the new remote player logic.
+//1.- Align Vitest's module resolution with the tsconfig alias while registering both HUD and weapon regression suites.
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
@@ -12,7 +12,11 @@ export default defineConfig({
     }
   },
   test: {
-    include: ['game/src/__tests__/remotePlayers.test.ts', 'game/src/__tests__/minimap.test.tsx'],
+    include: [
+      'game/src/__tests__/remotePlayers.test.ts',
+      'game/src/__tests__/minimap.test.tsx',
+      'game/src/weapons/__tests__/**/*.test.ts'
+    ],
     environment: 'node',
     environmentMatchGlobs: [['**/*.test.tsx', 'jsdom']],
     coverage: {


### PR DESCRIPTION
## Summary
- enlarge pooled homing missile rigs to 120% scale so the visuals read louder in flight
- ignite meteor missiles once ejection travel reaches 10% of the clearance distance while leaving spawn offsets unchanged
- add focused weapon tests and include them in the Vitest configuration

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e54491e3d08329ae01db279ec5138e