### PR TITLE
Pointer-lock relative mouse deltas enable 360° yaw; accumulators in controller

### DIFF
--- a/game/src/ui/__tests__/inputMap.pointerlock.test.ts
+++ b/game/src/ui/__tests__/inputMap.pointerlock.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createInput } from '../inputMap'
+
+declare global {
+  interface Document {
+    pointerLockElement?: Element | null
+  }
+}
+
+const mockRect = (): DOMRect => ({
+  bottom: 100,
+  height: 100,
+  left: 0,
+  right: 100,
+  top: 0,
+  width: 100,
+  x: 0,
+  y: 0,
+} as DOMRect)
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  Object.defineProperty(document, 'pointerLockElement', {
+    configurable: true,
+    enumerable: true,
+    value: null,
+    writable: true,
+  })
+})
+
+describe('createInput pointer lock', () => {
+  it('accumulates pointer deltas and orientation while locked', () => {
+    //1.- Instantiate input handling on a container that supports pointer lock requests.
+    const container = document.createElement('div')
+    container.getBoundingClientRect = mockRect
+    const requestPointerLock = vi.fn(() => {
+      document.pointerLockElement = container
+      document.dispatchEvent(new Event('pointerlockchange'))
+    })
+    ;(container as HTMLElement & { requestPointerLock?: () => void }).requestPointerLock = requestPointerLock
+    document.body.appendChild(container)
+
+    const input = createInput(container)
+
+    container.dispatchEvent(new MouseEvent('click'))
+    container.dispatchEvent(new MouseEvent('mousemove', { movementX: 5, movementY: -3 }))
+    container.dispatchEvent(new MouseEvent('mousemove', { movementX: 2, movementY: 1 }))
+
+    expect(requestPointerLock).toHaveBeenCalled()
+    expect(input.pointer.locked).toBe(true)
+    expect(input.pointer.deltaX).toBe(7)
+    expect(input.pointer.deltaY).toBe(-2)
+    expect(input.pointer.yaw).toBe(7)
+    expect(input.pointer.pitch).toBe(-2)
+  })
+
+  it('falls back to NDC sampling when pointer lock is unavailable', () => {
+    //1.- Retain legacy behaviour when pointer lock cannot be activated by sampling absolute coordinates.
+    const container = document.createElement('div')
+    container.getBoundingClientRect = mockRect
+    document.body.appendChild(container)
+
+    const input = createInput(container)
+
+    container.dispatchEvent(new MouseEvent('mousemove', { clientX: 75, clientY: 25 }))
+
+    expect(input.pointer.locked).toBe(false)
+    expect(input.pointer.deltaX).toBe(0)
+    expect(input.pointer.deltaY).toBe(0)
+    expect(input.mouse.x).toBeCloseTo(0.5)
+    expect(input.mouse.y).toBeCloseTo(0.5)
+  })
+})

--- a/game/src/ui/inputMap.ts
+++ b/game/src/ui/inputMap.ts
@@ -1,25 +1,60 @@
+type PointerState = {
+  locked: boolean
+  deltaX: number
+  deltaY: number
+  yaw: number
+  pitch: number
+}
+
 export function createInput(container: HTMLElement) {
   const keys = new Set<string>()
   const mouse = { x: 0, y: 0 }
+  const pointer: PointerState = { locked: false, deltaX: 0, deltaY: 0, yaw: 0, pitch: 0 }
   const pressed = (code: string) => keys.has(code)
 
   const onKeyDown = (e: KeyboardEvent) => keys.add(e.code)
   const onKeyUp = (e: KeyboardEvent) => keys.delete(e.code)
+  const onPointerLockChange = () => {
+    pointer.locked = (document as Document & { pointerLockElement?: Element | null }).pointerLockElement === container
+    if (!pointer.locked) {
+      pointer.deltaX = 0
+      pointer.deltaY = 0
+    }
+  }
   const onMouseMove = (e: MouseEvent) => {
+    if (pointer.locked) {
+      pointer.deltaX += e.movementX || 0
+      pointer.deltaY += e.movementY || 0
+      pointer.yaw += e.movementX || 0
+      pointer.pitch += e.movementY || 0
+      return
+    }
+
     const rect = container.getBoundingClientRect()
     mouse.x = (e.clientX - rect.left) / rect.width * 2 - 1
     mouse.y = -((e.clientY - rect.top) / rect.height * 2 - 1)
   }
+  const onClick = () => {
+    const request = (container as HTMLElement & { requestPointerLock?: () => void }).requestPointerLock
+    if (!request) return
+    request.call(container)
+  }
+
   container.tabIndex = 0
+  container.addEventListener('click', onClick)
   container.addEventListener('mousemove', onMouseMove)
+  document.addEventListener('pointerlockchange', onPointerLockChange)
   addEventListener('keydown', onKeyDown)
   addEventListener('keyup', onKeyUp)
 
   return {
     pressed,
     mouse,
+    pointer,
     dispose() {
+      container.removeEventListener('click', onClick)
       container.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('pointerlockchange', onPointerLockChange)
       removeEventListener('keydown', onKeyDown)
       removeEventListener('keyup', onKeyUp)
     }

--- a/game/src/vehicles/shared/__tests__/simpleController.pointer.test.ts
+++ b/game/src/vehicles/shared/__tests__/simpleController.pointer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+import { createController } from '../simpleController'
+
+describe('simpleController pointer lock steering', () => {
+  it('accumulates yaw beyond 360 degrees with successive pointer deltas', () => {
+    //1.- Seed a controller and pointer state locked to ensure relative deltas are consumed.
+    const group = new THREE.Group()
+    const scene = new THREE.Scene()
+    const pointer = { locked: true, deltaX: 0, deltaY: 0, yaw: 0, pitch: 0 }
+    const input = {
+      pointer,
+      mouse: { x: 0, y: 0 },
+      pressed: (_code: string) => false,
+    }
+    const controller = createController(group, scene)
+
+    for (let i = 0; i < 8; i += 1) {
+      pointer.deltaX = 200
+      controller.update(1 / 60, input, () => 0)
+    }
+
+    expect(Math.abs(group.rotation.y)).toBeGreaterThan(Math.PI)
+    expect(pointer.deltaX).toBe(0)
+
+    controller.dispose()
+  })
+
+  it('falls back to NDC smoothing when pointer lock is not active', () => {
+    //1.- Validate that the legacy reticle mapping still updates yaw without pointer lock support.
+    const group = new THREE.Group()
+    const scene = new THREE.Scene()
+    const input = {
+      pointer: { locked: false, deltaX: 0, deltaY: 0, yaw: 0, pitch: 0 },
+      mouse: { x: 1, y: 0 },
+      pressed: (_code: string) => false,
+    }
+    const controller = createController(group, scene)
+
+    for (let i = 0; i < 10; i += 1) {
+      controller.update(1 / 60, input, () => 0)
+    }
+
+    expect(group.rotation.y).toBeLessThan(0)
+
+    controller.dispose()
+  })
+})


### PR DESCRIPTION
## Summary
- capture pointer-lock mouse deltas and retain NDC fallback in the input map
- accumulate yaw/pitch in the simple controller for unlimited yaw with clamped pitch
- add regression tests for pointer-lock input and controller fallback behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e54621af84832998e5de82efab4c28