### PR TITLE
Prioritize tank in lobby vehicle list

### DIFF
--- a/game/src/__tests__/lobbyPage.test.tsx
+++ b/game/src/__tests__/lobbyPage.test.tsx
@@ -53,4 +53,16 @@ describe('LobbyPage validation', () => {
     const values = options.map((option) => option.getAttribute('value'))
     expect(values).toContain('tank')
   })
+
+  it('presents the tank as the leading vehicle option', () => {
+    //1.- Render the lobby to expose the vehicle dropdown in its initial ordering.
+    render(<LobbyPage />)
+
+    //2.- Collect the ordered option values so we can verify the hangar promotes the tank first.
+    const options = screen.getAllByRole('option')
+    const values = options.map((option) => option.getAttribute('value'))
+
+    //3.- Confirm the first entry corresponds to the tank so pilots encounter it at the top of the list.
+    expect(values[0]).toBe('tank')
+  })
 })

--- a/game/src/lib/pilotProfile.ts
+++ b/game/src/lib/pilotProfile.ts
@@ -1,12 +1,12 @@
 //1.- Define the canonical set of vehicle options that the lobby and engine agree on.
 export const VEHICLE_KEYS = [
+  'tank',
   'arrowhead',
   'octahedron',
   'pyramid',
   'icosahedron',
   'cube',
-  'transformer',
-  'tank'
+  'transformer'
 ] as const
 
 //1.- Expose the vehicle key union for type-safe interactions throughout the game loop.


### PR DESCRIPTION
## Summary
- reorder the shared vehicle key list so the tank appears first in the lobby dropdown
- extend the lobby page test suite to assert the tank option leads the select menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e55f25730c83299da71958a49b792d